### PR TITLE
Dev/annotation picker color (fix issue #2120)

### DIFF
--- a/src/renderer/assets/styles/components/annotations.scss
+++ b/src/renderer/assets/styles/components/annotations.scss
@@ -232,6 +232,10 @@
             cursor: pointer;
         }
     }
+
+    svg {
+      color: #4d4d4d;
+    }
   }
   
   .stylePicker {

--- a/src/renderer/assets/styles/components/annotations.scss.d.ts
+++ b/src/renderer/assets/styles/components/annotations.scss.d.ts
@@ -23,7 +23,6 @@ export declare const button_primary_blue: string;
 export declare const colorPicker: string;
 export declare const docked_annotation_line: string;
 export declare const drawType_active: string;
-export declare const icon: string;
 export declare const R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE: string;
 export declare const R2_CSS_CLASS__FORCE_NO_TARGET_OUTLINE: string;
 export declare const R2_CSS_CLASS__KEYBOARD_INTERACT: string;

--- a/src/renderer/assets/styles/components/annotations.scss.d.ts
+++ b/src/renderer/assets/styles/components/annotations.scss.d.ts
@@ -23,6 +23,7 @@ export declare const button_primary_blue: string;
 export declare const colorPicker: string;
 export declare const docked_annotation_line: string;
 export declare const drawType_active: string;
+export declare const icon: string;
 export declare const R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE: string;
 export declare const R2_CSS_CLASS__FORCE_NO_TARGET_OUTLINE: string;
 export declare const R2_CSS_CLASS__KEYBOARD_INTERACT: string;


### PR DESCRIPTION
change the color of the check icon for annotations color picker in dark mode from white to black to fix visibility issue (#2120)