### PR TITLE
fix: navigation panel closes on button/hyperlink click and enter with key modifiers (TOC, landmarks, bookmarks, search, goto page)

### DIFF
--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -1312,7 +1312,7 @@ class Reader extends React.Component<IProps, IState> {
         }
     }
 
-    private goToLocator(locator: R2Locator, closeMenu = true) {
+    private goToLocator(locator: R2Locator, closeNavPanel = true) {
 
         if (this.props.isPdf) {
 
@@ -1327,8 +1327,9 @@ class Reader extends React.Component<IProps, IState> {
                 this.currentDivinaPlayer.goToPageWithIndex(index);
             }
         } else {
-            if (closeMenu)
+            if (closeNavPanel) {
                 this.focusMainAreaLandmarkAndCloseMenu();
+            }
 
             handleLinkLocator(locator);
         }
@@ -1336,7 +1337,7 @@ class Reader extends React.Component<IProps, IState> {
     }
 
     // tslint:disable-next-line: max-line-length
-    private handleLinkClick(event: TMouseEventOnSpan | TMouseEventOnAnchor | TKeyboardEventOnAnchor | undefined, url: string, closeMenu = true) {
+    private handleLinkClick(event: TMouseEventOnSpan | TMouseEventOnAnchor | TKeyboardEventOnAnchor | undefined, url: string, closeNavPanel = true) {
         if (event) {
             event.preventDefault();
         }
@@ -1358,8 +1359,9 @@ class Reader extends React.Component<IProps, IState> {
             this.currentDivinaPlayer.goTo(newUrl);
 
         } else {
-            if (closeMenu)
+            if (closeNavPanel) {
                 this.focusMainAreaLandmarkAndCloseMenu();
+            }
             const newUrl = this.props.manifestUrlR2Protocol + "/../" + url;
             handleLinkUrl(newUrl);
 

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -20,7 +20,7 @@ import {
     TranslatorProps, withTranslator,
 } from "readium-desktop/renderer/common/components/hoc/translator";
 import SVG from "readium-desktop/renderer/common/components/SVG";
-import { TFormEvent, TKeyboardEventButton, TMouseEventOnButton  } from "readium-desktop/typings/react";
+import { TKeyboardEventButton, TMouseEventOnButton  } from "readium-desktop/typings/react";
 import { TDispatch } from "readium-desktop/typings/redux";
 import { Unsubscribe } from "redux";
 
@@ -227,13 +227,19 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                                     isRTL ? styles.rtlDir : " ")
                             }
                             onClick=
+                                {link.Href ? (e) => {
+                                    const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                    this.props.handleLinkClick(e, link.Href, closeNavPanel);
+                                } : undefined}
+                            onDoubleClick=
                                 {link.Href ? (e) => this.props.handleLinkClick(e, link.Href, false) : undefined}
                             tabIndex={0}
                             onKeyPress=
                                 {
                                     (e) => {
                                         if (link.Href && e.key === "Enter") {
-                                            this.props.handleLinkClick(e, link.Href, true);
+                                            const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                            this.props.handleLinkClick(e, link.Href, closeNavPanel);
                                         }
                                     }
                                 }
@@ -277,13 +283,19 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                                             isRTL ? styles.rtlDir : " ")
                                     }
                                     onClick=
+                                        {link.Href ? (e) => {
+                                            const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                            this.props.handleLinkClick(e, link.Href, closeNavPanel);
+                                        } : undefined}
+                                    onDoubleClick=
                                         {link.Href ? (e) => this.props.handleLinkClick(e, link.Href, false) : undefined}
                                     tabIndex={0}
                                     onKeyPress=
                                         {
                                             (e) => {
                                                 if (link.Href && e.key === "Enter") {
-                                                    this.props.handleLinkClick(e, link.Href, true);
+                                                    const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                                    this.props.handleLinkClick(e, link.Href, closeNavPanel);
                                                 }
                                             }
                                         }
@@ -305,13 +317,19 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                                             isRTL ? styles.rtlDir : " ")
                                     }
                                     onClick=
+                                        {link.Href ? (e) => {
+                                            const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                            this.props.handleLinkClick(e, link.Href, closeNavPanel);
+                                        } : undefined}
+                                    onDoubleClick=
                                         {link.Href ? (e) => this.props.handleLinkClick(e, link.Href, false) : undefined}
                                     tabIndex={0}
                                     onKeyPress=
                                         {
                                             (e) => {
                                                 if (link.Href && e.key === "Enter") {
-                                                    this.props.handleLinkClick(e, link.Href, true);
+                                                    const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                                    this.props.handleLinkClick(e, link.Href, closeNavPanel);
                                                 }
                                             }
                                         }
@@ -392,12 +410,17 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                     <button
                         className={styles.bookmark_infos}
                         tabIndex={0}
-                        onClick={(e) => this.handleBookmarkClick(e, bookmark.locator, false)}
+                        onClick={(e) => {
+                            const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                            this.handleBookmarkClick(e, bookmark.locator, closeNavPanel);
+                        }}
+                        onDoubleClick={(e) => this.handleBookmarkClick(e, bookmark.locator, false)}
                         onKeyPress=
                         {
                             (e) => {
-                                if (e.key === "Enter") {
-                                    this.handleBookmarkClick(e, bookmark.locator, true);
+                                if (e.key === "Enter" || e.key === "Space") {
+                                    const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                    this.handleBookmarkClick(e, bookmark.locator, closeNavPanel);
                                 }
                             }
                         }
@@ -477,7 +500,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                 }
             </label>
 
-            <form onSubmit={this.handleSubmitPage}>
+            <form id="gotoPageForm">
                 {(isFixedLayout || this.props.r2Publication?.PageList) &&
                 <select
                     onChange={(ev) => {
@@ -545,7 +568,24 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                     alt={__("reader.navigation.goToPlaceHolder")}
                 />
                 <button
-                    type="submit"
+                    type="button"
+
+                    onClick=
+                        {(e) => {
+                            const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                            this.handleSubmitPage(e, closeNavPanel);
+                        }}
+                    onDoubleClick=
+                        {(e) => this.handleSubmitPage(e, false)}
+                    onKeyPress=
+                        {
+                            (e) => {
+                                if (e.key === "Enter" || e.key === "Space") {
+                                    const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                    this.handleSubmitPage(e, closeNavPanel);
+                                }
+                            }
+                        }
                     disabled={
                         !(isFixedLayout || this.props.r2Publication.PageList || this.props.isDivina || this.props.isPdf)
                     }
@@ -571,7 +611,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
         this.setState({ bookmarkToUpdate: undefined });
     }
 
-    private handleSubmitPage(e: TFormEvent) {
+    private handleSubmitPage(e: React.MouseEvent<any> | React.KeyboardEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLButtonElement>, closeNavPanel = true) {
         e.preventDefault();
         if (!this.goToRef?.current?.value) {
             return;
@@ -588,7 +628,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                 const spineLink = this.props.r2Publication.Spine[spineIndex];
                 if (spineLink) {
                     this.setState({pageError: false});
-                    this.props.handleLinkClick(undefined, spineLink.Href);
+                    this.props.handleLinkClick(undefined, spineLink.Href, closeNavPanel);
                     return;
                 }
             } catch (_e) {
@@ -620,7 +660,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                     href: (page || pageNbr).toString(),
                     // progression generate in divina pagechange event
                 };
-                this.props.handleBookmarkClick(loc as any);
+                this.props.handleBookmarkClick(loc as any, closeNavPanel);
 
                 return;
             }
@@ -632,7 +672,7 @@ export class ReaderMenu extends React.Component<IProps, IState> {
                 undefined;
             if (foundPage) {
                 this.setState({pageError: false});
-                this.props.handleLinkClick(undefined, foundPage.Href);
+                this.props.handleLinkClick(undefined, foundPage.Href, closeNavPanel);
 
                 return;
             }
@@ -641,9 +681,9 @@ export class ReaderMenu extends React.Component<IProps, IState> {
         }
     }
 
-    private handleBookmarkClick(e: TKeyboardEventButton | TMouseEventOnButton, locator: Locator, closeMenu = true) {
+    private handleBookmarkClick(e: TKeyboardEventButton | TMouseEventOnButton, locator: Locator, closeNavPanel = true) {
         e.preventDefault();
-        this.props.handleBookmarkClick(locator, closeMenu);
+        this.props.handleBookmarkClick(locator, closeNavPanel);
     }
 }
 

--- a/src/renderer/reader/components/ReaderMenuSearch.tsx
+++ b/src/renderer/reader/components/ReaderMenuSearch.tsx
@@ -244,15 +244,19 @@ class ReaderMenuSearch extends React.Component<IProps, IState> {
                                             fontWeight: "normal",
                                         }}
                                         onClick=
-                                            {(e) => this.handleSearchClickDebounced(e, v.uuid, false)}
+                                            {(e) => {
+                                                const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                                this.handleSearchClickDebounced(e, v.uuid, closeNavPanel);
+                                            }}
                                         onDoubleClick=
-                                            {(e) => this.handleSearchClickDebounced(e, v.uuid, true)}
+                                            {(e) => this.handleSearchClickDebounced(e, v.uuid, false)}
                                         tabIndex={0}
                                         onKeyPress=
                                             {
                                                 (e) => {
                                                     if (e.key === "Enter") {
-                                                        this.handleSearchClick(e, v.uuid, true);
+                                                        const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+                                                        this.handleSearchClick(e, v.uuid, closeNavPanel);
                                                     }
                                                 }
                                             }
@@ -353,7 +357,8 @@ class ReaderMenuSearch extends React.Component<IProps, IState> {
     //                                         {
     //                                             (e) => {
     //                                                 if (link.Href && e.key === "Enter") {
-    //                                                     this.handleSearchClick(e, link.Href, true);
+    //                                                     const closeNavPanel = e.shiftKey && e.altKey ? false : true;
+    //                                                     this.handleSearchClick(e, link.Href, closeNavPanel);
     //                                                 }
     //                                             }
     //                                         }
@@ -374,17 +379,17 @@ class ReaderMenuSearch extends React.Component<IProps, IState> {
     private handleSearchClick(
         e: React.MouseEvent<any> | React.KeyboardEvent<HTMLAnchorElement>,
         href: string,
-        escape: boolean) {
+        closeNavPanel: boolean) {
 
-        handleSearchClickFunc(this, e, href, escape);
+        handleSearchClickFunc(this, e, href, closeNavPanel);
     }
 
     private handleSearchClickDebounced(
         e: React.MouseEvent<any> | React.KeyboardEvent<HTMLAnchorElement>,
         href: string,
-        escape: boolean) {
+        closeNavPanel: boolean) {
 
-        handleSearchClickFuncDebounced(this, e, href, escape);
+        handleSearchClickFuncDebounced(this, e, href, closeNavPanel);
     }
 }
 
@@ -392,12 +397,12 @@ const handleSearchClickFunc = (
     thiz: ReaderMenuSearch,
     e: React.MouseEvent<any> | React.KeyboardEvent<HTMLAnchorElement>,
     href: string,
-    escape: boolean) => {
+    closeNavPanel: boolean) => {
 
     e.preventDefault();
     console.log(href);
     thiz.props.focus(href); // search uuid
-    if (escape) {
+    if (closeNavPanel) {
         thiz.props.focusMainAreaLandmarkAndCloseMenu();
     }
 };

--- a/src/renderer/reader/components/options-values.ts
+++ b/src/renderer/reader/components/options-values.ts
@@ -110,8 +110,8 @@ export interface IReaderMenuProps {
     open: boolean;
     r2Publication: R2Publication;
     // tslint:disable-next-line: max-line-length
-    handleLinkClick: (event: TMouseEventOnSpan | TMouseEventOnAnchor | TKeyboardEventOnAnchor | undefined, url: string, closeMenu?: boolean) => void;
-    handleBookmarkClick: (locator: R2Locator, closeMenu?: boolean) => void;
+    handleLinkClick: (event: TMouseEventOnSpan | TMouseEventOnAnchor | TKeyboardEventOnAnchor | undefined, url: string, closeNavPanel?: boolean) => void;
+    handleBookmarkClick: (locator: R2Locator, closeNavPanel?: boolean) => void;
     toggleMenu: () => void;
     focusMainAreaLandmarkAndCloseMenu: () => void;
     pdfToc: TToc;


### PR DESCRIPTION
Fixes #1449
Follows #1484 and #1478 which incorrectly addressed the initial problem, see https://github.com/edrlab/thorium-reader/pull/1484#issuecomment-849407992 and https://github.com/edrlab/thorium-reader/issues/1449#issuecomment-848803274