### PR TITLE
fixes #1148 - filter opds1 entryLinks on rel='alternate' - better contentType parsing

### DIFF
--- a/src/main/converter/opds.ts
+++ b/src/main/converter/opds.ts
@@ -320,6 +320,7 @@ export class OpdsFeedViewConverter {
         const entrylinkView = fallback(
             this.convertFilterLinkToView(baseUrl, r2OpdsPublication.Links, {
                 type: "type=entry;profile=opds-catalog",
+                rel: "alternate",
             }),
             this.convertFilterLinkToView(baseUrl, r2OpdsPublication.Links, {
                 type: ContentType.Opds2Pub,

--- a/src/renderer/library/opds/handleLink.ts
+++ b/src/renderer/library/opds/handleLink.ts
@@ -11,7 +11,7 @@ import { IOpdsLinkView } from "readium-desktop/common/views/opds";
 import { decodeB64 } from "readium-desktop/renderer/common/logics/base64";
 import { buildOpdsBrowserRoute } from "readium-desktop/renderer/library/opds/route";
 import { TDispatch } from "readium-desktop/typings/redux";
-import { ContentType } from "readium-desktop/utils/content-type";
+import { ContentType, parseContentType } from "readium-desktop/utils/content-type";
 
 import { dispatchHistoryPush, TLocation } from "../routing";
 import { extractParamFromOpdsRoutePathname } from "./route";
@@ -22,10 +22,11 @@ export const dispatchOpdsLink =
 
             dispatch(dialogActions.closeRequest.build());
 
-            if (ln.type === ContentType.Opds2 ||
-                ln.type === ContentType.Opds2Auth ||
-                ln.type === ContentType.Opds2Pub ||
-                ln.type === ContentType.AtomXml) {
+            const contentType = parseContentType(ln.type);
+            if (contentType === ContentType.Opds2 ||
+                contentType === ContentType.Opds2Auth ||
+                contentType === ContentType.Opds2Pub ||
+                contentType === ContentType.AtomXml) {
 
                 const param = extractParamFromOpdsRoutePathname(location.pathname);
 

--- a/src/utils/content-type.ts
+++ b/src/utils/content-type.ts
@@ -33,3 +33,16 @@ export enum ContentType {
     lcppdf = "application/pdf+lcp",
     pdf = "application/pdf",
 }
+
+export const parseContentType = (RawContentType: string): ContentType | undefined => {
+
+    if (!RawContentType) {
+        return undefined;
+    }
+
+    const contentTypeArray = RawContentType.replace(/\s/g, "").split(";");
+
+    const contentType = contentTypeArray.reduce<ContentType | undefined>(
+        (pv, cv) => pv || Object.values(ContentType).find((v) => v === cv), undefined);
+    return contentType;
+};


### PR DESCRIPTION
- filter alternate entrylinks in opds1

'alternate' rel is it sufficient ?





fixes #1148 