### PR TITLE
fix(i18n): remove untranslated title attribute from General settings tab

### DIFF
--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -344,7 +344,7 @@ export const Settings: React.FC<ISettingsProps> = () => {
                         </Tabs.Trigger>
                     </Tabs.List>
                     <div className={stylesSettings.settings_content} style={{marginTop: "70px"}}>
-                        <Tabs.Content value="tab1" title="General" tabIndex={-1}>
+                        <Tabs.Content value="tab1" tabIndex={-1}>
                             <TabHeader title={__("settings.tabs.general")} />
                             <div className={stylesSettings.settings_tab}>
                                 <LanguageSettings />


### PR DESCRIPTION
This value is not translated and is being displayed as the tooltip when hovering on any element in the "General" settings tab:

![Screenshot displaying the tooltip with the untranslated word "General" while hovering on an element in the "General" settings tab while Thorium is set to use the Lithuanian language](https://github.com/user-attachments/assets/c0b4dc17-1ef7-4389-ba12-6d5b3e5001ac)

As [the other tabs do not have](https://github.com/edrlab/thorium-reader/blob/1e026d2efee7987c7ce9459fb77a7a7799d07849/src/renderer/library/components/settings/Settings.tsx#L357-L363) a `title` attribute, I've elected to remove it instead of introducing the `title` attribute to other tabs.