### PR TITLE
[refactoring] migrate bookmark locator repository to the reader redux state

### DIFF
--- a/docs/logs/db-migration.txt
+++ b/docs/logs/db-migration.txt
@@ -1,0 +1,2 @@
+
+how to migrate the pouch-db database ?

--- a/docs/logs/db-migration.txt
+++ b/docs/logs/db-migration.txt
@@ -1,2 +1,0 @@
-
-how to migrate the pouch-db database ?

--- a/src/common/api/interface/readerApi.interface.ts
+++ b/src/common/api/interface/readerApi.interface.ts
@@ -6,28 +6,13 @@
 // ==LICENSE-END==
 
 import { ReaderMode } from "readium-desktop/common/models/reader";
-import { LocatorView } from "readium-desktop/common/views/locator";
 
 import { IEventPayload_R2_EVENT_CLIPBOARD_COPY } from "@r2-navigator-js/electron/common/events";
 import { LocatorExtended } from "@r2-navigator-js/electron/renderer";
-import { Locator as R2Locator } from "@r2-shared-js/models/locator";
 
 export interface IReaderApi {
     // setLastReadingLocation: (publicationIdentifier: string, locator: R2Locator) => Promise<LocatorView>;
     getLastReadingLocation: (publicationIdentifier: string) => Promise<LocatorExtended | undefined>;
-    findBookmarks: (publicationIdentifier: string) => Promise<LocatorView[]>;
-    updateBookmark: (
-        identifier: string,
-        publicationIdentifier: string,
-        locator: R2Locator,
-        name?: string,
-    ) => Promise<void>;
-    addBookmark: (
-        publicationIdentifier: string,
-        locator: R2Locator,
-        name?: string,
-    ) => Promise<void>;
-    deleteBookmark: (identifier: string) => Promise<void>;
     clipboardCopy: (
         publicationIdentifier: string,
         clipboardData: IEventPayload_R2_EVENT_CLIPBOARD_COPY) => Promise<boolean>;
@@ -37,10 +22,6 @@ export interface IReaderApi {
 export interface IReaderModuleApi {
     // "reader/setLastReadingLocation": IReaderApi["setLastReadingLocation"];
     "reader/getLastReadingLocation": IReaderApi["getLastReadingLocation"];
-    "reader/findBookmarks": IReaderApi["findBookmarks"];
-    "reader/updateBookmark": IReaderApi["updateBookmark"];
-    "reader/addBookmark": IReaderApi["addBookmark"];
-    "reader/deleteBookmark": IReaderApi["deleteBookmark"];
     "reader/clipboardCopy": IReaderApi["clipboardCopy"];
     "reader/getMode": IReaderApi["getMode"];
 }

--- a/src/common/redux/states/bookmark.ts
+++ b/src/common/redux/states/bookmark.ts
@@ -1,0 +1,16 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Locator } from "readium-desktop/common/models/locator";
+import { TMapState } from "readium-desktop/utils/redux-reducers/map.reducer";
+
+export type TID = string;
+export type TBookmarkState = TMapState<TID, IBookmarkState>;
+export interface IBookmarkState {
+    name: string;
+    locator: Locator;
+}

--- a/src/common/redux/states/bookmark.ts
+++ b/src/common/redux/states/bookmark.ts
@@ -6,11 +6,15 @@
 // ==LICENSE-END==
 
 import { Locator } from "readium-desktop/common/models/locator";
-import { TMapState } from "readium-desktop/utils/redux-reducers/map.reducer";
+import { TPQueueState } from "readium-desktop/utils/redux-reducers/pqueue.reducer";
 
-export type TID = string;
-export type TBookmarkState = TMapState<TID, IBookmarkState>;
-export interface IBookmarkState {
+export type TBookmarkState = TPQueueState<number, IBookmarkState>;
+
+export interface IBookmarkBaseState {
+    uuid: string;
+}
+
+export interface IBookmarkState extends IBookmarkBaseState {
     name: string;
     locator: Locator;
 }

--- a/src/common/redux/states/renderer/readerRootState.ts
+++ b/src/common/redux/states/renderer/readerRootState.ts
@@ -14,6 +14,7 @@ import { TMapState } from "readium-desktop/utils/redux-reducers/map.reducer";
 
 import { IHighlight } from "@r2-navigator-js/electron/common/highlight";
 import { LocatorExtended } from "@r2-navigator-js/electron/renderer";
+import { TBookmarkState } from "../bookmark";
 
 export interface IReaderRootState extends ICommonRootState {
     reader: IReaderStateReader;
@@ -25,6 +26,7 @@ export interface IReaderStateReader {
     config: ReaderConfig;
     info: ReaderInfo;
     locator: LocatorExtended;
+    bookmark: TBookmarkState;
     highlight: {
         handler: TMapState<string, IHighlightHandlerState>;
         mounter: TMapState<string, IHighlight>;

--- a/src/main/api/catalog.ts
+++ b/src/main/api/catalog.ts
@@ -55,12 +55,6 @@ export class CatalogApi implements ICatalogApi {
     @inject(diSymbolTable["publication-repository"])
     private readonly publicationRepository!: PublicationRepository;
 
-    // @inject(diSymbolTable["config-repository"])
-    // private readonly configRepository!: ConfigRepository<CatalogConfig>;
-
-    // @inject(diSymbolTable["locator-repository"])
-    // private readonly locatorRepository!: LocatorRepository;
-
     @inject(diSymbolTable["publication-view-converter"])
     private readonly publicationViewConverter!: PublicationViewConverter;
 

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -140,8 +140,8 @@ const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReader
                     ],
                 ], []);
 
-                const bookmarkFromPouchdbFiltered = bookmarkFromPouchdb.filter(([identifierSrc]) =>
-                    !bookmarkFromRedux.find(([identifier]) => identifierSrc === identifier));
+                const bookmarkFromPouchdbFiltered = bookmarkFromPouchdb.filter(([,identifierSrc]) =>
+                    !bookmarkFromRedux.find(([,identifier]) => identifierSrc === identifier));
 
 
                 const bookmark = [

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -7,13 +7,9 @@
 
 import * as debug_ from "debug";
 import { app } from "electron";
-import * as Ramda from "ramda";
 import { LocaleConfigIdentifier, LocaleConfigValueType } from "readium-desktop/common/config";
 import { LocatorType } from "readium-desktop/common/models/locator";
-import {
-    LocatorExtendedWithLocatorOnly,
-} from "readium-desktop/common/redux/states/locatorInitialState";
-import { readerConfigInitialState } from "readium-desktop/common/redux/states/reader";
+import { TBookmarkState } from "readium-desktop/common/redux/states/bookmark";
 import { AvailableLanguages } from "readium-desktop/common/services/translator";
 import { ConfigDocument } from "readium-desktop/main/db/document/config";
 import { ConfigRepository } from "readium-desktop/main/db/repository/config";
@@ -25,7 +21,6 @@ import { RootState } from "readium-desktop/main/redux/states";
 import { IS_DEV } from "readium-desktop/preprocessor-directives";
 import { ObjectKeys } from "readium-desktop/utils/object-keys-values";
 import { PromiseAllSettled } from "readium-desktop/utils/promise";
-import { TPQueueState } from "readium-desktop/utils/redux-reducers/pqueue.reducer";
 import { applyMiddleware, createStore, Store } from "redux";
 import createSagaMiddleware, { SagaMiddleware } from "redux-saga";
 
@@ -48,62 +43,114 @@ const defaultLocale = (): LocaleConfigValueType => {
     };
 };
 
-async function absorbLocatorRepositoryToReduxState() {
+// can be safely removed
+// introduce in a thorium previous version
+//
+// async function absorbLocatorRepositoryToReduxState() {
+
+//     const locatorRepository = diMainGet("locator-repository");
+//     const locatorFromDb = await locatorRepository.find(
+//         {
+//             selector: { locatorType: LocatorType.LastReadingLocation },
+//             sort: [{ updatedAt: "asc" }],
+//         },
+//     );
+
+
+//     const lastReadingQueue: TPQueueState = [];
+//     const registryReader: IDictWinRegistryReaderState = {};
+
+//     for (const locator of locatorFromDb) {
+//         if (locator.publicationIdentifier) {
+
+//             lastReadingQueue.push([locator.createdAt, locator.publicationIdentifier]);
+
+//             registryReader[locator.publicationIdentifier] = {
+//                 windowBound: {
+//                     width: 800,
+//                     height: 600,
+//                     x: 0,
+//                     y: 0,
+//                 },
+//                 reduxState: {
+//                     config: readerConfigInitialState,
+//                     locator: LocatorExtendedWithLocatorOnly(locator.locator),
+//                     bookmark: undefined,
+//                     info: {
+//                         publicationIdentifier: locator.publicationIdentifier,
+//                         manifestUrlR2Protocol: undefined,
+//                         manifestUrlHttp: undefined,
+//                         filesystemPath: undefined,
+//                         r2Publication: undefined,
+//                         publicationView: undefined,
+//                     },
+//                     highlight: {
+//                         handler: undefined,
+//                         mounter: undefined,
+//                     },
+//                 },
+//             };
+
+//             await locatorRepository.delete(locator.identifier);
+//         }
+//     }
+
+//     if (lastReadingQueue.length === 0 && ObjectKeys(registryReader).length === 0) {
+//         return undefined;
+//     }
+
+//     return {
+//         lastReadingQueue,
+//         registryReader,
+//     };
+// }
+
+const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReaderState) => {
 
     const locatorRepository = diMainGet("locator-repository");
-    const locatorFromDb = await locatorRepository.find(
+
+    const bookmarkFromDb = await locatorRepository.find(
         {
-            selector: { locatorType: LocatorType.LastReadingLocation },
+            selector: { locatorType: LocatorType.Bookmark },
             sort: [{ updatedAt: "asc" }],
         },
     );
 
-    const lastReadingQueue: TPQueueState = [];
-    const registryReader: IDictWinRegistryReaderState = {};
-
-    for (const locator of locatorFromDb) {
+    for (const locator of bookmarkFromDb) {
         if (locator.publicationIdentifier) {
 
-            lastReadingQueue.push([locator.createdAt, locator.publicationIdentifier]);
+            const reader = registryReader[locator.publicationIdentifier]?.reduxState;
+            if (reader) {
 
-            registryReader[locator.publicationIdentifier] = {
-                windowBound: {
-                    width: 800,
-                    height: 600,
-                    x: 0,
-                    y: 0,
-                },
-                reduxState: {
-                    config: readerConfigInitialState,
-                    locator: LocatorExtendedWithLocatorOnly(locator.locator),
-                    info: {
-                        publicationIdentifier: locator.publicationIdentifier,
-                        manifestUrlR2Protocol: undefined,
-                        manifestUrlHttp: undefined,
-                        filesystemPath: undefined,
-                        r2Publication: undefined,
-                        publicationView: undefined,
-                    },
-                    highlight: {
-                        handler: undefined,
-                        mounter: undefined,
-                    },
-                },
-            };
 
-            await locatorRepository.delete(locator.identifier);
+                // this is not a set reducer but a map reducer
+                // so there is no merge with union set method
+                const bookmarkFromRedux = reader.bookmark;
+                const bookmarkFromPouchdb = bookmarkFromDb.reduce<TBookmarkState>((pv, cv) => [
+                    ...pv,
+                    [cv.identifier, {
+                        name: cv.name || "",
+                        locator: cv.locator,
+                    }],
+                ], []);
+
+                const bookmarkFromPouchdbFiltered = bookmarkFromPouchdb.filter(([identifierSrc]) =>
+                    !bookmarkFromRedux.find(([identifier]) => identifierSrc === identifier));
+
+
+                const bookmark = [
+                    ...bookmarkFromRedux,
+                    ...bookmarkFromPouchdbFiltered,
+                ];
+
+                reader.bookmark = bookmark;
+            }
         }
+
     }
 
-    if (lastReadingQueue.length === 0 && ObjectKeys(registryReader).length === 0) {
-        return undefined;
-    }
-
-    return {
-        lastReadingQueue,
-        registryReader,
-    };
-}
+    return registryReader;
+};
 
 export async function initStore(configRepository: ConfigRepository<any>)
 : Promise<[Store<RootState>, SagaMiddleware<object>]> {
@@ -138,7 +185,7 @@ export async function initStore(configRepository: ConfigRepository<any>)
         debug("ERR when get state from FS", err);
     }
 
-    let reduxStateWin = reduxStateWinRepository?.value?.win
+    const reduxStateWin = reduxStateWinRepository?.value?.win
         ? reduxStateWinRepository.value
         : undefined;
 
@@ -146,42 +193,56 @@ export async function initStore(configRepository: ConfigRepository<any>)
                 ? i18nStateRepository.value
                 : defaultLocale();
 
-    try {
-        // executed once time for locatorRepository to ReduxState migration
-        const locatorRepositoryAbsorbed = await absorbLocatorRepositoryToReduxState();
+    // new version of THORIUM
+    // the migration can be safely removed
+    //
+    // try {
+    //     // executed once time for locatorRepository to ReduxState migration
+    //     const locatorRepositoryAbsorbed = await absorbLocatorRepositoryToReduxState();
 
-        if (locatorRepositoryAbsorbed) {
-            reduxStateWin = {
-                ...reduxStateWin,
-                ...{
-                    publication: {
-                        lastReadingQueue: Ramda.uniqBy(
-                            (item) => item[1],
-                            Ramda.concat(
-                                reduxStateWin.publication.lastReadingQueue,
-                                locatorRepositoryAbsorbed.lastReadingQueue,
-                            ),
-                        ),
-                    },
-                },
-                ...{
-                    win: {
-                        session: {
-                            library: reduxStateWin.win.session.library,
-                            reader: reduxStateWin.win.session.reader,
-                        },
-                        registry: {
-                            reader: {
-                                ...locatorRepositoryAbsorbed.registryReader,
-                                ...reduxStateWin.win.registry.reader,
-                            },
-                        },
-                    },
-                },
-            };
-        }
-    } catch (err) {
-        debug("ERR on absorbLocatorRepositoryToReduxState", err);
+    //     if (locatorRepositoryAbsorbed) {
+    //         reduxStateWin = {
+    //             ...reduxStateWin,
+    //             ...{
+    //                 publication: {
+    //                     lastReadingQueue: Ramda.uniqBy(
+    //                         (item) => item[1],
+    //                         Ramda.concat(
+    //                             reduxStateWin.publication.lastReadingQueue,
+    //                             locatorRepositoryAbsorbed.lastReadingQueue,
+    //                         ),
+    //                     ),
+    //                 },
+    //             },
+    //             ...{
+    //                 win: {
+    //                     session: {
+    //                         library: reduxStateWin.win.session.library,
+    //                         reader: reduxStateWin.win.session.reader,
+    //                     },
+    //                     registry: {
+    //                         reader: {
+    //                             ...locatorRepositoryAbsorbed.registryReader,
+    //                             ...reduxStateWin.win.registry.reader,
+    //                         },
+    //                     },
+    //                 },
+    //             },
+    //         };
+    //     }
+    // } catch (err) {
+    //     debug("ERR on absorbLocatorRepositoryToReduxState", err);
+    // }
+
+    try {
+
+        // Be carefull not an object copy / same reference
+        reduxStateWin.win.registry.reader =
+            await absorbBookmarkToReduxState(reduxStateWin.win.registry.reader);
+
+    } catch (e) {
+
+        debug("ERR on absorb bookmark to redux state", e);
     }
 
     const preloadedState = {

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -116,6 +116,8 @@ const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReader
         },
     );
 
+    let counter = 0;
+
     for (const locator of bookmarkFromDb) {
         if (locator.publicationIdentifier) {
 
@@ -128,10 +130,14 @@ const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReader
                 const bookmarkFromRedux = reader.bookmark;
                 const bookmarkFromPouchdb = bookmarkFromDb.reduce<TBookmarkState>((pv, cv) => [
                     ...pv,
-                    [cv.identifier, {
-                        name: cv.name || "",
-                        locator: cv.locator,
-                    }],
+                    [
+                        ++counter,
+                        {
+                            uuid: cv.identifier,
+                            name: cv.name || "",
+                            locator: cv.locator,
+                        },
+                    ],
                 ], []);
 
                 const bookmarkFromPouchdbFiltered = bookmarkFromPouchdb.filter(([identifierSrc]) =>

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -128,7 +128,10 @@ const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReader
                 // this is not a set reducer but a map reducer
                 // so there is no merge with union set method
                 const bookmarkFromRedux = reader.bookmark;
-                const bookmarkFromPouchdb = bookmarkFromDb.reduce<TBookmarkState>((pv, cv) => [
+                const bookmarkFromPouchdbFiltered = bookmarkFromDb.filter((_v) => {
+                    return !bookmarkFromRedux.find(([,v]) => v.uuid === _v.identifier);
+                });
+                const bookmarkFromPouchdbConverted = bookmarkFromPouchdbFiltered.reduce<TBookmarkState>((pv, cv) => [
                     ...pv,
                     [
                         ++counter,
@@ -140,13 +143,9 @@ const absorbBookmarkToReduxState = async (registryReader: IDictWinRegistryReader
                     ],
                 ], []);
 
-                const bookmarkFromPouchdbFiltered = bookmarkFromPouchdb.filter(([,identifierSrc]) =>
-                    !bookmarkFromRedux.find(([,identifier]) => identifierSrc === identifier));
-
-
                 const bookmark = [
                     ...bookmarkFromRedux,
-                    ...bookmarkFromPouchdbFiltered,
+                    ...bookmarkFromPouchdbConverted,
                 ];
 
                 reader.bookmark = bookmark;

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -335,6 +335,8 @@ class Reader extends React.Component<IProps, IState> {
         }
 
         this.getReaderMode();
+
+        await this.checkBookmarks();
     }
 
     public async componentDidUpdate(oldProps: IProps, _oldState: IState) {

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -1456,11 +1456,11 @@ class Reader extends React.Component<IProps, IState> {
                     name = `${timestamp} (${percent}%)`;
                 }
 
-                try {
-                    await apiAction("reader/addBookmark", this.props.pubId, locator, name);
-                } catch (e) {
-                    console.error("Error to fetch api reader/addBookmark", e);
-                }
+                this.props.setBookmark({
+                    uuid: nanoid(),
+                    locator,
+                    name,
+                });
             }
         }
     }

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -330,35 +330,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
         const { __ } = this.props;
         if (this.props.r2Publication && this.props.bookmarks) {
             const { bookmarkToUpdate } = this.state;
-            return this.props.bookmarks.sort((a, b) => {
-                if (!a.locator || !b.locator) {
-                    return 0;
-                }
-                if (!a.locator.locations || !b.locator.locations) {
-                    return 0;
-                }
-                const aLink = this.props.r2Publication.Spine.find((link) => {
-                    return link.Href === a.locator.href;
-                });
-                const aLinkIndex = this.props.r2Publication.Spine.indexOf(aLink);
-                const bLink = this.props.r2Publication.Spine.find((link) => {
-                    return link.Href === b.locator.href;
-                });
-                const bLinkIndex = this.props.r2Publication.Spine.indexOf(bLink);
-                if (aLinkIndex > bLinkIndex) {
-                    return 1;
-                }
-                if (aLinkIndex < bLinkIndex) {
-                    return -1;
-                }
-                // aLinkIndex === bLinkIndex
-                if (a.locator.locations.progression > b.locator.locations.progression) {
-                    return 1;
-                } else if (a.locator.locations.progression < b.locator.locations.progression) {
-                    return -1;
-                }
-                return 0;
-            }).map((bookmark, i) =>
+            return this.props.bookmarks.map((bookmark, i) =>
                 <div
                     className={styles.bookmarks_line}
                     key={i}
@@ -366,7 +338,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                     { bookmarkToUpdate === i &&
                         <UpdateBookmarkForm
                             close={ this.closeBookarkEditForm }
-                            bookmark={ bookmark }
+                        bookmark={bookmark}
                         />
                     }
                     <button

--- a/src/renderer/reader/components/UpdateBookmarkForm.tsx
+++ b/src/renderer/reader/components/UpdateBookmarkForm.tsx
@@ -6,14 +6,16 @@
 // ==LICENSE-END==
 
 import * as React from "react";
-import { LocatorView } from "readium-desktop/common/views/locator";
-import { apiAction } from "readium-desktop/renderer/reader/apiAction";
+import { connect } from "react-redux";
+import { IBookmarkState } from "readium-desktop/common/redux/states/bookmark";
 import { TFormEvent } from "readium-desktop/typings/react";
+import { TDispatch } from "readium-desktop/typings/redux";
+import { readerLocalActionBookmarks } from "../redux/actions";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IBaseProps {
     close: () => void;
-    bookmark: LocatorView;
+    bookmark: IBookmarkState;
 }
 
 // IProps may typically extend:
@@ -21,7 +23,7 @@ interface IBaseProps {
 // ReturnType<typeof mapStateToProps>
 // ReturnType<typeof mapDispatchToProps>
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface IProps extends IBaseProps {
+interface IProps extends IBaseProps, ReturnType<typeof mapDispatchToProps> {
 }
 
 interface IState {
@@ -75,16 +77,21 @@ export class UpdateBookmarkForm extends React.Component<IProps, IState> {
         const normalizedValue = value.trim().replace(/\s\s+/g, " ");
         if (normalizedValue.length > 0) {
             bookmark.name = normalizedValue;
-            apiAction("reader/updateBookmark",
-                bookmark.identifier,
-                bookmark.publicationIdentifier,
-                bookmark.locator,
-                bookmark.name,
-            ).catch((error) => console.error("Error to fetch api reader/updateBookmark", error));
+            this.props.updateBookmark(bookmark);
         }
 
         this.props.close();
     }
 }
 
-export default UpdateBookmarkForm;
+const mapDispatchToProps = (dispatch: TDispatch) => {
+
+
+    return {
+        updateBookmark: (bookmark: IBookmarkState) => {
+            dispatch(readerLocalActionBookmarks.update.build(bookmark));
+        },
+    };
+};
+
+export default connect(undefined, mapDispatchToProps)(UpdateBookmarkForm);

--- a/src/renderer/reader/components/UpdateBookmarkForm.tsx
+++ b/src/renderer/reader/components/UpdateBookmarkForm.tsx
@@ -75,9 +75,11 @@ export class UpdateBookmarkForm extends React.Component<IProps, IState> {
         const { bookmark } = this.props;
         const value: string = this.inputRef.current.value;
         const normalizedValue = value.trim().replace(/\s\s+/g, " ");
+
         if (normalizedValue.length > 0) {
-            bookmark.name = normalizedValue;
-            this.props.updateBookmark(bookmark);
+            const newBookmark = { ...bookmark };
+            newBookmark.name = normalizedValue;
+            this.props.updateBookmark(newBookmark);
         }
 
         this.props.close();

--- a/src/renderer/reader/redux/actions/bookmarks/index.ts
+++ b/src/renderer/reader/redux/actions/bookmarks/index.ts
@@ -1,0 +1,16 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import * as pop from "./pop";
+import * as push from "./push";
+import * as update from "./update";
+
+export {
+    push,
+    pop,
+    update,
+};

--- a/src/renderer/reader/redux/actions/bookmarks/pop.ts
+++ b/src/renderer/reader/redux/actions/bookmarks/pop.ts
@@ -1,0 +1,26 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+import { IBookmarkState } from "readium-desktop/common/redux/states/bookmark";
+
+export const ID = "READER_BOOKMARKS_POP";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface IPayload extends IBookmarkState {
+}
+
+export function build(param: IBookmarkState):
+    Action<typeof ID, IPayload> {
+
+    return {
+        type: ID,
+        payload: param,
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/renderer/reader/redux/actions/bookmarks/push.ts
+++ b/src/renderer/reader/redux/actions/bookmarks/push.ts
@@ -1,0 +1,31 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { nanoid } from "nanoid";
+import { Action } from "readium-desktop/common/models/redux";
+import { IBookmarkBaseState, IBookmarkState } from "readium-desktop/common/redux/states/bookmark";
+
+export const ID = "READER_BOOKMARKS_PUSH";
+
+type IBookmarkStateWithoutUUID = Partial<IBookmarkBaseState> & Required<IBookmarkState>;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface IPayload extends IBookmarkState {
+}
+
+export function build(param: IBookmarkStateWithoutUUID):
+    Action<typeof ID, IPayload> {
+
+    param.uuid = param.uuid || nanoid();
+
+    return {
+        type: ID,
+        payload: param,
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/renderer/reader/redux/actions/bookmarks/update.ts
+++ b/src/renderer/reader/redux/actions/bookmarks/update.ts
@@ -1,0 +1,26 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+import { IBookmarkState } from "readium-desktop/common/redux/states/bookmark";
+
+export const ID = "READER_BOOKMARKS_UPDATE";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface IPayload extends IBookmarkState {
+}
+
+export function build(param: IBookmarkState):
+    Action<typeof ID, IPayload> {
+
+    return {
+        type: ID,
+        payload: param,
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/renderer/reader/redux/actions/index.ts
+++ b/src/renderer/reader/redux/actions/index.ts
@@ -11,6 +11,7 @@ import * as readerLocalActionPicker from "./picker";
 import * as readerLocalActionSearch from "./search";
 import * as readerLocalActionSetConfig from "./setConfig";
 import * as readerLocalActionSetLocator from "./setLocator";
+import * as readerLocalActionBookmarks from "./bookmarks";
 
 export {
     readerLocalActionSetConfig,
@@ -19,4 +20,5 @@ export {
     readerLocalActionLocatorHrefChanged,
     readerLocalActionPicker,
     readerLocalActionSearch,
+    readerLocalActionBookmarks,
 };

--- a/src/renderer/reader/redux/middleware/persistence.ts
+++ b/src/renderer/reader/redux/middleware/persistence.ts
@@ -45,6 +45,11 @@ export const reduxPersistMiddleware: Middleware
                     readerState.locator = nextState.reader.locator;
                     dispatchFlag = true;
                 }
+                if (!ramda.equals(prevState.reader.bookmark, nextState.reader.bookmark)) {
+
+                    readerState.bookmark = nextState.reader.bookmark;
+                    dispatchFlag = true;
+                }
                 if (dispatchFlag) {
 
                     dispatchSetReduxState(store, readerState);

--- a/src/renderer/reader/redux/reducers/index.ts
+++ b/src/renderer/reader/redux/reducers/index.ts
@@ -60,8 +60,11 @@ export const rootReducer = () => {
                             sortFct: (a, b) => b[0] - a[0],
                             update: {
                                 type: readerLocalActionBookmarks.update.ID,
-                                selector: (action) =>
-                                    [undefined, action.payload],
+                                selector: (action, queue) =>
+                                    [
+                                        queue.reduce<number>((pv, [k, v]) => v.uuid === action.payload.uuid ? k : pv, undefined),
+                                        action.payload,
+                                    ],
                             },
                         },
                     ),

--- a/src/renderer/reader/redux/reducers/index.ts
+++ b/src/renderer/reader/redux/reducers/index.ts
@@ -19,13 +19,15 @@ import { combineReducers } from "redux";
 
 import { IHighlight } from "@r2-navigator-js/electron/common/highlight";
 
-import { readerLocalActionHighlights } from "../actions";
+import { readerLocalActionBookmarks, readerLocalActionHighlights } from "../actions";
 import { IHighlightHandlerState } from "../state/highlight";
 import { readerInfoReducer } from "./info";
 import { pickerReducer } from "./picker";
 import { readerConfigReducer } from "./readerConfig";
 import { readerLocatorReducer } from "./readerLocator";
 import { searchReducer } from "./search";
+import { IBookmarkState } from "readium-desktop/common/redux/states/bookmark";
+import { priorityQueueReducer } from "readium-desktop/utils/redux-reducers/pqueue.reducer";
 
 export const rootReducer = () => {
     return combineReducers<IReaderRootState>({
@@ -35,6 +37,34 @@ export const rootReducer = () => {
             config: readerConfigReducer,
             info: readerInfoReducer,
             locator: readerLocatorReducer,
+            bookmark: priorityQueueReducer
+                    <
+                        readerLocalActionBookmarks.push.TAction,
+                        readerLocalActionBookmarks.pop.TAction,
+                        number,
+                        IBookmarkState,
+                        string,
+                        readerLocalActionBookmarks.update.TAction
+                    >(
+                        {
+                            push: {
+                                type: readerLocalActionBookmarks.push.ID,
+                                selector: (action) =>
+                                    [(new Date()).getTime(), action.payload],
+                            },
+                            pop: {
+                                type: readerLocalActionBookmarks.pop.ID,
+                                selector: (action) =>
+                                    [undefined, action.payload],
+                            },
+                            sortFct: (a, b) => b[0] - a[0],
+                            update: {
+                                type: readerLocalActionBookmarks.update.ID,
+                                selector: (action) =>
+                                    [undefined, action.payload],
+                            },
+                        },
+                    ),
             highlight: combineReducers({
                 handler: mapReducer
                     <

--- a/src/utils/redux-reducers/pqueue.reducer.ts
+++ b/src/utils/redux-reducers/pqueue.reducer.ts
@@ -89,7 +89,8 @@ export function priorityQueueReducer
 
                     return left.concat(right);
                 }
-            } else if (action.type === data.update.type) {
+
+            } else if (action.type === data.update?.type) {
 
 
                 const selectorItem = data.update.selector(action as TUpdateAction);

--- a/src/utils/redux-reducers/pqueue.reducer.ts
+++ b/src/utils/redux-reducers/pqueue.reducer.ts
@@ -25,9 +25,11 @@ export interface IPQueueData
     Key = number,
     Value = string,
     ActionType = string,
+    TUpdateAction extends ActionWithPayload<ActionType> = undefined,
 > {
     push: IPQueueAction<TPushAction, Key, Value, ActionType>;
     pop: IPQueueAction<TPopAction, Key, Value, ActionType>;
+    update?: IPQueueAction<TUpdateAction, Key, Value, ActionType>
     sortFct?: (a: IPQueueState<Key, Value>, b: IPQueueState<Key, Value>) => number;
 }
 
@@ -41,14 +43,15 @@ export function priorityQueueReducer
         Key = number,
         Value = string,
         ActionType = string,
+        TUpdateAction extends ActionWithPayload<ActionType> = undefined,
     >(
-        data: IPQueueData<TPushAction, TPopAction, Key, Value, ActionType>,
+        data: IPQueueData<TPushAction, TPopAction, Key, Value, ActionType, TUpdateAction>,
 ) {
 
     const reducer =
         (
                 queue: TPQueueState<Key, Value>,
-                action: TPopAction | TPushAction,
+                action: TPopAction | TPushAction | TUpdateAction,
         ): TPQueueState<Key, Value> => {
 
             if (!queue || !Array.isArray(queue)) {
@@ -86,6 +89,17 @@ export function priorityQueueReducer
 
                     return left.concat(right);
                 }
+            } else if (action.type === data.update.type) {
+
+
+                const selectorItem = data.update.selector(action as TUpdateAction);
+                const index = queue.findIndex((item) => item[1] === selectorItem[1]);
+
+                if (index > -1) {
+
+                    queue[index][1] = selectorItem[1];
+                }
+
             }
 
             return queue;


### PR DESCRIPTION
db repository : 
- config
- lcp-secret
- locator
- opds
- publication

redux state : 
```ts
export interface RootState {
    session: ISessionState;
    app: AppState;
    // net: NetState;
    i18n: I18NState;
    streamer: StreamerState;
    reader: {
        defaultConfig: ReaderConfig,
    };
    // update: UpdateState;
    win: {
        session: {
            library: IWinSessionLibraryState,
            reader: IDictWinSessionReaderState,
        },
        registry: {
            reader: IDictWinRegistryReaderState,
        },
    };
    mode: ReaderMode;
    lcp: ILcpState;
    publication: {
        lastReadingQueue: TPQueueState;
    };
    keyboard: KeyboardState;
}
```


# Goal : full locator repository migration