### PR TITLE
Experimental test feature: annotations / highlights (solid, underline, strikethrough)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "nanoid": "^5.0.5",
         "node-fetch": "^3.3.2",
         "r2-lcp-js": "^1.0.39",
-        "r2-navigator-js": "^1.14.11",
+        "r2-navigator-js": "^1.14.12",
         "r2-opds-js": "^1.0.43",
         "r2-shared-js": "^1.0.71",
         "r2-streamer-js": "^1.0.47",
@@ -65,7 +65,7 @@
         "yazl": "^2.5.1"
       },
       "devDependencies": {
-        "@axe-core/react": "^4.8.4",
+        "@axe-core/react": "^4.8.5",
         "@babel/generator": "^7.23.6",
         "@electron/notarize": "^2.2.1",
         "@electron/rebuild": "^3.6.0",
@@ -98,8 +98,8 @@
         "@types/yargs": "^17.0.32",
         "@types/yauzl": "^2.10.3",
         "@types/yazl": "^2.4.5",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.1",
+        "@typescript-eslint/parser": "^7.0.1",
         "@vanilla-extract/babel-plugin": "^1.2.0",
         "@vanilla-extract/css": "^1.14.1",
         "@vanilla-extract/webpack-plugin": "^2.3.6",
@@ -158,7 +158,7 @@
         "webpack": "^5.90.1",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.0",
+        "webpack-dev-server": "^5.0.1",
         "webpack-node-externals": "^3.0.0",
         "worker-loader": "^3.0.8"
       },
@@ -190,12 +190,12 @@
       }
     },
     "node_modules/@axe-core/react": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.4.tgz",
-      "integrity": "sha512-Duzl4PsEvezvVbzFvfBZAFB7K3+7kOTq2ChUgQinoqA8QrojJ9Kn+GE/62b9ad2ycDiNc+3Q4K24T8MVnCXv0g==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.5.tgz",
+      "integrity": "sha512-GKXFAc/VPa3sDPv8lqPZlDvBt0UNwOwN0B/EnUOaHTRe5IcLl+RfcD+LHVEE75Quc1LOgSyw4T0O9kvJuPzIxg==",
       "dev": true,
       "dependencies": {
-        "axe-core": "~4.8.3",
+        "axe-core": "~4.8.4",
         "requestidlecallback": "^0.3.0"
       }
     },
@@ -3875,9 +3875,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.1.0.tgz",
-      "integrity": "sha512-g3/sYJWXTAf3Ce861z4/mW9jDxN7hoNHZMEyhd3Zh7GKQPiovWNttzhRW2BeGPwPxPpLDKumL6Sg056VAMjdkg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.2.0.tgz",
+      "integrity": "sha512-UTce8mUwUW0RikMb/eseJ7ys0BRkZVFB86orHzrfW12ZmFtym5zua8joZ4L7okH2dDFHkcFjqnZ5GocWBXOFtA==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -4596,16 +4596,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
+      "integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/type-utils": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -4621,8 +4621,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4664,15 +4664,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
+      "integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4683,7 +4683,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4692,13 +4692,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+      "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -4709,13 +4709,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
+      "integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -4727,7 +4727,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4736,9 +4736,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -4749,13 +4749,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+      "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4810,17 +4810,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -4831,7 +4831,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
@@ -4868,12 +4868,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/types": "7.0.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -7012,14 +7012,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.6.tgz",
-      "integrity": "sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
-        "set-function-length": "^1.2.0"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8566,17 +8567,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.2.tgz",
-      "integrity": "sha512-SRtsSqsDbgpJBbW3pABMCOt6rQyeM8s8RiyeSN8jYG8sYmt/kGJejbydttUsnDs1tadr19tvhT4ShwMyoqAm4g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.2",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -9463,9 +9466,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.665",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.665.tgz",
-      "integrity": "sha512-UpyCWObBoD+nSZgOC2ToaIdZB0r9GhqT2WahPKiSki6ckkSuKhQNso8V2PrFcHBMleI/eqbKgVQgVC4Wni4ilw=="
+      "version": "1.4.668",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.668.tgz",
+      "integrity": "sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -9579,49 +9582,51 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-      "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.4.tgz",
+      "integrity": "sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg==",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.5",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.6",
+        "call-bind": "^1.0.7",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.2",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.2",
-        "get-symbol-description": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
+        "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.1",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.0",
+        "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.8",
         "string.prototype.trimend": "^1.0.7",
         "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
+        "typed-array-buffer": "^1.0.1",
         "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.13"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9636,6 +9641,17 @@
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -9645,21 +9661,21 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.16.tgz",
-      "integrity": "sha512-CREG2A9Vq7bpDRnldhFcMKuKArvkZtsH6Y0DHOHVg49qhf+LD8uEdUM3OkOAICv0EziGtDEnQtqY2/mfBILpFw==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.17.tgz",
+      "integrity": "sha512-lh7BsUqelv4KUbR5a/ZTaGGIMLCjPGPqJ6q+Oq24YP0RdyptX1uzm4vvaqzk7Zx3bpl/76YLTTDj9L7uYQ92oQ==",
       "dev": true,
       "dependencies": {
         "asynciterator.prototype": "^1.0.0",
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
+        "es-abstract": "^1.22.4",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.0.2",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.7",
@@ -12184,11 +12200,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15879,9 +15895,9 @@
       }
     },
     "node_modules/jsdom/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-My1KCEPs6A0hb4qCVzYp8iEvA8j8YqcvXLZZH8C9OFuTYpYjHE7N2dtG3mRl1HMD4+VGXpF3XcDVcxGBT7yDZQ==",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -15891,9 +15907,9 @@
       }
     },
     "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.3.tgz",
+      "integrity": "sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -15938,13 +15954,14 @@
       }
     },
     "node_modules/json-joy": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
-      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "version": "11.28.0",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-11.28.0.tgz",
+      "integrity": "sha512-WTq2tYD2r+0rUFId4gtUjwejV20pArh4q2WRJKxJdwLlPFHyW94HwwB2vUr5lUJTVkehhhWEVLwOUI0MSacNIw==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.2",
-        "hyperdyperid": "^1.2.0"
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^1.14.1"
       },
       "bin": {
         "jj": "bin/jj.js",
@@ -19558,9 +19575,9 @@
       }
     },
     "node_modules/r2-navigator-js": {
-      "version": "1.14.11",
-      "resolved": "https://registry.npmjs.org/r2-navigator-js/-/r2-navigator-js-1.14.11.tgz",
-      "integrity": "sha512-f80c56Y6s76XWYrsZ+ZOqa+C4W2UqA7P0jhBroR5Wxu7BJ4DU7t8EQma/+42OJMZe0QDD4Vp82WpRsGfzoeoXg==",
+      "version": "1.14.12",
+      "resolved": "https://registry.npmjs.org/r2-navigator-js/-/r2-navigator-js-1.14.12.tgz",
+      "integrity": "sha512-HlE0j27JYkhMdM0bkQdZxkKk7D+SrLByDeSE+P8l23jwYkBITsG3rrtr2Q77d8UmP6tTtl+pwukFwmZlgcFKxw==",
       "hasInstallScript": true,
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -25681,12 +25698,12 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/memfs": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.6.0.tgz",
-      "integrity": "sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.7.0.tgz",
+      "integrity": "sha512-FGbf9Yz2gzXCUmpymkKnzAQOitriZQlIMtmnzb2LOcT0FTUdzL6AAwNGQrSOACx/UiW7XQsG65vrIA9+L01Edw==",
       "dev": true,
       "dependencies": {
-        "json-joy": "^9.2.0",
+        "json-joy": "^11.0.0",
         "thingies": "^1.11.1"
       },
       "engines": {
@@ -25701,9 +25718,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.0.tgz",
-      "integrity": "sha512-3nEQmKcNTrHMcYoOOwOb+Uy/SuJ5I1uEvNPXxrXct/QDBV1l8xc2vh21GAPNUWcw7ECfNX051yhNCpR4VYqVdw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.1.tgz",
+      "integrity": "sha512-Mbla51FSVfk9WvGiCWRJLsMLq87LNxQitz477z0LIhHbx7ig/fIkU9R/OCNmf6A3tTaJoObwmYco9buC1oN+yA==",
       "dev": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "nanoid": "^5.0.5",
     "node-fetch": "^3.3.2",
     "r2-lcp-js": "^1.0.39",
-    "r2-navigator-js": "^1.14.11",
+    "r2-navigator-js": "^1.14.12",
     "r2-opds-js": "^1.0.43",
     "r2-shared-js": "^1.0.71",
     "r2-streamer-js": "^1.0.47",
@@ -305,7 +305,7 @@
     "yazl": "^2.5.1"
   },
   "devDependencies": {
-    "@axe-core/react": "^4.8.4",
+    "@axe-core/react": "^4.8.5",
     "@babel/generator": "^7.23.6",
     "@electron/notarize": "^2.2.1",
     "@electron/rebuild": "^3.6.0",
@@ -338,8 +338,8 @@
     "@types/yargs": "^17.0.32",
     "@types/yauzl": "^2.10.3",
     "@types/yazl": "^2.4.5",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
     "@vanilla-extract/babel-plugin": "^1.2.0",
     "@vanilla-extract/css": "^1.14.1",
     "@vanilla-extract/webpack-plugin": "^2.3.6",
@@ -398,7 +398,7 @@
     "webpack": "^5.90.1",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.0",
+    "webpack-dev-server": "^5.0.1",
     "webpack-node-externals": "^3.0.0",
     "worker-loader": "^3.0.8"
   },

--- a/src/common/keyboard.ts
+++ b/src/common/keyboard.ts
@@ -304,6 +304,27 @@ const _defaults_ = Object.freeze({
         shift: false,
         key: "Digit9",
     }),
+    AnnotationsTest1: Object.freeze<TKeyboardShortcut>({
+        alt: true,
+        control: true,
+        shift: true,
+        // meta: true,
+        key: "Digit5",
+    }),
+    AnnotationsTest2: Object.freeze<TKeyboardShortcut>({
+        alt: true,
+        control: true,
+        shift: true,
+        // meta: true,
+        key: "Digit6",
+    }),
+    AnnotationsTest3: Object.freeze<TKeyboardShortcut>({
+        alt: true,
+        control: true,
+        shift: true,
+        // meta: true,
+        key: "Digit7",
+    }),
 });
 export const _defaults = sortObject(_defaults_);
 

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -91,6 +91,12 @@ import { URL_PARAM_CLIPBOARD_INTERCEPT, URL_PARAM_CSS, URL_PARAM_DEBUG_VISUALS, 
 
 import { createOrGetPdfEventBus } from "readium-desktop/renderer/reader/pdf/driver";
 
+import {
+    highlightsCreate,
+} from "@r2-navigator-js/electron/renderer";
+
+import { IS_DEV } from "readium-desktop/preprocessor-directives";
+
 // main process code!
 // thoriumhttps
 // import { THORIUM_READIUM2_ELECTRON_HTTP_PROTOCOL } from "readium-desktop/main/streamer/streamerNoHttp";
@@ -942,6 +948,22 @@ class Reader extends React.Component<IProps, IState> {
             true, // listen for key up (not key down)
             this.props.keyboardShortcuts.AudioStop,
             this.onKeyboardAudioStop);
+
+        // TODO HIGHLIGHTS-ANNOTATIONS: just for testing!
+        if (IS_DEV) {
+          registerKeyboardListener(
+              true, // listen for key up (not key down)
+              this.props.keyboardShortcuts.AnnotationsTest1,
+              this.onKeyboardAnnotationsTest1);
+          registerKeyboardListener(
+              true, // listen for key up (not key down)
+              this.props.keyboardShortcuts.AnnotationsTest2,
+              this.onKeyboardAnnotationsTest2);
+          registerKeyboardListener(
+              true, // listen for key up (not key down)
+              this.props.keyboardShortcuts.AnnotationsTest3,
+              this.onKeyboardAnnotationsTest3);
+        }
     }
 
     private unregisterAllKeyboardListeners() {
@@ -969,6 +991,13 @@ class Reader extends React.Component<IProps, IState> {
         unregisterKeyboardListener(this.onKeyboardAudioPreviousAlt);
         unregisterKeyboardListener(this.onKeyboardAudioNextAlt);
         unregisterKeyboardListener(this.onKeyboardAudioStop);
+
+        // TODO HIGHLIGHTS-ANNOTATIONS: just for testing!
+        if (IS_DEV) {
+            unregisterKeyboardListener(this.onKeyboardAnnotationsTest1);
+            unregisterKeyboardListener(this.onKeyboardAnnotationsTest2);
+            unregisterKeyboardListener(this.onKeyboardAnnotationsTest3);
+        }
     }
 
     private handleLinkLocator = (locator: R2Locator, isFromOnPopState = false) => {
@@ -995,6 +1024,81 @@ class Reader extends React.Component<IProps, IState> {
     private handleLinkUrl = (url: string, isFromOnPopState = false) => {
         handleLinkUrl_UpdateHistoryState(url, isFromOnPopState);
         r2HandleLinkUrl(url);
+    };
+
+    // TODO HIGHLIGHTS-ANNOTATIONS: just for testing!
+    private onKeyboardAnnotationsTest = (type: number) => {
+
+        if (IS_DEV) {
+            if (this.props.isDivina || this.props.isPdf) {
+                return;
+            }
+
+            // navigator loc has updated selectionInfo (may have been invalidated / cleared since last notified here ... so takes precedence over local state)
+            const loc = getCurrentReadingLocation() || this.state.currentLocation;
+
+            if (!loc?.locator?.href || !loc?.selectionInfo) { // loc?.selectionIsNew
+                return;
+            }
+
+            const colors = [{
+                red: 210,
+                green: 137,
+                blue: 156,
+            },
+            {
+                red: 6,
+                green: 202,
+                blue: 56,
+            },
+            {
+                red: 57,
+                green: 153,
+                blue: 208,
+            },
+            {
+                red: 213,
+                green: 180,
+                blue: 120,
+            },
+            {
+                red: 61,
+                green: 181,
+                blue: 172,
+            }];
+            const color = true ? colors[Math.floor(Math.random() * colors.length)] : {
+                red: Math.floor(Math.random() * 256),
+                green: Math.floor(Math.random() * 256),
+                blue: Math.floor(Math.random() * 256),
+            };
+            console.log("DEV HIGHLIGHT CREATE: " + type, JSON.stringify(color, null, 4));
+
+            highlightsCreate(loc.locator.href, [
+                {
+                    selectionInfo: loc.selectionInfo,
+                    // range: Range,
+
+                    color,
+
+                    // 0 is full background (default), 1 is underline, 2 is strikethrough
+                    // FUTURE: 3 is composite background + underline
+                    drawType: type,
+
+                    expand: 3,
+
+                    group: "annotations",
+                },
+            ]);
+        }
+    };
+    private onKeyboardAnnotationsTest1 = () => {
+        this.onKeyboardAnnotationsTest(0);
+    };
+    private onKeyboardAnnotationsTest2 = () => {
+        this.onKeyboardAnnotationsTest(1);
+    };
+    private onKeyboardAnnotationsTest3 = () => {
+        this.onKeyboardAnnotationsTest(2);
     };
 
     private onKeyboardAudioStop = () => {

--- a/src/renderer/reader/redux/sagas/highlight/mounter.ts
+++ b/src/renderer/reader/redux/sagas/highlight/mounter.ts
@@ -7,6 +7,7 @@
 
 import * as debug_ from "debug";
 
+import { IEventPayload_R2_EVENT_HIGHLIGHT_CLICK } from "@r2-navigator-js/electron/common/events";
 import { zipWith } from "ramda";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 import { eventChannel, SagaIterator } from "redux-saga";
@@ -101,14 +102,14 @@ export function* unmountHightlight(href: string, mountUUIDs: string[]): SagaIter
     yield put(readerLocalActionHighlights.mounter.unmount.build(uuids));
 }
 
-export type THighlightClick = [string, IHighlight];
+export type THighlightClick = [string, IHighlight, IEventPayload_R2_EVENT_HIGHLIGHT_CLICK["event"]];
 
 export function getHightlightClickChannel() {
     const channel = eventChannel<THighlightClick>(
         (emit) => {
 
-            const handler = (href: string, highlight: IHighlight) => {
-                emit([href, highlight]);
+            const handler = (href: string, highlight: IHighlight, event: IEventPayload_R2_EVENT_HIGHLIGHT_CLICK["event"]) => {
+                emit([href, highlight, event]);
             };
 
             highlightsClickListen(handler);

--- a/src/renderer/reader/redux/sagas/search.ts
+++ b/src/renderer/reader/redux/sagas/search.ts
@@ -35,6 +35,17 @@ const handleLinkLocatorDebounced = debounce(handleLinkLocator, 200);
 
 const debug = debug_("readium-desktop:renderer:reader:redux:sagas:search");
 
+const COLOR_SEARCH = {
+    red: 190,
+    green: 233,
+    blue: 34,
+};
+const COLOR_SEARCH_FOCUS = {
+    red: 241,
+    green: 79,
+    blue: 237,
+};
+
 function createLocatorLink(href: string, rangeInfo: IRangeInfo): R2Locator {
 
     return {
@@ -70,11 +81,7 @@ function* searchRequest(action: readerLocalActionSearch.request.TAction) {
     yield put(readerLocalActionSearch.found.build(flatten(res)));
 }
 
-function converterSearchResultToHighlightHandlerState(v: ISearchResult, color = {
-    red: 0,
-    green: 255,
-    blue: 0,
-}): IHighlightHandlerState {
+function converterSearchResultToHighlightHandlerState(v: ISearchResult, color = COLOR_SEARCH): IHighlightHandlerState {
     return {
         uuid: v.uuid,
         href: v.href,
@@ -144,11 +151,7 @@ function* searchFocus(action: readerLocalActionSearch.focus.TAction) {
         yield put(
             readerLocalActionHighlights.handler.push.build([
                 converterSearchResultToHighlightHandlerState(oldItemClone),
-                converterSearchResultToHighlightHandlerState(newItemClone, {
-                    red: 255,
-                    green: 0,
-                    blue: 0,
-                }),
+                converterSearchResultToHighlightHandlerState(newItemClone, COLOR_SEARCH_FOCUS),
             ]),
         );
 
@@ -167,11 +170,7 @@ function* searchFocus(action: readerLocalActionSearch.focus.TAction) {
 
         yield put(
             readerLocalActionHighlights.handler.push.build([
-                converterSearchResultToHighlightHandlerState(newItemClone, {
-                    red: 255,
-                    green: 0,
-                    blue: 0,
-                }),
+                converterSearchResultToHighlightHandlerState(newItemClone, COLOR_SEARCH_FOCUS),
             ]),
         );
 


### PR DESCRIPTION
To create "annotation" highlights:

* select text / character ranges in the HTML document
* `SHIFT` + `CTRL` + `ALT` + `5` (solid highlight) or `6` (underline) or `7` (strikethrough)
* click on a highlight to set the reading location at that particular spot
* `ALT` + click on highlights to toggle between normal inline mode and margin indicator mode
* `META` + click on highlights to remove them

Note that this keyboard shortcut is intentionally annoyingly cumbersome and there are no alternative GUI buttons etc. This is a "hidden" feature to test the experimental underlying highlights engine, the UX is knowingly incomplete.
Note that colours cycle randomly among a small set of predefined tones that work well in both light and dark modes. Ultimately, the user will be able to pick colours from a GUI control.

This functionality works concurrently with the text search feature. To create "search" highlights:

* `CTRL` + `F`
* click to activate / select a particular search result (this sets the reading location)
* `ALT` + click on "search" highlights toggles them (margin/inline mode), but does not affect "annotation" highlights which are isolated in a separate category / group.

This functionality also works concurrently with TTS readaloud which uses the same underlying highlights engine. The readaloud sentence / word highlights are not interactive (cannot be moved into the margin)
