### PR TITLE
Do not mark Traditional Chinese (`zh-Hant` and `zh-TW`) as a RTL language

### DIFF
--- a/src/common/language-string.ts
+++ b/src/common/language-string.ts
@@ -104,7 +104,5 @@ export function convertMultiLangStringToLangString(items: string | IStringMap | 
 export function langStringIsRTL(lang: string): boolean {
     return lang === "ar" || lang.startsWith("ar-") ||
         lang === "he" || lang.startsWith("he-") ||
-        lang === "fa" || lang.startsWith("fa-") ||
-        lang === "zh-Hant" ||
-        lang === "zh-TW";
+        lang === "fa" || lang.startsWith("fa-");
 }

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -135,19 +135,15 @@ const isRTL = (r2Publication: R2Publication) => (_link: ILink) => {
                 [r2Publication.Metadata.Language]) :
             [] as string[];
         isRTL = lang.reduce<boolean>((pv, cv) => {
-            const rtlExcludingJapanese = typeof cv === "string" ?
-                // we test for Arabic and Hebrew,
-                // in order to exclude Japanese Vertical Writing Mode which is also RTL!
+            const rtlLang = typeof cv === "string" ?
                 // see langStringIsRTL()
                 (
                     cv === "ar" || cv.startsWith("ar-") ||
                     cv === "he" || cv.startsWith("he-") ||
-                    cv === "fa" || cv.startsWith("fa-") ||
-                    cv === "zh-Hant" ||
-                    cv === "zh-TW"
+                    cv === "fa" || cv.startsWith("fa-")
                 ) :
                 false;
-            return pv || rtlExcludingJapanese;
+            return pv || rtlLang;
         }, false);
     }
     return isRTL;


### PR DESCRIPTION
Thorium currently marks the IETF BCP 47 tags of `zh-Hant` and `zh-TW` as RTL scripts for some reason when those scripts are decided not.

[This w3.org article](https://www.w3.org/International/questions/qa-scripts) lists the scripts written in RTL, where Chinese, Japanese, and other east Asian logographic languages are not present. Except for a carve-out in the in the "Historical scripts" section:

> In addition to the usual candidates for right-to-left text direction (Arabic, Hebrew, N'Ko, Syriac, Thaana, etc.), a number of other writing systems that are nowadays written left-to-right (LTR) were once written in a right-to-left (RTL) direction. These writing systems include **Chinese, Japanese**, Egyptian hieroglyphs, Tifinagh, and Old Norse runes. See [RTL rendering of LTR scripts](https://www.w3.org/International/questions/qa-ltr-scripts-in-rtl) for a discussion of how to produce RTL text for these scripts.

_(emphasis mine)_

Documents using these scripts should have their [dir](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/dir) tag set as `rtl` and should be rendered accordingly.

Expanding more on the [dir](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/dir) tag, the `auto` value has the following description:

> `auto`, which lets the user agent decide. It uses a basic algorithm as it parses the characters inside the element until it finds a character with a strong directionality, then applies that directionality to the whole element.

If we inspect an arbitrary character such as [鐵](https://util.unicode.org/UnicodeJsps/character.jsp?a=9435) (Traditional Chinese, `zh-Hant`), we can see the `Bidi_Class` is `Left_To_Right`.

Indeed if we look at similar characters: [铁](https://util.unicode.org/UnicodeJsps/character.jsp?a=94C1) (Simplified Chinese, `zh`) and [鉄](https://util.unicode.org/UnicodeJsps/character.jsp?a=9244) (Japanese, `ja`) we see the same `Bidi_Class` of `Left_To_Right`. Essentially there should be no treatment difference between those 3 scripts.

As I partially explained in https://github.com/edrlab/thorium-reader/issues/1987#issuecomment-2233586863, the "RTL" nature is only true of columns of characters (governed by the CSS property [writing-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode)). In essence, the aforementioned east Asian scripts (as well as others like Hangul) are all considered LTR scripts that can have a `writing-mode` property of [horizontal-tb](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode#horizontal-tb) where they render much like English **or** [vertical-rl](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode#vertical-rl) where they render vertically in columns that go right-to-left (**but HTML `dir="ltr"`**).

In other words, the "script" itself has an intrinsic direction of LTR (defined essentially as the writing direction when rendered horizontally) but two `writing-mode`/rendering axes of `horizontal-tb` and `vertical-rl`.

Setting `writing-mode` to `vertical-rl` **and** `dir` to `rtl` yields incorrect results where the text is bottom-aligned and the full stop 『。』 is placed before the sentence.

---

This PR removes `zh-Hant` and `zh-TW` from the list of languages considered to be RTL which fixes rendering for Traditional Chinese documents.

Note: this PR **does not** fix #1987 since that is a bug specific to RTL image display. By correctly classifying Traditional Chinese as LTR, #1987 no longer triggers for Traditional Chinese documents but will still trigger for Arabic/Hebrew documents.