### PR TITLE
Changes to OAuth 2.0 Implicit Grant Flow handling

### DIFF
--- a/src/main/redux/sagas/auth.ts
+++ b/src/main/redux/sagas/auth.ts
@@ -576,15 +576,11 @@ function opdsAuthDocConverter(doc: OPDSAuthenticationDoc, baseUrl: string): IOPD
 
     // https://drafts.opds.io/authentication-for-opds-1.0#231-core-properties
     if (!doc.Id || doc.Id === "") {
-        // Todo: Return typed error so user-friendly message can be displayed
-        debug("OPDS Authentication Document missing required `id` property.");
-        return undefined;
+        debug("OPDS Authentication Document missing required `id` property. IGNORED and bypassed to ensure legacy compatibility with misconfigured OPDS OAuth 2.0 servers");
     }
 
     if (!doc.Title || doc.Title === "") {
-        // Todo: Return typed error so user-friendly message can be displayed
-        debug("OPDS Authentication Document missing required `title` property.");
-        return undefined;
+        debug("OPDS Authentication Document missing required `title` property. IGNORED and bypassed to ensure legacy compatibility with misconfigured OPDS OAuth 2.0 servers");
     }
 
     if (!doc.Authentication) {

--- a/src/main/redux/sagas/auth.ts
+++ b/src/main/redux/sagas/auth.ts
@@ -453,35 +453,46 @@ async function opdsSetAuthCredentials(
     return [, new Error("")];
 }
 
-let _implicitNonce = "";
-const setAndGetImplicitNonceForImplicitAuthentication = () => (_implicitNonce = nanoid(16), _implicitNonce);
-const getImplicitNonceForImplicitAuthentication = () => _implicitNonce;
+const _implicitAuthData = { authenticationDocumentId: "", nonce: "" };
+const setAndGetImplicitNonceForImplicitAuthentication = () => (_implicitAuthData.nonce = nanoid(16), _implicitAuthData.nonce);
+const getImplicitAuthData = () => _implicitAuthData;
 
 function getHtmlAuthenticationUrl(auth: IOPDSAuthDocParsed) {
-
     let browserUrl: string;
     switch (auth.authenticationType) {
-
         case "http://opds-spec.org/auth/oauth/implicit": {
-
             try {
+                if (!auth.links?.authenticate?.url) {
+                    debug("OPDS Authentication Document Authentication Object property `authentication.links.href` null, empty, or missing.", auth.links?.authenticate?.url ?? "undefined");
+                    browserUrl = "";
+                    break;
+                }
+
                 const browserUrlParsed = new URL(auth.links?.authenticate?.url);
+                
+                // Record the OPDS Authentication Document's Id for later verification
+                const implicitAuthData = getImplicitAuthData();
+                implicitAuthData.authenticationDocumentId = auth.id;
 
-                // The unique identifier used in the callback URI must have the same value as the identifier provided in the Authentication Document.
-                // https://drafts.opds.io/authentication-for-opds-1.0#342-a-shared-client-identifier:~:text=The%20unique%20identifier%20used%20in%20the%20callback%20URI%20must%20have%20the%20same%20value%20as%20the%20identifier%20provided%20in%20the%20Authentication%20Document.
+                // client_id: Required. 
+                // Any Authentication Provider that supports OPDS Authentication 1.0 and exposes an Authentication Flow based on OAuth
+                // must identify all OPDS clients using the client_id "http://opds-spec.org/auth/client"
+                browserUrlParsed.searchParams.set("client_id", "http://opds-spec.org/auth/client");
 
-                // see also the callback response : it must use the id query parameter to indicate the Authentication Document identifier
-                // https://drafts.opds.io/authentication-for-opds-1.0#342-a-shared-client-identifier:~:text=it%20must%20use%20the%20id%20query%20parameter%20to%20indicate%20the%20Authentication%20Document%20identifier
-
-                browserUrlParsed.searchParams.set("client_id", encodeURIComponent_RFC3986(auth?.id || "http://opds-spec.org/auth/client"));
-
+                // response_type: Mandatory for Implicit Flow
                 browserUrlParsed.searchParams.set("response_type", "token");
+
+                // state: Optional, but helps to prevent unsolicited flows
                 browserUrlParsed.searchParams.set("state", encodeURIComponent_RFC3986(setAndGetImplicitNonceForImplicitAuthentication()));
+                
+                // redirect_uri: Optional, but good to include since it's mandatory if a client has more than one redirect URI configurated
+                // Note: Trailing slash is necessary as it is specified in the OPDS Authentication 1.0 specification
+                browserUrlParsed.searchParams.set("redirect_uri", "opds://authorize/"); 
 
                 browserUrl = browserUrlParsed.toString();
 
             } catch {
-                debug("Error to parse browserUrl", auth.links?.authenticate?.url);
+                debug("Error parsing browserUrl", auth.links?.authenticate?.url);
                 browserUrl = "";
             }
 
@@ -521,7 +532,6 @@ function getHtmlAuthenticationUrl(auth: IOPDSAuthDocParsed) {
         }
 
         default: {
-
             debug("authentication method not found", auth.authenticationType);
             return undefined;
         }
@@ -558,16 +568,28 @@ interface IOPDSAuthDocParsed {
 
 }
 function opdsAuthDocConverter(doc: OPDSAuthenticationDoc, baseUrl: string): IOPDSAuthDocParsed | undefined {
-
     if (!doc || !(doc instanceof OPDSAuthenticationDoc)) {
+        // Todo: Return typed error so user-friendly message can be displayed
+        debug("OPDS Authentication Document is not an instance of the model");
+        return undefined;
+    }
 
-        debug("opds authentication doc is not an instance of the model");
+    // https://drafts.opds.io/authentication-for-opds-1.0#231-core-properties
+    if (!doc.Id || doc.Id === "") {
+        // Todo: Return typed error so user-friendly message can be displayed
+        debug("OPDS Authentication Document missing required `id` property.");
+        return undefined;
+    }
+
+    if (!doc.Title || doc.Title === "") {
+        // Todo: Return typed error so user-friendly message can be displayed
+        debug("OPDS Authentication Document missing required `title` property.");
         return undefined;
     }
 
     if (!doc.Authentication) {
-
-        debug("no authentication data in the opds authentication doc");
+        // Todo: Return typed error so user-friendly message can be displayed
+        debug("OPDS Authentication Document missing required `authentication` property.");
         return undefined;
     }
 
@@ -576,7 +598,6 @@ function opdsAuthDocConverter(doc: OPDSAuthenticationDoc, baseUrl: string): IOPD
     }, filename_);
 
     if (!viewConvert) {
-
         debug("no viewConverter !!");
         return undefined;
     }
@@ -798,22 +819,50 @@ function parseRequestFromCustomProtocol(req: Electron.ProtocolRequest)
 
         if (method === "GET") {
             if (host === "authorize") {
+                // OPDS Authentication Document Specification is at odds with the OAuth 2.0 Implicit Grant Flow Specification:
+                //     OPDS Auth wants the response parameters in the query component of the Redirection URI
+                //     OAuth 2.0 Implicit Grant Flow wants the response parameters in the fragment component of the Redirection URI
+                // Solution: Replace the fragment component with a query component to ensure the response parameters are parsed correctly
                 const urlSearchParam = url.replace("#", "?");
+
                 const urlObject = new URL(urlSearchParam);
                 const data: Record<string, string> = {};
                 for (const [key, value] of urlObject.searchParams) {
                     data[key] = value;
                 }
 
-                if (data.state !== getImplicitNonceForImplicitAuthentication()) {
-                    debug("received state parameter is not equal to the nonce sent", "value=", data.state);
-                    debug("the state verification is IGNORED and bypassed to ensure a legacy compatibility with all OPDS OAUTH2 server");
+                // https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthError
+                // When using the Implicit Flow, Authorization Error Responses are made in the same manner 
+                // as for the Authorization Code Flow:
+                //     When using the Authorization Code Flow, the error response parameters are added to the 
+                //     query component of the Redirection URI, unless a different Response Mode was specified. 
+                if (data.error) {
+                    debug("OAuth Error Response", "error:", { error: data.error, error_description: data.error_description });
+                    return undefined;
+                }
+
+                const implicitAuthData = getImplicitAuthData();
+
+                // Only validate the Id if it is present in the response
+                // This should ensure backwards compatibility with existing OPDS Authentication Providers 
+                // who may be omitting it
+                if (data.id && data.id !== implicitAuthData.authenticationDocumentId) {
+                    debug("OAuth 2.0 implicit grant flow contained an id but it did not match the id in the OPDS Authentication Document", "expected:", implicitAuthData.authenticationDocumentId, "actual:", data.id);
+                    return undefined;
+                }
+                else {
+                    debug("OAuth 2.0 implicit grant flow does not contain an id, validation IGNORED and bypassed to ensure legacy compatibility with OPDS OAuth 2.0 servers");
+                }
+
+                 if (data.state !== implicitAuthData.nonce) {
+                    debug("OAuth 2.0 implicit grant flow response state parameter is not equal to the nonce sent", "expected:", implicitAuthData.nonce, "value=", data.state);
+                    debug("state nonce verification IGNORED and bypassed to ensure legacy compatibility with OPDS OAuth 2.0 servers");
                     // TODO: improve this and enable the state verification
 
                     // https://auth0.com/docs/secure/attack-protection/state-parameters
                     // https://github.com/edrlab/thorium-reader/issues/2506
                 } else {
-                    debug("State parameter of the callback response is VERIFIED and CORRECT");
+                    debug("OAuth 2.0 implicit grant flow response parameters VERIFIED and CORRECT");
                 }
 
                 return {


### PR DESCRIPTION
Made the following changes on top of @panaC's branch:

* Not using the OPDS Authentication Document's Id as the client_id, using "http://opds-spec.org/auth/client" in all cases
* OPDS Authentication Document Id is validated against the id returned in the callback_url (validation skipped if missing for backwards compatability)
* Basic OPDS Authentication Document validation
* Debug messaging improvements to provide developers with context about why requests are rejected
* Documentation of OAuth parameters and any workarounds for OPDS Authentication/OAuth specification conflicts