### PR TITLE
fix(#2228): make checkboxes in reader settings selectable with the tab key

### DIFF
--- a/src/renderer/reader/components/ReaderSettings.tsx
+++ b/src/renderer/reader/components/ReaderSettings.tsx
@@ -143,10 +143,10 @@ const Theme = ({theme, set}: {theme: Pick<ReaderConfig, "theme">, set: (a: Pick<
     ]);
 
 
-    const defaultKey = 
-    theme.theme === "neutral" ? 1 
-    : theme.theme === "night" ? 4 
-    : theme.theme === "sepia" ? 2 
+    const defaultKey =
+    theme.theme === "neutral" ? 1
+    : theme.theme === "night" ? 4
+    : theme.theme === "sepia" ? 2
     : theme.theme === "contrast1" ? 5
     : theme.theme === "paper" ? 3
     : theme.theme === "contrast2" ? 6
@@ -161,34 +161,34 @@ const Theme = ({theme, set}: {theme: Pick<ReaderConfig, "theme">, set: (a: Pick<
         value={themeOptions.find((theme) => theme.id === defaultKey).value}
                 onValueChange={(option) => set({ theme: option as TTheme  })}
             >
-                {themeOptions.map((theme) => 
-                                <RadioGroupItem 
+                {themeOptions.map((theme) =>
+                                <RadioGroupItem
                                 key={theme.value}
-                                value={theme.value} 
+                                value={theme.value}
                                 description={theme.name}
-                                className={stylesSettings.settings_theme_container} 
+                                className={stylesSettings.settings_theme_container}
                                 style={theme.style}
                                 svg={defaultKey === theme.id ? DoubleCheckIcon : null}
                                 />,
                 )}
-                {/* <RadioGroupItem 
-                value="neutral" 
+                {/* <RadioGroupItem
+                value="neutral"
                 description={`${__("reader.settings.theme.name.Neutral")}`}
-                className={stylesSettings.settings_theme_container} 
+                className={stylesSettings.settings_theme_container}
                 style={{backgroundColor: "#fff", color: "black"}}
                 svg={defaultKey === 1 ? CheckIcon : null}
                 />
-                <RadioGroupItem 
-                value="sepia" 
+                <RadioGroupItem
+                value="sepia"
                 description={`${__("reader.settings.theme.name.Sepia")}`}
-                className={stylesSettings.settings_theme_container} 
+                className={stylesSettings.settings_theme_container}
                 style={{backgroundColor: "#faf4e8", color: "black"}}
                 svg={defaultKey === 2 ? CheckIcon : null}
                 />
-                <RadioGroupItem 
-                value="night" 
+                <RadioGroupItem
+                value="night"
                 description={`${__("reader.settings.theme.name.Night")}`}
-                className={stylesSettings.settings_theme_container} 
+                className={stylesSettings.settings_theme_container}
                 style={{backgroundColor: "#2D2D2D", color: "#fff" }}
                 svg={defaultKey === 3 ? CheckIcon : null}
                 /> */}
@@ -659,7 +659,7 @@ export const ReadingAudio = ({ useMO, config: { mediaOverlaysEnableCaptionsMode:
     );
 };
 
-const ReadingDisplayMathJax = ({
+const ReadingDisplayCheckboxSettings = ({
     config: { enableMathJax, reduceMotion, noFootnotes, noRuby },
     set,
     disableRTLFlip,
@@ -731,7 +731,16 @@ const ReadingDisplayMathJax = ({
                             className={stylesGlobal.checkbox_custom_input}
                         />
                         <label htmlFor={option.id} style={{margin: "0 5px", height: "unset"}} className={stylesGlobal.checkbox_custom_label}>
-                        <div className={stylesGlobal.checkbox_custom} style={{ border: option.checked ? "2px solid transparent" : "2px solid var(--color-primary)", backgroundColor: option.checked ? "var(--color-blue)" : "transparent" }}>
+                        <div
+                            tabIndex={0}
+                            role="checkbox"
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    option.onChange();
+                                }
+                            }}
+                            className={stylesGlobal.checkbox_custom}
+                            style={{ border: option.checked ? "2px solid transparent" : "2px solid var(--color-primary)", backgroundColor: option.checked ? "var(--color-blue)" : "transparent" }}>
                                             {option.checked ?
                                                 <SVG ariaHidden svg={CheckIcon} />
                                                 :
@@ -754,7 +763,15 @@ const ReadingDisplayMathJax = ({
                         className={stylesGlobal.checkbox_custom_input}
                     />
                     <label htmlFor="noRTLFlipCheckBox" style={{margin: "0 5px", height: "unset"}} className={stylesGlobal.checkbox_custom_label}>
-                    <div className={stylesGlobal.checkbox_custom} style={{ border: disableRTLFlip ? "2px solid transparent" : "2px solid var(--color-primary)", backgroundColor: disableRTLFlip ? "var(--color-blue)" : "transparent" }}>
+                    <div
+                        tabIndex={0}
+                        role="checkbox"
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                setDisableRTLFlip(!disableRTLFlip);
+                            }
+                        }}
+                        className={stylesGlobal.checkbox_custom} style={{ border: disableRTLFlip ? "2px solid transparent" : "2px solid var(--color-primary)", backgroundColor: disableRTLFlip ? "var(--color-blue)" : "transparent" }}>
                                             {disableRTLFlip ?
                                                 <SVG ariaHidden svg={CheckIcon} />
                                                 :
@@ -1023,7 +1040,7 @@ export const ReaderSettings: React.FC<IBaseProps> = (props) => {
 
             setTimeout(() => {
                 if (dockedModeRef.current) {
-    
+
                     console.log("Focus on docked mode combobox");
                     dockedModeRef.current.focus();
                 } else {
@@ -1258,7 +1275,7 @@ export const ReaderSettings: React.FC<IBaseProps> = (props) => {
                             {isPdf ? <></> : <ReadingDisplayLayout config={readerConfig} set={setPartialSettingsDebounced} isFXL={props.isFXL} />}
                             {isPdf ? <></> : <ReadingDisplayAlign config={readerConfig} set={setPartialSettingsDebounced} />}
                             <ReadingDisplayCol config={readerConfig} set={setPartialSettingsDebounced} isPdf={props.isPdf} pdfCol={pdfState.pdfCol} />
-                            {isPdf ? <></> : <ReadingDisplayMathJax config={readerConfig} set={setPartialSettingsDebounced} disableRTLFlip={props.disableRTLFlip} setDisableRTLFlip={props.setDisableRTLFlip} />}
+                            {isPdf ? <></> : <ReadingDisplayCheckboxSettings config={readerConfig} set={setPartialSettingsDebounced} disableRTLFlip={props.disableRTLFlip} setDisableRTLFlip={props.setDisableRTLFlip} />}
                         </section>
                     </Tabs.Content>
                     {/* <Tabs.Content value="tab-audio" tabIndex={-1}>


### PR DESCRIPTION
Fix for #2228 