### PR TITLE
WIP(DO NOT MERGE) refactor: LCP

### DIFF
--- a/src/main/services/lcp.ts
+++ b/src/main/services/lcp.ts
@@ -47,10 +47,6 @@ import { lcpActions } from "../redux/actions";
 import { extractCrc32OnZip } from "../tools/crc";
 import { DeviceIdManager } from "./device";
 
-// import { Server } from "@r2-streamer-js/http/server";
-
-// import { JsonMap } from "readium-desktop/typings/json";
-
 // Logger
 const debug = debug_("readium-desktop:main#services/lcp");
 
@@ -1154,3 +1150,4 @@ export class LcpManager {
         return err;
     }
 }
+


### PR DESCRIPTION
Goals of this PR: top-down refactor of LCP in thorium

- fixes #890 and implement the latest state chart, if necessary in redux-saga
- migrate and replace request from https://github.com/readium/r2-lcp-js/tree/develop/src/lsd to service/lcp in thorium 
- migrate LCP decryptions and node-api binding from https://github.com/readium/r2-lcp-js/blob/57af10d684559697378a140354aba5713ba0b7f2/src/parser/epub/lcp.ts#L34 to service/lcp 
- clean r2-lcp-js to remove unused dependencies like request, In this repo they should have only the class transformer typing. All the logic will be transferred in thorium.
- fixes #540 and implement http 'problems-details' in lcp request logic
- fixes #983 from redux-saga, dispatch to the library process the current state of the lcp flowchart and then display to user the information.