### PR TITLE
fix tabIndex navigation arrows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "EDRLab.ThoriumReader",
-  "version": "3.0.0",
+  "version": "3.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "EDRLab.ThoriumReader",
-      "version": "3.0.0",
+      "version": "3.1.0-alpha.1",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/src/renderer/library/components/opds/PageNavigation.tsx
+++ b/src/renderer/library/components/opds/PageNavigation.tsx
@@ -97,6 +97,7 @@ class PageNavigation extends React.Component<IProps, undefined> {
                     <button
                         className={stylesPublication.allBooks_header_pagination_arrow}
                         aria-label={`${__("opds.firstPage")}`}
+                        tabIndex={-1}
                         disabled={!pageLinks?.first[0]?.url || pageInfo?.currentPage === 0}
                     >
                         {pageLinks?.first[0]?.url ?
@@ -117,6 +118,7 @@ class PageNavigation extends React.Component<IProps, undefined> {
                             transform: "rotate(180deg)",
                         }}
                         aria-label={`${__("opds.previous")}`}
+                        tabIndex={-1}
                         disabled={!pageLinks?.previous[0]?.url || pageInfo?.currentPage === 0}>
                         {
                             pageLinks?.previous[0]?.url ?
@@ -164,6 +166,7 @@ class PageNavigation extends React.Component<IProps, undefined> {
                     <button
                         className={stylesPublication.allBooks_header_pagination_arrow}
                         aria-label={`${__("opds.next")}`}
+                        tabIndex={-1}
                         disabled={!pageLinks?.next[0]?.url || pageInfo?.currentPage === Math.ceil(pageInfo?.numberOfItems / (pageInfo?.itemsPerPage || 1))}>
                         {pageLinks?.next[0]?.url ?
                             <Link
@@ -180,6 +183,7 @@ class PageNavigation extends React.Component<IProps, undefined> {
                     <button
                         className={stylesPublication.allBooks_header_pagination_arrow}
                         aria-label={`${__("opds.lastPage")}`}
+                        tabIndex={-1}
                         disabled={!pageLinks?.last[0]?.url || pageInfo?.currentPage === Math.ceil(pageInfo?.numberOfItems / (pageInfo?.itemsPerPage || 1))}>
                         {
                             pageLinks?.last[0]?.url ?
@@ -187,7 +191,8 @@ class PageNavigation extends React.Component<IProps, undefined> {
                                     to={{
                                         ...this.props.location,
                                         pathname: buildRoute(pageLinks.last[0]),
-                                    }}>
+                                    }}
+                                    >
                                     <SVG ariaHidden={true} svg={ArrowLastIcon} />
                                 </Link>
                                 : <SVG ariaHidden={true} svg={ArrowLastIcon} />}


### PR DESCRIPTION
Fixes #2495

@llemeurfr, about "I cannot move pages using the keyboard (Next button)" : 
Yes you can do it but it is binded to specific keyboard shortcuts which are by default "Ctrl, SHIFT, ArrowLeft" and "Ctrl, SHIFT, ArrowRight" ("keyboardShortcuts.NavigatePreviousOPDSPage" / "keyboardShortcuts.NavigateNextOPDSPage"