### PR TITLE
fix: pdf+lcp import from opds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+.idea/*
 .vscode/*
 .history/*
 .github/*

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "start:quick": "cross-env DEBUG=r2:*,readium-desktop:* electron .",
     "lint:ts": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:eslint:fix": "eslint --fix \"src/**/*.{ts,tsx}\"",
-    "lint:editorconfig": "eclint check '**/*' '!changelogs/**/*' '!.vscode/**/*' '!.git/**/*' '!node_modules/**/*' '!resources/**/*' '!src/renderer/assets/**/*' '!dist/**/*' '!release/**/*' '!**/.DS_Store' '!src/typings/en.translation.d.*' '!src/main/w3c/**' '!src/resources/**/*' '!src/**/*.bcmap' '!src/**/*.svg'",
+    "lint:editorconfig": "eclint check '**/*' '!changelogs/**/*' '!.idea/**/*' '!.vscode/**/*' '!.git/**/*' '!node_modules/**/*' '!resources/**/*' '!src/renderer/assets/**/*' '!dist/**/*' '!release/**/*' '!**/.DS_Store' '!src/typings/en.translation.d.*' '!src/main/w3c/**' '!src/resources/**/*' '!src/**/*.bcmap' '!src/**/*.svg'",
     "lint:editorconfig:fix": "eclint fix '**/*' '!changelogs/**/*' '!.vscode/**/*' '!.git/**/*' '!node_modules/**/*' '!resources/**/*' '!src/renderer/assets/**/*' '!dist/**/*' '!release/**/*' '!**/.DS_Store' '!src/typings/en.translation.d.*' '!src/main/w3c/**' '!src/resources/**/*' '!src/**/*.bcmap' '!src/**/*.svg'",
     "lint": "npm run lint:editorconfig && npm run lint:ts",
     "start:dev:renderer:library-reader-pdf": "npm run start:dev:renderer:pdf && concurrently --kill-others \"npm run start:dev:renderer:library\" \"npm run start:dev:renderer:reader\"",

--- a/src/main/converter/opds.ts
+++ b/src/main/converter/opds.ts
@@ -52,7 +52,7 @@ const supportedFileTypeLinkArray = [
     ContentType.Json,
     ContentType.JsonLd,
     ContentType.pdf,
-    ContentType.lcppdf,
+    ContentType.lcpdf,
 ];
 
 @injectable()

--- a/src/main/redux/sagas/api/publication/import/importFromLink.ts
+++ b/src/main/redux/sagas/api/publication/import/importFromLink.ts
@@ -112,8 +112,7 @@ export function* importFromLinkService(
         || contentTypeArray.includes(ContentType.AudioBook)
         || contentTypeArray.includes(ContentType.JsonLd)
         || contentTypeArray.includes(ContentType.Divina)
-        || contentTypeArray.includes(ContentType.webpub)
-        || contentTypeArray.includes(ContentType.lcppdf);
+        || contentTypeArray.includes(ContentType.webpub);
 
     debug(contentTypeArray, isHtml, isJson);
 

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -273,7 +273,7 @@ export class PublicationStorage {
                                         : isWebpub
                                             ? ContentType.webpubPacked
                                             : isLcpPdf
-                                                ? ContentType.lcppdf
+                                                ? ContentType.lcpdf
                                                 : ContentType.Epub
                             ),
                     size: getFileSize(dstPath),

--- a/src/utils/contentType.ts
+++ b/src/utils/contentType.ts
@@ -31,7 +31,7 @@ export enum ContentType {
     webpubPacked = "application/webpub+zip",
     Lcp = "application/vnd.readium.lcp.license.v1.0+json",
     Lsd = "application/vnd.readium.license.status.v1.0+json",
-    lcppdf = "application/pdf+lcp",
+    lcpdf = "application/pdf+lcp",
     pdf = "application/pdf",
     ApiProblem = "application/api-problem+json",
     Opf = "application/oebps-package+xml",


### PR DESCRIPTION
lcpdf imports from opds feeds was failing as those were considered as json https://github.com/edrlab/thorium-reader/pull/1519/files#diff-6b1817d6e52d7df596edc4b004acf1d97a647935075629cb7e0e60c98a107613L116