### PR TITLE
fix vertical scroll on left side wizard + position buttons

### DIFF
--- a/src/renderer/assets/styles/components/modals.scss
+++ b/src/renderer/assets/styles/components/modals.scss
@@ -218,11 +218,12 @@
   margin-top: 30px!important;
 
   .guidedTour_tab {
-    margin-top: 0;
+    margin-top: 0!important;
 
     h3 {
       font-size: 25px;
       margin-top: 0;
+      margin-bottom: 10px;
     }
 
     p {
@@ -248,9 +249,10 @@
       align-items: center;
       justify-content: flex-end;
       gap: 20px;
-      position: absolute;
-      bottom: 20px;
-      right: 20px;
+      // position: absolute;
+      // bottom: 20px;
+      // right: 20px;
+      margin: 20px 0;
     }
   }
 }

--- a/src/renderer/assets/styles/components/settings.scss
+++ b/src/renderer/assets/styles/components/settings.scss
@@ -21,6 +21,12 @@ $setting_color: var(--color-blue);
         }
     }
 
+    &:has(.guidedTour_content) {
+        @media screen and (height <= 700px) {
+            height: 512px;
+        }
+    }
+
     .section {
         padding-bottom: 15px ;
         border-bottom: 2px solid var(--color-extralight-grey);
@@ -277,13 +283,13 @@ $setting_color: var(--color-blue);
 
 .close_button_div {
     position: absolute;
-    top: 10px;
-    right: 20px;
+    top: 5px;
+    right: 10px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    background-color: var(--color-secondary);
+    background-color: transparent;
     padding: 10px;
     width: 60%;
     z-index: 10;


### PR DESCRIPTION
Fixes #2290

Due to the length of some texts, the only solution I could find is to change the absolute positioning of the buttons (which placed them always at the bottom right of the modal) to a "default" positioning with a margin of 20px at there top and bottom. 
We still have scroll on some tabs and on other the buttons are a bit high.. This is not perfect but this is the only way the buttons are never over the images no matter the screen size or the text length. 