### PR TITLE
Updating Swedish locale after 5f6fe81212cd5b6093255be668514e18542e6823

### DIFF
--- a/src/resources/locales/sv.json
+++ b/src/resources/locales/sv.json
@@ -338,7 +338,7 @@
         },
         "settings": {
             "column": {
-                "auto": "Automatiskt",
+                "auto": "Standard",
                 "one": "1 kol",
                 "oneTitle": "en kolumn",
                 "title": "Kolumner",


### PR DESCRIPTION
I noticed a string adjustment in the default (en) locale, so this PR implements the same change in Swedish. 