### PR TITLE
fix z-index for reader searchbar

### DIFF
--- a/src/renderer/assets/styles/components/readerHeader.scss
+++ b/src/renderer/assets/styles/components/readerHeader.scss
@@ -165,7 +165,7 @@
     width: 100vw;
     height: 48px;
     background-color: var(--color-extralight-grey);
-    z-index: 200;
+    z-index: 100;
     top: 70px;
     right: 0;
     left: unset;


### PR DESCRIPTION
Fixes #2661

Z-index set to "100" to match the z-index of the dialogs so when they're opened they come on top of it.