### PR TITLE
fix: fix floating-promises errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,7 @@ module.exports = {
         "@typescript-eslint/no-base-to-string": 0,
         "@typescript-eslint/no-misused-promises": 0,
         "@typescript-eslint/require-await": 0,
-        "@typescript-eslint/no-floating-promises": 0,
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/unbound-method": 0,
 
         "@typescript-eslint/no-unsafe-enum-comparison": 0,

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ setLcpNativePluginPath(lcpNativePluginPath);
 initSessionsNoHTTP();
 
 if (__TH__IS_VSCODE_LAUNCH__) {
-    createStoreFromDi().then((store) => store.dispatch(appActions.initRequest.build()));
+    void createStoreFromDi().then((store) => store.dispatch(appActions.initRequest.build()));
 } else {
     commandLineMainEntry(); // call main fct
 }

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -228,7 +228,7 @@ const yargsInit = () =>
                 if (openPublicationRequestedBool) {
 
                     // flush session because user ask to read a publication
-                    flushSession();
+                    await flushSession();
 
                     // pathArgv can be an url with deepLinkInvocation in windows
                     // https://github.com/oikonomopo/electron-deep-linking-mac-win
@@ -316,7 +316,7 @@ export function commandLineMainEntry(
     debug("processArgv", processArgv, "arg", argFormated);
 
     try {
-        y.parse(argFormated);
+        void y.parse(argFormated);
     } catch (e) {
         debug("YARGS ERROR !!!!!", e);
     }

--- a/src/main/redux/sagas/auth.ts
+++ b/src/main/redux/sagas/auth.ts
@@ -247,7 +247,7 @@ function* opdsRequestMediaFlow({request, callback}: TregisterHttpProtocolHandler
             return ;
         }
 
-        httpGet(url, {
+        void httpGet(url, {
             ...request,
         }, (response) => {
 
@@ -755,7 +755,7 @@ function createOpdsAuthenticationModalWin(url: string): BrowserWindow | undefine
         win.show();
     });
 
-    win.loadURL(url);
+    void win.loadURL(url);
 
     return win;
 }

--- a/src/main/services/device.ts
+++ b/src/main/services/device.ts
@@ -65,7 +65,7 @@ export class DeviceIdManager implements IDeviceIDManager {
             const deviceConfig: DeviceConfig = {
                 device_id: deviceId,
             };
-            this.saveDeviceConfigJson(deviceConfig);
+            await this.saveDeviceConfigJson(deviceConfig);
             debug(deviceConfig);
         }
 
@@ -86,7 +86,7 @@ export class DeviceIdManager implements IDeviceIDManager {
             deviceConfig,
         );
         newDeviceConfig[deviceIdKey] = "_"; // deviceId
-        this.saveDeviceConfigJson(newDeviceConfig);
+        await this.saveDeviceConfigJson(newDeviceConfig);
 
         debug("DeviceIdManager recordDeviceID:");
         debug(key);
@@ -104,7 +104,7 @@ export class DeviceIdManager implements IDeviceIDManager {
 
         _cache = conf;
         const str = JSON.stringify(conf);
-        fs.promises.writeFile(lcpLsdDevicesFilePath, str, { encoding: "utf-8" });
+        return fs.promises.writeFile(lcpLsdDevicesFilePath, str, { encoding: "utf-8" });
     }
     private async getDeviceConfigJson(): Promise<DeviceConfig> {
 

--- a/src/main/services/lcp.ts
+++ b/src/main/services/lcp.ts
@@ -160,7 +160,7 @@ export class LcpManager {
 
         const str = JSON.stringify(allSecrets);
         const encrypted = encryptPersist(str, CONFIGREPOSITORY_LCP_SECRETS, lcpHashesFilePath);
-        fs.promises.writeFile(lcpHashesFilePath, encrypted);
+        return fs.promises.writeFile(lcpHashesFilePath, encrypted);
     }
 
     private async injectLcplIntoZip_(epubPath: string, lcpStr: string) {

--- a/src/main/streamer/streamerNoHttp.ts
+++ b/src/main/streamer/streamerNoHttp.ts
@@ -300,7 +300,7 @@ const streamProtocolHandlerTunnel = async (
 
     debug("............... streamProtocolHandlerTunnel req.url", req.url);
     req.url = convertCustomSchemeToHttpUrl(req.url);
-    await streamProtocolHandler(req, callback);
+    return streamProtocolHandler(req, callback);
 };
 
 // super hacky!! :(

--- a/src/main/w3c/audiobooks/toc.ts
+++ b/src/main/w3c/audiobooks/toc.ts
@@ -520,7 +520,7 @@ if (require.main === module) {
     `;
 
     const manifestParsed = JSON.parse(w3cManifest);
-    w3cPublicationManifestToReadiumPublicationManifest(manifestParsed, (uniqueResources) => {
+    void w3cPublicationManifestToReadiumPublicationManifest(manifestParsed, (uniqueResources) => {
         const toc = extract_TOC(el, uniqueResources);
 
         console.log("TOC");
@@ -533,5 +533,4 @@ if (require.main === module) {
         return undefined;
 
     });
-
 }

--- a/src/renderer/common/apiSubscribe.ts
+++ b/src/renderer/common/apiSubscribe.ts
@@ -22,7 +22,7 @@ export function apiSubscribeFactory(storeCb: () => Store<any>) {
         const lastApiSuccess = store.getState().api[LAST_API_SUCCESS_ID];
         let lastSuccessTime = lastApiSuccess?.lastTime || 0;
 
-        cb();
+        void cb();
 
         return store.subscribe(() => {
             const state = store.getState();
@@ -34,7 +34,7 @@ export function apiSubscribeFactory(storeCb: () => Store<any>) {
                 if (!data.error) {
                     const path = `${data.moduleId}/${data.methodId}` as TApiMethodName;
                     if (pathArrayToRefresh.includes(path)) {
-                        cb();
+                        void cb();
                     }
                 }
             }

--- a/src/renderer/library/components/dialog/DeletePublicationConfirm.tsx
+++ b/src/renderer/library/components/dialog/DeletePublicationConfirm.tsx
@@ -32,16 +32,16 @@ const DeletePublicationConfirm = (props: { publicationView: PublicationView, tri
 
     React.useEffect(() => {
 
-        (async () => {
+        void (async () => {
 
             try {
                 const notes: INoteState[] = await(await fetch(`${THORIUM_READIUM2_ELECTRON_HTTP_PROTOCOL}://${THORIUM_READIUM2_ELECTRON_HTTP_PROTOCOL__IP_ORIGIN_PUB_NOTES}/publication-notes/${props.publicationView.identifier}`)).json();
-    
+
                 if (Array.isArray(notes) && notes.length) {
                     setHasNotes(true);
                 }
             } catch (_) {
-                // nothing 
+                // nothing
             }
         })();
 

--- a/src/renderer/library/components/dialog/publicationInfos/opdsControls/OpdsControls.tsx
+++ b/src/renderer/library/components/dialog/publicationInfos/opdsControls/OpdsControls.tsx
@@ -97,7 +97,7 @@ export class OpdsControls extends React.Component<IProps, undefined> {
                                 onClick={() => {
 
                                     if (ln.type === ContentType.Html || ln.type === ContentType.Xhtml) {
-                                        this.props.link(
+                                        void this.props.link(
                                             ln,
                                             this.props.location,
                                         );
@@ -131,7 +131,7 @@ export class OpdsControls extends React.Component<IProps, undefined> {
                                 onClick={() => {
 
                                     if (ln.type === ContentType.Html || ln.type === ContentType.Xhtml) {
-                                        this.props.link(
+                                        void this.props.link(
                                             ln,
                                             this.props.location,
                                         );

--- a/src/renderer/library/components/settings/KeyboardSettings.tsx
+++ b/src/renderer/library/components/settings/KeyboardSettings.tsx
@@ -177,9 +177,7 @@ class KeyboardSettings extends React.Component<IProps, IState> {
                 KEY_CODES.push(def.key);
             }
         });
-        (async () => {
-            await this.loadKeyboardLayoutMap(/* KEY_CODES , "selectLayoutMap" */);
-        })();
+        void this.loadKeyboardLayoutMap(/* KEY_CODES , "selectLayoutMap" */);
     }
 
     public componentDidUpdate(oldProps: IProps) {
@@ -192,9 +190,7 @@ class KeyboardSettings extends React.Component<IProps, IState> {
                 }
             });
             if (needsUpdating) {
-                (async () => {
-                    await this.loadKeyboardLayoutMap(/* KEY_CODES, "selectLayoutMap" */);
-                })();
+                void this.loadKeyboardLayoutMap(/* KEY_CODES, "selectLayoutMap" */);
             }
         }
     }
@@ -866,9 +862,7 @@ class KeyboardSettings extends React.Component<IProps, IState> {
 
         if (!KEY_CODES.includes(def.key)) {
             KEY_CODES.push(def.key);
-            (async () => {
-                await this.loadKeyboardLayoutMap(/* KEY_CODES, "selectLayoutMap" */);
-            })();
+            void this.loadKeyboardLayoutMap(/* KEY_CODES, "selectLayoutMap" */);
         }
 
         const keySelect =

--- a/src/renderer/library/index_library.ts
+++ b/src/renderer/library/index_library.ts
@@ -65,7 +65,7 @@ initGlobalConverters_GENERIC();
 //     }, 5000);
 // }
 
-ipcRenderer.on(winIpc.CHANNEL, (_0: any, data: winIpc.EventPayload) => {
+ipcRenderer.on(winIpc.CHANNEL, async (_0: any, data: winIpc.EventPayload) => {
     switch (data.type) {
         case winIpc.EventType.IdResponse:
             // Initialize window
@@ -84,7 +84,7 @@ ipcRenderer.on(winIpc.CHANNEL, (_0: any, data: winIpc.EventPayload) => {
             };
             const [store, _reduxHistory, _sagaMiddleware] = createStoreFromDi(preloadedState);
             const locale = store.getState().i18n.locale;
-            getTranslator().setLocale(locale);
+            await getTranslator().setLocale(locale);
 
             store.dispatch(winActions.initRequest.build(data.payload.win.identifier));
 

--- a/src/renderer/reader/components/ReaderHeader.tsx
+++ b/src/renderer/reader/components/ReaderHeader.tsx
@@ -275,7 +275,7 @@ export class ReaderHeader extends React.Component<IProps, IState> {
         }
 
         if (!this.props.isDivina && !this.props.isPdf) {
-            getVoices(/*TODO Param? */).then((voices) => {
+            void getVoices(/*TODO Param? */).then((voices) => {
                 this.setVoices(voices);
             });
         }

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -486,7 +486,7 @@ const AnnotationCard: React.FC<{ annotation: INoteState, isEdited: boolean, trig
                 console.log(parsed, hrefSanitized);
             }
         };
-        fc();
+        void fc();
     }, [textualValue]);
 
     const dispatch = useDispatch();
@@ -799,7 +799,7 @@ const BookmarkCard: React.FC<{ bookmark: INoteState, isEdited: boolean, triggerE
                 console.log(parsed, hrefSanitized);
             }
         };
-        fc();
+        void fc();
     }, [bookmark.textualValue]);
 
     const dispatch = useDispatch();

--- a/src/renderer/reader/index_reader.ts
+++ b/src/renderer/reader/index_reader.ts
@@ -45,7 +45,7 @@ initGlobalConverters_GENERIC();
 // }
 
 ipcRenderer.on(readerIpc.CHANNEL,
-    (_0: any, data: readerIpc.EventPayload) => {
+    async (_0: any, data: readerIpc.EventPayload) => {
         switch (data.type) {
             case readerIpc.EventType.request:
                 // Initialize window
@@ -87,7 +87,7 @@ ipcRenderer.on(readerIpc.CHANNEL,
 
                 const store = createStoreFromDi({ ...data.payload, noteTagsIndex } as Partial<IReaderRootState>);
                 const locale = store.getState().i18n.locale;
-                getTranslator().setLocale(locale);
+                await getTranslator().setLocale(locale);
 
                 store.dispatch(winActions.initRequest.build(data.payload.win.identifier));
 


### PR DESCRIPTION
While viewing this code, I noticed there were a handful of places where promises were left floating – for instance, in the LCP passphrase save code, the code never actually waited for the write to go through (or whether it failed), which could be problematic.

I noticed [the ESlint rule for the issue](https://typescript-eslint.io/rules/no-floating-promises/) had been turned off, so I turned it on and fixed the issues – either by `await`ing where possible, or `void`ing the promises, so as to mark them "yes, we mean to ignore the return value of this promise".