### PR TITLE
fix(i18n): translate "Go To Page" when reader menu is docked

### DIFF
--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -2303,7 +2303,7 @@ export const ReaderMenu: React.FC<IBaseProps> = (props) => {
             <h3>{__("reader.marks.goTo")}</h3>
         </Tabs.Trigger>;
     const optionGoToPageItem = {
-        id: 4, value: "tab-gotopage", name: "Go To Page", disabled: false,
+        id: 4, value: "tab-gotopage", name: __("reader.marks.goTo"), disabled: false,
         svg: TargetIcon,
     };
 


### PR DESCRIPTION
Currently, when the reader menu window is docked, the "Go To Page" label in the combobox is not using translations, while the label is translated if the menu is not docked.

Running 941fb36c30974b43eee1493aed326f0c49d26acf in Lithuanian language:
![Screenshot displays the issue of the "Go To Page" label not being translated into Lithuanian language in the docked reader menu in Thorium Reader while reading a publication](https://github.com/user-attachments/assets/96182968-fa5d-452a-a833-a2e9eb8fe449)