### PR TITLE
fix focus style on Import Publication button

### DIFF
--- a/src/renderer/assets/styles/components/buttons.scss
+++ b/src/renderer/assets/styles/components/buttons.scss
@@ -326,11 +326,13 @@ button {
   
   input {
     position: absolute;
-    right: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
+    right: 5px;
+    top: 2px;
+    width: 90%;
+    height: 80%;
     z-index: -10;
+    border-radius: 5px;
+    padding: 1%;
   }
 }
 


### PR DESCRIPTION
Fixes #2172

(Was caused by the input "hidden" behind it, I shrank the input a bit so it doesn't mess with the focus design of the label anymore.)