### PR TITLE
Add Linux .desktop file keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
       ],
       "desktop": {
         "MimeType": "application/epub+zip",
-        "Keywords": "Audiobook;Book;Ebook;EPUB;Reader;Readium;Viewer;",
+        "Keywords": "Audiobook;Book;Ebook;EPUB;Reader;Readium;Viewer;"
       },
       "executableName": "thorium",
       "category": "Office"

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
         "AppImage"
       ],
       "desktop": {
-        "MimeType": "application/epub+zip"
+        "MimeType": "application/epub+zip",
+        "Keywords": "Audiobook;Book;Ebook;EPUB;Reader;Readium;Viewer;",
       },
       "executableName": "thorium",
       "category": "Office"


### PR DESCRIPTION
Adding keywords to the Linux .desktop file makes it easier to search and find Thorium without using the application name.

Note: I haven't tried building the Thorium package to confirm this works, but I referred to the electron-builder docs and compared with some other Electron apps' package.json files.