### PR TITLE
feat: use user's preferred language on first launch if available

### DIFF
--- a/src/common/services/translator.ts
+++ b/src/common/services/translator.ts
@@ -196,7 +196,7 @@ export const GetMatchingAvailableLanguage = (lang: string) => {
     // First match full BCP47 code, then match only the language code.
     const langKeys = Object.keys(AvailableLanguages);
     return langKeys.find((key) => key === lang) ??
-           langKeys.find((key) => key.startsWith(lang.split("-")[0]));
+           langKeys.find((key) => key.split("-")[0] == lang.split("-")[0]);
 };
 
 interface LocalizedContent {

--- a/src/common/services/translator.ts
+++ b/src/common/services/translator.ts
@@ -192,6 +192,10 @@ export const AvailableLanguages = {
     "sl": "Slovenščina (Slovene)",
 };
 
+export const GetMatchingAvailableLanguage = (lang: string) => {
+    return Object.entries(AvailableLanguages).find((key) => lang.startsWith(key[0]));
+}
+
 interface LocalizedContent {
     [locale: string]: string;
 }

--- a/src/common/services/translator.ts
+++ b/src/common/services/translator.ts
@@ -194,7 +194,7 @@ export const AvailableLanguages = {
 
 export const GetMatchingAvailableLanguage = (lang: string) => {
     return Object.entries(AvailableLanguages).find((key) => lang.startsWith(key[0]));
-}
+};
 
 interface LocalizedContent {
     [locale: string]: string;

--- a/src/common/services/translator.ts
+++ b/src/common/services/translator.ts
@@ -193,7 +193,10 @@ export const AvailableLanguages = {
 };
 
 export const GetMatchingAvailableLanguage = (lang: string) => {
-    return Object.entries(AvailableLanguages).find((key) => lang.startsWith(key[0]));
+    // First match full BCP47 code, then match only the language code.
+    const langKeys = Object.keys(AvailableLanguages);
+    return langKeys.find((key) => key === lang) ??
+           langKeys.find((key) => key.startsWith(lang.split("-")[0]));
 };
 
 interface LocalizedContent {

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -46,7 +46,7 @@ export function* handleFirstLaunch() {
         const preferredLanguage = app.getPreferredSystemLanguages(); // Get OS primary locale via Electron.
         try {
             // Check if the user's first preferred language is available in the app.
-            const matchingLanguage = GetMatchingAvailableLanguage(preferredLanguage[0])
+            const matchingLanguage = GetMatchingAvailableLanguage(preferredLanguage[0]);
             debug("Found matching app language at first launch", matchingLanguage);
             if (matchingLanguage !== undefined) {
                 // Use first component of the matching language (language code).

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -39,7 +39,7 @@ const filename_ = "readium-desktop:main:saga:app";
 const debug = debug_(filename_);
 
 // Path to the first launch flag file
-const firstLaunchFlagPath = path.join(app.getPath('userData'), 'firstLaunchFlag.txt');
+const firstLaunchFlagPath = path.join(app.getPath("userData"), "firstLaunchFlag.txt");
 
 export function* handleFirstLaunch() {
     if (!existsSync(firstLaunchFlagPath)) {
@@ -47,13 +47,13 @@ export function* handleFirstLaunch() {
         try {
             // Check if the user's first preferred language is available in the app.
             const matchingLanguage = GetMatchingAvailableLanguage(preferredLanguage[0])
-            debug('Found matching app language at first launch', matchingLanguage);
+            debug("Found matching app language at first launch", matchingLanguage);
             if (matchingLanguage !== undefined) {
                 // Use first component of the matching language (language code).
                 yield put(i18nActions.setLocale.build(matchingLanguage[0]));
             }
         } finally {
-            writeFileSync(firstLaunchFlagPath, 'first_launch');
+            writeFileSync(firstLaunchFlagPath, "first_launch");
         }
     }
 }

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -43,15 +43,16 @@ const firstLaunchFlagPath = path.join(app.getPath("userData"), "firstLaunchFlag.
 
 export function* handleFirstLaunch() {
     if (!existsSync(firstLaunchFlagPath)) {
-        // Get user's preferred languages via Electron.
-        const preferredLanguage = app.getPreferredSystemLanguages();
         try {
-            // Check if the user's first preferred language is available in the app.
-            const matchingLanguage = GetMatchingAvailableLanguage(preferredLanguage[0]);
-            debug("Found matching app language at first launch", matchingLanguage);
-            if (matchingLanguage !== undefined) {
-                // Use first component of the matching language (language code).
-                yield put(i18nActions.setLocale.build(matchingLanguage[0]));
+            // Set locale to user's preferred language if available.
+            const preferredLanguages = app.getPreferredSystemLanguages();
+            for (const prefLang of preferredLanguages) {
+                const match = GetMatchingAvailableLanguage(prefLang);
+                if (match) {
+                    debug("Found preferred app locale at first launch", match);
+                    yield put(i18nActions.setLocale.build(match));
+                    break;
+                }
             }
         } finally {
             writeFileSync(firstLaunchFlagPath, "first_launch");

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -43,7 +43,8 @@ const firstLaunchFlagPath = path.join(app.getPath("userData"), "firstLaunchFlag.
 
 export function* handleFirstLaunch() {
     if (!existsSync(firstLaunchFlagPath)) {
-        const preferredLanguage = app.getPreferredSystemLanguages(); // Get OS primary locale via Electron.
+        // Get user's preferred languages via Electron.
+        const preferredLanguage = app.getPreferredSystemLanguages();
         try {
             // Check if the user's first preferred language is available in the app.
             const matchingLanguage = GetMatchingAvailableLanguage(preferredLanguage[0]);

--- a/src/main/redux/sagas/index.ts
+++ b/src/main/redux/sagas/index.ts
@@ -140,6 +140,9 @@ export function* rootSaga() {
 
     // open reader from CLI or open-file event on MACOS
     yield events.saga();
+
+    // handle first launch of the app
+    yield call(appSaga.handleFirstLaunch);
 }
 
 function* checkAppVersionUpdate() {


### PR DESCRIPTION
Hi EDRLab.
During our testing of our LCP implementation in Nota, our users complained that Thorium Reader wasn't using the same language as their OS when first launching it. I have tried to implement this, but do not have much experience with using Electron and saga.

Please feel free to recommend a more optimal way to do this. The logic around doing this on first launch, using a dummy file, feels a little rudimentary.
