### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable version of thorium-reader receives security updates. Make sure you are running the most recent release.
+
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security problems. Instead, use GitHub's "Report a vulnerability" feature in the Security tab of this repository. We will review and respond as soon as possible.
+
+## Security Updates
+
+If we fix a vulnerability, we will announce it in the release notes. Keep your installation up to date to receive the latest fixes.


### PR DESCRIPTION

Hi Developers,
Thank you for developing thorium-reader!
I am writing to kindly request to create a security page, to guide responsible vulnerability disclosure.
Could you also enable the vulnerability reporting option for this repository on the security tab? This will allow submitting private vulnerability report. The report remains visible only to maintainers until you publish it. Thanks!
