### PR TITLE
fixes #1351: incorrect LCP error message for licenses that start in the future (different than LSD expired state)

### DIFF
--- a/src/main/api/lcp.ts
+++ b/src/main/api/lcp.ts
@@ -10,7 +10,6 @@ import { inject, injectable } from "inversify";
 import { ILcpApi } from "readium-desktop/common/api/interface/lcpApi.interface";
 import { lcpActions } from "readium-desktop/common/redux/actions";
 import { readerActions } from "readium-desktop/common/redux/actions/";
-import { Translator } from "readium-desktop/common/services/translator";
 import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { diSymbolTable } from "readium-desktop/main/diSymbolTable";
 import { LcpManager } from "readium-desktop/main/services/lcp";
@@ -31,9 +30,6 @@ export class LcpApi implements ILcpApi {
 
     @inject(diSymbolTable["publication-repository"])
     private readonly publicationRepository!: PublicationRepository;
-
-    @inject(diSymbolTable.translator)
-    private readonly translator!: Translator;
 
     @inject(diSymbolTable["publication-view-converter"])
     private readonly publicationViewConverter!: PublicationViewConverter;

--- a/src/main/api/lcp.ts
+++ b/src/main/api/lcp.ts
@@ -63,8 +63,9 @@ export class LcpApi implements ILcpApi {
                 await this.lcpManager.unlockPublication(publicationDocument, passphrase);
 
             if (typeof unlockPublicationRes !== "undefined") {
-                const message = unlockPublicationRes === 11 ?
-                    this.translator.translate("publication.expiredLcp") :
+                const message =
+                    // unlockPublicationRes === 11 ?
+                    // this.translator.translate("publication.expiredLcp") :
                     this.lcpManager.convertUnlockPublicationResultToString(unlockPublicationRes);
                 debug(message);
 

--- a/src/main/redux/sagas/publication/openPublication.ts
+++ b/src/main/redux/sagas/publication/openPublication.ts
@@ -99,9 +99,10 @@ export function* streamerOpenPublicationAndReturnManifestUrl(pubId: string) {
                 yield* callTyped(() => lcpManager.unlockPublication(publicationDocument, undefined));
 
             if (typeof unlockPublicationRes !== "undefined") {
-                const message = unlockPublicationRes === 11
-                    ? translator.translate("publication.expiredLcp")
-                    : lcpManager.convertUnlockPublicationResultToString(unlockPublicationRes);
+                const message =
+                    // unlockPublicationRes === 11
+                    // ? translator.translate("publication.expiredLcp") :
+                    lcpManager.convertUnlockPublicationResultToString(unlockPublicationRes);
 
                 try {
                     const publicationView = publicationViewConverter.convertDocumentToView(publicationDocument);
@@ -185,8 +186,9 @@ export function* streamerOpenPublicationAndReturnManifestUrl(pubId: string) {
                 yield* callTyped(() => lcpManager.unlockPublication(publicationDocument, undefined));
 
             if (typeof unlockPublicationRes !== "undefined") {
-                const message = unlockPublicationRes === 11 ?
-                    translator.translate("publication.expiredLcp") :
+                const message =
+                    // unlockPublicationRes === 11 ?
+                    // translator.translate("publication.expiredLcp") :
                     lcpManager.convertUnlockPublicationResultToString(unlockPublicationRes);
                 debug(message);
 

--- a/src/resources/locales/fr.json
+++ b/src/resources/locales/fr.json
@@ -208,7 +208,7 @@
         "lcpRightsCopy": "Copie de caractères",
         "lcpRightsPrint": "Copies d'imprimante",
         "lcpStart": "Début",
-        "licenseOutOfDate": "License expirée",
+        "licenseOutOfDate": "License inutilisable à cette date",
         "licenseSignatureDateInvalid": "Date de signature de license invalide",
         "licenseSignatureInvalid": "Signature de license invalide",
         "progression": {


### PR DESCRIPTION
Fixes #1351
This PR supersedes: https://github.com/edrlab/thorium-reader/pull/1354