### PR TITLE
[customization] welcome-screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13130,6 +13130,7 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",

--- a/src/common/readium/customization/manifest.ts
+++ b/src/common/readium/customization/manifest.ts
@@ -5,7 +5,7 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { JsonArray } from "src/typings/json";
+import { JsonArray } from "readium-desktop/typings/json";
 
 // https://www.notion.so/edrlab/Thorium-Reader-Profiles-1d8a1ca5712f80619738c2f26e700355
 

--- a/src/common/redux/actions/customization/addHistory.ts
+++ b/src/common/redux/actions/customization/addHistory.ts
@@ -11,7 +11,6 @@ export const ID = "CUSTOMIZATION_ADD_HISTORY";
 export interface IPayload {
     id: string;
     version: string;
-    welcomeScreenShowAgain: boolean;
 }
 
 export function build(profileIdentifier: string, version: string) {

--- a/src/common/redux/actions/customization/addHistory.ts
+++ b/src/common/redux/actions/customization/addHistory.ts
@@ -1,0 +1,30 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+export const ID = "CUSTOMIZATION_ADD_HISTORY";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IPayload {
+    id: string;
+    version: string;
+    welcomeScreenShowAgain: boolean;
+}
+
+export function build(profileIdentifier: string, version: string, welcomeScreenShowAgain?: boolean) {
+
+    return {
+        type: ID,
+        payload: {
+            id: profileIdentifier,
+            version,
+            welcomeScreenShowAgain,
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;
+

--- a/src/common/redux/actions/customization/index.ts
+++ b/src/common/redux/actions/customization/index.ts
@@ -12,6 +12,7 @@ import * as acquire from "./acquire";
 import * as lock from "./lock";
 import * as history from "./addHistory";
 import * as welcomeScreen from "./welcomeScreen";
+import * as manifest from "./manifest";
 
 export {
     activate as activating,
@@ -20,4 +21,5 @@ export {
     lock,
     history as addHistory,
     welcomeScreen,
+    manifest,
 };

--- a/src/common/redux/actions/customization/index.ts
+++ b/src/common/redux/actions/customization/index.ts
@@ -10,10 +10,14 @@ import * as activate from "./activate";
 import * as provision from "./provision";
 import * as acquire from "./acquire";
 import * as lock from "./lock";
+import * as history from "./addHistory";
+import * as welcomeScreen from "./welcomeScreen";
 
 export {
     activate as activating,
     provision as provisioning,
     acquire,
     lock,
+    history as addHistory,
+    welcomeScreen,
 };

--- a/src/common/redux/actions/customization/manifest.ts
+++ b/src/common/redux/actions/customization/manifest.ts
@@ -5,23 +5,18 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-export const ID = "CUSTOMIZATION_ADD_HISTORY";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
+
+export const ID = "CUSTOMIZATION_MANIFEST";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IPayload {
-    id: string;
-    version: string;
-    welcomeScreenShowAgain: boolean;
-}
+export interface IPayload extends ICustomizationManifest {};
 
-export function build(profileIdentifier: string, version: string) {
+export function build(manifest: ICustomizationManifest) {
 
     return {
         type: ID,
-        payload: {
-            id: profileIdentifier,
-            version,
-        },
+        payload: manifest,
     };
 }
 build.toString = () => ID; // Redux StringableActionCreator

--- a/src/common/redux/actions/customization/welcomeScreen.ts
+++ b/src/common/redux/actions/customization/welcomeScreen.ts
@@ -1,0 +1,26 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+export const ID = "CUSTOMIZATION_WELCOME_SCREEN";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IPayload {
+    enable: boolean;
+}
+
+export function build(enable: boolean) {
+
+    return {
+        type: ID,
+        payload: {
+            enable,
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;
+

--- a/src/common/redux/reducers/customization/manifest.ts
+++ b/src/common/redux/reducers/customization/manifest.ts
@@ -1,0 +1,26 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { type Reducer } from "redux";
+import { customizationActions } from "../../actions";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
+
+
+export const initialState: ICustomizationManifest = undefined;
+
+function customizationPackageManifestReducer_(
+    state: ICustomizationManifest = null, // (preloaded state?) see registerReader
+    action: customizationActions.manifest.TAction,
+): ICustomizationManifest {
+    switch (action.type) {
+        case customizationActions.manifest.ID:
+            return JSON.parse(JSON.stringify(action.payload));
+        default:
+            return state;
+    }
+}
+export const customizationPackageManifestReducer = customizationPackageManifestReducer_ as Reducer<ReturnType<typeof customizationPackageManifestReducer_>>;

--- a/src/common/redux/reducers/customization/welcomeScreen.ts
+++ b/src/common/redux/reducers/customization/welcomeScreen.ts
@@ -1,0 +1,30 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { type Reducer } from "redux";
+import { ICustomizationProfileWelcomeScreen } from "../../states/customization";
+import { customizationActions } from "../../actions";
+
+
+export const initialState: ICustomizationProfileWelcomeScreen = {
+    enable: false,
+};
+
+function customizationPackageWelcomeScreenReducer_(
+    state: ICustomizationProfileWelcomeScreen = initialState, // (preloaded state?) see registerReader
+    action: customizationActions.welcomeScreen.TAction,
+): ICustomizationProfileWelcomeScreen {
+    switch (action.type) {
+        case customizationActions.welcomeScreen.ID:
+            return {
+                enable: action.payload.enable,
+            };
+        default:
+            return state;
+    }
+}
+export const customizationPackageWelcomeScreenReducer = customizationPackageWelcomeScreenReducer_ as Reducer<ReturnType<typeof customizationPackageWelcomeScreenReducer_>>;

--- a/src/common/redux/states/commonRootState.ts
+++ b/src/common/redux/states/commonRootState.ts
@@ -16,6 +16,7 @@ import { I18NState } from "readium-desktop/common/redux/states/i18n";
 import { ILcpState } from "./lcp";
 import { INoteExportState } from "./renderer/note";
 import { ICustomizationProfileActivated, ICustomizationProfileHistory, ICustomizationProfileLock, ICustomizationProfileProvisioned, ICustomizationProfileWelcomeScreen } from "./customization";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
 
 export interface ICommonRootState {
     i18n: I18NState;
@@ -36,5 +37,6 @@ export interface ICommonRootState {
         provision: ICustomizationProfileProvisioned[],
         lock: ICustomizationProfileLock,
         welcomeScreen: ICustomizationProfileWelcomeScreen,
+        manifest?: ICustomizationManifest;
     }
 }

--- a/src/common/redux/states/commonRootState.ts
+++ b/src/common/redux/states/commonRootState.ts
@@ -15,7 +15,7 @@ import { INoteCreator } from "./creator";
 import { I18NState } from "readium-desktop/common/redux/states/i18n";
 import { ILcpState } from "./lcp";
 import { INoteExportState } from "./renderer/note";
-import { ICustomizationProfileActivated, ICustomizationProfileLock, ICustomizationProfileProvisioned } from "./customization";
+import { ICustomizationProfileActivated, ICustomizationProfileHistory, ICustomizationProfileLock, ICustomizationProfileProvisioned, ICustomizationProfileWelcomeScreen } from "./customization";
 
 export interface ICommonRootState {
     i18n: I18NState;
@@ -31,8 +31,10 @@ export interface ICommonRootState {
     noteExport: INoteExportState;
     lcp: ILcpState;
     customization: {
+        history: ICustomizationProfileHistory[],
         activate: ICustomizationProfileActivated,
         provision: ICustomizationProfileProvisioned[],
         lock: ICustomizationProfileLock,
+        welcomeScreen: ICustomizationProfileWelcomeScreen,
     }
 }

--- a/src/common/redux/states/customization.ts
+++ b/src/common/redux/states/customization.ts
@@ -8,7 +8,7 @@
 // export type TCustomizationProvisioningPackage = Array<[identifier: string, fileName: string, version: string]>;
 
 export interface ICustomizationProfileProvisioned {
-    identifier: string; // identifier URI from manifest
+    id: string; // identifier URI from manifest
     fileName: string; // relative file from well-known folder, not an absolute file path. Allow to move well-known folder without compromise internal redux state
     version: string; // semantic versionning from manifest
 }
@@ -19,8 +19,18 @@ fileName: string; error: boolean; message: string;
 
 export type ICustomizationProfileProvisionedWithError = ICustomizationProfileProvisioned | ICustomizationProfileError;
 
+export interface ICustomizationProfileHistory {
+    id: string,
+    version: string,
+    welcomeScreenShowAgain?: boolean;
+}
+
 export interface ICustomizationProfileActivated {
     id: string, // identifier URI from manifest // pointer to ICustomizationProfileProvisioned.id
+}
+
+export interface ICustomizationProfileWelcomeScreen {
+    enable: boolean;
 }
 
 export interface ICustomizationLockInfo {

--- a/src/common/redux/states/customization.ts
+++ b/src/common/redux/states/customization.ts
@@ -22,7 +22,6 @@ export type ICustomizationProfileProvisionedWithError = ICustomizationProfilePro
 export interface ICustomizationProfileHistory {
     id: string,
     version: string,
-    welcomeScreenShowAgain?: boolean;
 }
 
 export interface ICustomizationProfileActivated {

--- a/src/common/redux/states/theme.ts
+++ b/src/common/redux/states/theme.ts
@@ -5,7 +5,7 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { ICustomizationManifest } from "src/common/readium/customization/manifest";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
 
 export type TTheme = "system" | "dark" | "light";
 

--- a/src/main/customization/provisioning.ts
+++ b/src/main/customization/provisioning.ts
@@ -113,7 +113,7 @@ export async function customizationPackageProvisionningFromFolder(wellKnownFolde
                 packagesErrorArray.push((profileProvisioned as ICustomizationProfileError));
             } else {
                 packagesArray = [
-                    ...packagesArray.filter(({identifier}) => (profileProvisioned as ICustomizationProfileProvisioned).identifier !== identifier),
+                    ...packagesArray.filter(({id}) => (profileProvisioned as ICustomizationProfileProvisioned).id !== id),
                     profileProvisioned as ICustomizationProfileProvisioned,
                 ];
             }
@@ -142,9 +142,9 @@ export async function customizationPackageProvisioningAccumulator(packagesArray:
         return { fileName: packageFileName, error: true, message: error };
     }
 
-    const packageProvisionedWithTheSameIdentifier = packagesArray.find(({ identifier }) => identifier === manifest.identifier);
+    const packageProvisionedWithTheSameIdentifier = packagesArray.find(({ id }) => id === manifest.identifier);
     if (!packageProvisionedWithTheSameIdentifier || semver.gt(manifest.version, packageProvisionedWithTheSameIdentifier.version)) {
-        return { identifier: manifest.identifier, fileName: packageFileName, version: manifest.version };
+        return { id: manifest.identifier, fileName: packageFileName, version: manifest.version };
     }
 
     return { fileName: packageFileName, error: true, message: "profile version is under or equal to the currrent provisioned profile version" };

--- a/src/main/db/sqlite/note.ts
+++ b/src/main/db/sqlite/note.ts
@@ -1,7 +1,7 @@
 
 import * as debug_ from "debug";
 import { getSqliteDatabaseSync } from ".";
-import { INoteState } from "src/common/redux/states/renderer/note";
+import { INoteState } from "readium-desktop/common/redux/states/renderer/note";
 
 const debug = debug_("readium-desktop:main:db:sqlite:note"); 
 

--- a/src/main/redux/middleware/persistence.ts
+++ b/src/main/redux/middleware/persistence.ts
@@ -50,6 +50,7 @@ export const reduxPersistMiddleware: Middleware
                         activate: prevState.customization.activate,
                         lock: undefined,
                         welcomeScreen: undefined,
+                        manifest: undefined,
                     },
                 };
 
@@ -77,6 +78,7 @@ export const reduxPersistMiddleware: Middleware
                         activate: nextState.customization.activate,
                         lock: undefined,
                         welcomeScreen: undefined,
+                        manifest: undefined,
                     },
                 };
 

--- a/src/main/redux/middleware/persistence.ts
+++ b/src/main/redux/middleware/persistence.ts
@@ -44,7 +44,13 @@ export const reduxPersistMiddleware: Middleware
                     settings: prevState.settings,
                     creator: prevState.creator,
                     noteExport: prevState.noteExport,
-                    customization: prevState.customization,
+                    customization: {
+                        provision: [],
+                        history: prevState.customization.history,
+                        activate: prevState.customization.activate,
+                        lock: undefined,
+                        welcomeScreen: undefined,
+                    },
                 };
 
                 const persistNextState: PersistRootState = {
@@ -65,7 +71,13 @@ export const reduxPersistMiddleware: Middleware
                     settings: nextState.settings,
                     creator: nextState.creator,
                     noteExport: nextState.noteExport,
-                    customization: nextState.customization,
+                    customization: {
+                        provision: [],
+                        history: nextState.customization.history,
+                        activate: nextState.customization.activate,
+                        lock: undefined,
+                        welcomeScreen: undefined,
+                    },
                 };
 
                 // RangeError: Maximum call stack size exceeded

--- a/src/main/redux/middleware/sync.ts
+++ b/src/main/redux/middleware/sync.ts
@@ -97,6 +97,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     customizationActions.provisioning.ID,
     customizationActions.acquire.ID,
     customizationActions.lock.ID,
+    customizationActions.addHistory.ID,
 ];
 
 export const reduxSyncMiddleware: Middleware

--- a/src/main/redux/reducers/index.ts
+++ b/src/main/redux/reducers/index.ts
@@ -14,7 +14,7 @@ import { priorityQueueReducer } from "readium-desktop/utils/redux-reducers/pqueu
 import { combineReducers } from "redux";
 
 import { publicationActions, winActions } from "../actions";
-import { publicationActions as publicationActionsFromCommonAction } from "readium-desktop/common/redux/actions";
+import { customizationActions, publicationActions as publicationActionsFromCommonAction } from "readium-desktop/common/redux/actions";
 import { readerDefaultConfigReducer } from "../../../common/redux/reducers/reader/defaultConfig";
 import { winRegistryReaderReducer } from "./win/registry/reader";
 import { winSessionLibraryReducer } from "./win/session/library";
@@ -35,6 +35,9 @@ import { noteExportReducer } from "readium-desktop/common/redux/reducers/noteExp
 import { customizationPackageActivatingReducer } from "readium-desktop/common/redux/reducers/customization/activate";
 import { customizationPackageProvisioningReducer } from "readium-desktop/common/redux/reducers/customization/provision";
 import { customizationPackageActivatingLockReducer } from "readium-desktop/common/redux/reducers/customization/lock";
+import { arrayReducer } from "readium-desktop/utils/redux-reducers/array.reducer";
+import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
+import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
 
 export const rootReducer = combineReducers({ // RootState
     versionUpdate: versionUpdateReducer,
@@ -111,8 +114,22 @@ export const rootReducer = combineReducers({ // RootState
     creator: creatorReducer,
     noteExport: noteExportReducer,
     customization: combineReducers({
+        history: arrayReducer<customizationActions.addHistory.TAction, undefined, ICustomizationProfileHistory, Pick<ICustomizationProfileHistory, "id">>(
+                {
+                    add: {
+                        type: customizationActions.addHistory.ID,
+                        selector: (payload, _state) => {
+                            const { id, version } = payload;
+                            return [{id, version}];
+                        },
+                    },
+                    remove: undefined,
+                    getId: (item) => item.id,
+                },
+            ),
         activate: customizationPackageActivatingReducer,
         provision: customizationPackageProvisioningReducer,
         lock: customizationPackageActivatingLockReducer,
+        welcomeScreen: customizationPackageWelcomeScreenReducer,
     }),
 });

--- a/src/main/redux/reducers/index.ts
+++ b/src/main/redux/reducers/index.ts
@@ -38,6 +38,7 @@ import { customizationPackageActivatingLockReducer } from "readium-desktop/commo
 import { arrayReducer } from "readium-desktop/utils/redux-reducers/array.reducer";
 import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
 import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
 
 export const rootReducer = combineReducers({ // RootState
     versionUpdate: versionUpdateReducer,
@@ -131,5 +132,6 @@ export const rootReducer = combineReducers({ // RootState
         provision: customizationPackageProvisioningReducer,
         lock: customizationPackageActivatingLockReducer,
         welcomeScreen: customizationPackageWelcomeScreenReducer,
+        manifest: () => null as ICustomizationManifest,
     }),
 });

--- a/src/main/redux/sagas/customization.ts
+++ b/src/main/redux/sagas/customization.ts
@@ -43,7 +43,7 @@ export function* sagaCustomizationProfileProvisioning() {
     if (customizationState.activate.id) {
 
         let error = false;
-        const packageFileName = packagesArray.find(({identifier}) => identifier === customizationState.activate.id)?.fileName;
+        const packageFileName = packagesArray.find(({id}) => id === customizationState.activate.id)?.fileName;
         if (!packageFileName) {
             debug(`CRITICAL ERROR: no pointer to identifier:"${customizationState.activate.id}" found in provisioned array`);
             error = true;
@@ -158,7 +158,7 @@ export function* acquireProvisionsActivates(action: customizationActions.acquire
 
                     // TODO: in the case of a drag-and-drop of an older profile than one already provisioned,
                     // it can be better to activate the newer profile vendor and do not provisioned the older profile
-                    const packageId = fileNameProvisionedFound.identifier;
+                    const packageId = fileNameProvisionedFound.id;
                     lockInfo.id = packageId;
                     yield* putTyped(customizationActions.lock.build("ACTIVATING", lockInfo));
                     yield* putTyped(customizationActions.activating.build(packageId));

--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -52,7 +52,7 @@ export function saga() {
 
                     if (removed) {
                         const packageFound = packagesArray.find(({ fileName }) => fileName === packageFileName);
-                        if (packageFound && packageFound.identifier === customizationState.activate.id && packageFound.fileName === packageFileName) {
+                        if (packageFound && packageFound.id === customizationState.activate.id && packageFound.fileName === packageFileName) {
                             debug("rollback to thorium vanilla profile");
                             yield* putTyped(customizationActions.activating.build("")); // no profile
                         }
@@ -64,7 +64,7 @@ export function saga() {
                             errorPackages.push((profileProvisioned as ICustomizationProfileError));
                         } else {
                             packagesArray = [
-                                ...packagesArray.filter(({ identifier }) => (profileProvisioned as ICustomizationProfileProvisioned).identifier !== identifier),
+                                ...packagesArray.filter(({ id }) => (profileProvisioned as ICustomizationProfileProvisioned).id !== id),
                                 profileProvisioned as ICustomizationProfileProvisioned,
                             ];
                         }

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -50,6 +50,7 @@ const persistStateToFs = async (nextState: RootState) => {
             history: nextState.customization.history,
             activate: nextState.customization.activate,
             welcomeScreen: undefined,
+            manifest: undefined,
         },
     };
 

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -44,7 +44,13 @@ const persistStateToFs = async (nextState: RootState) => {
         settings: nextState.settings,
         creator: nextState.creator,
         noteExport: nextState.noteExport,
-        customization: nextState.customization,
+        customization: {
+            provision: [],
+            lock: undefined,
+            history: nextState.customization.history,
+            activate: nextState.customization.activate,
+            welcomeScreen: undefined,
+        },
     };
 
     await fsp.writeFile(stateFilePath, JSON.stringify(value), {encoding: "utf8"});

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -29,7 +29,7 @@ import { TBookmarkState } from "readium-desktop/common/redux/states/bookmark";
 import { TAnnotationState } from "readium-desktop/common/redux/states/renderer/annotation";
 import { sqliteInitTableNote, sqliteTableNoteDeleteWherePubId, sqliteTableNoteInsert, sqliteTableSelectLastModifiedDateWherePubId } from "readium-desktop/main/db/sqlite/note";
 import { sqliteInitialisation } from "readium-desktop/main/db/sqlite";
-import { IReaderStateReaderSession } from "src/common/redux/states/renderer/readerRootState";
+import { IReaderStateReaderSession } from "readium-desktop/common/redux/states/renderer/readerRootState";
 
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;

--- a/src/main/streamer/streamerNoHttp.ts
+++ b/src/main/streamer/streamerNoHttp.ts
@@ -461,7 +461,7 @@ const streamProtocolHandler = async (
 
 
         const state = diMainGet("store").getState();
-        const profile = state.customization.provision.find(({identifier}) => identifier === id);
+        const profile = state.customization.provision.find((profile) => profile.id === id);
 
         if (!profile) {
             const err = "PROFILE ID " + uPathname + " ; " + id;

--- a/src/renderer/common/components/customizationProfileDialog.tsx
+++ b/src/renderer/common/components/customizationProfileDialog.tsx
@@ -54,12 +54,12 @@ export const CustomizationProfileDialog: React.FC = () => {
                         <span>LOCKINFO={JSON.stringify(customization.lock.lockInfo, null, 4)}</span>
                     </AlertDialog.Description>
                     <div className={stylesAlertModals.AlertDialogButtonContainer}>
-                        <AlertDialog.Cancel asChild onClick={() => { dispatch(customizationActions.lock.build("IDLE")); dispatch(customizationActions.activating.build("")); }}>
+                        {/* <AlertDialog.Cancel asChild onClick={() => { dispatch(customizationActions.lock.build("IDLE")); dispatch(customizationActions.activating.build("")); }}>
                             <button className={stylesButtons.button_secondary_blue}>{__("dialog.cancel")}</button>
-                        </AlertDialog.Cancel>
+                        </AlertDialog.Cancel> */}
                         <AlertDialog.Action asChild>
-                            <button className={stylesButtons.button_primary_blue} onClick={() => { dispatch(customizationActions.welcomeScreen.build(false)); }}>
-                                Enter
+                            <button disabled={!customization.welcomeScreen.enable} className={stylesButtons.button_primary_blue} onClick={() => { dispatch(customizationActions.welcomeScreen.build(false)); }}>
+                                {__("dialog.yes")}
                             </button>
                         </AlertDialog.Action>
                     </div>

--- a/src/renderer/common/components/customizationProfileDialog.tsx
+++ b/src/renderer/common/components/customizationProfileDialog.tsx
@@ -8,31 +8,34 @@
 import * as React from "react";
 import { useTranslator } from "readium-desktop/renderer/common/hooks/useTranslator";
 // import { annotationActions } from "readium-desktop/common/redux/actions";
-// import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
+import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
 import * as stylesAlertModals from "readium-desktop/renderer/assets/styles/components/alert.modals.scss";
-// import * as stylesGlobal from "readium-desktop/renderer/assets/styles/global.scss";
-// import SVG from "readium-desktop/renderer/common/components/SVG";
+import * as stylesGlobal from "readium-desktop/renderer/assets/styles/global.scss";
+import SVG from "readium-desktop/renderer/common/components/SVG";
 // import * as PlusIcon from "readium-desktop/renderer/assets/icons/Plus-bold.svg";
 // import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
 import { customizationActions } from "readium-desktop/common/redux/actions";
-import { useDispatch } from "../hooks/useDispatch";
-// import SVG from "./SVG";
-// import * as CheckIcon from "readium-desktop/renderer/assets/icons/singlecheck-icon.svg";
+import * as CheckIcon from "readium-desktop/renderer/assets/icons/singlecheck-icon.svg";
 
-export const CustomizationProfileModal: React.FC = () => {
+export const CustomizationProfileDialog: React.FC = () => {
 
     const customization = useSelector((state: ICommonRootState) => state.customization);
     const open = customization.lock.state !== "IDLE" || customization.welcomeScreen.enable;
+    const manifest = customization.manifest;
 
     const dispatch = useDispatch();
     const [__] = useTranslator();
 
-    // const profileInHistoryFound = customization.history.find(({id}) => id && id === customization.activate.id);
-    // const [checked, setChecked] = React.useState<boolean>((profileInHistoryFound && profileInHistoryFound.welcomeScreenShowAgain) ? profileInHistoryFound.welcomeScreenShowAgain : true);
+    const profileInHistoryFound = customization.history.find(({id}) => id && id === customization.activate.id);
+    const [checked, setChecked] = React.useState<boolean>(profileInHistoryFound && manifest?.version && profileInHistoryFound.version === manifest?.version);
+
+    React.useEffect(() => {
+        setChecked(profileInHistoryFound && manifest?.version && profileInHistoryFound.version === manifest?.version);
+    }, [setChecked, manifest?.version, profileInHistoryFound]);
 
 
     return (
@@ -60,8 +63,8 @@ export const CustomizationProfileModal: React.FC = () => {
                             </button>
                         </AlertDialog.Action>
                     </div>
-                    {/* customization.welcomeScreen.enable && profileInHistoryFound ? <div style={{ display: "flex", alignItems: "center", gap: "10px", position: "absolute", bottom: "30px", left: "30px" }}>
-                        <input type="checkbox" checked={checked} onChange={() => { setChecked(!checked); dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, profileInHistoryFound.version, checked ? true : false)); }} id="wizardCheckbox" name="wizardCheckbox" className={stylesGlobal.checkbox_custom_input} />
+                    {customization.welcomeScreen.enable && profileInHistoryFound ? <div style={{ display: "flex", alignItems: "center", gap: "10px", position: "absolute", bottom: "30px", left: "30px" }}>
+                        <input type="checkbox" checked={checked} onChange={() => { setChecked(!checked); dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, checked ? "" : profileInHistoryFound.version)); }} id="wizardCheckbox" name="wizardCheckbox" className={stylesGlobal.checkbox_custom_input} />
                         <label htmlFor="wizardCheckbox" className={stylesGlobal.checkbox_custom_label}>
                             <div
                                 tabIndex={0}
@@ -82,7 +85,7 @@ export const CustomizationProfileModal: React.FC = () => {
                                     if (e.key === " ") { // WORKS
                                         e.preventDefault();
                                         setChecked(!checked);
-                                        dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, profileInHistoryFound.version, checked ? true : false));
+                                        dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, checked ? "" : profileInHistoryFound.version));
                                     }
                                 }}
                                 className={stylesGlobal.checkbox_custom}
@@ -97,7 +100,7 @@ export const CustomizationProfileModal: React.FC = () => {
                                 {__("wizard.dontShow")}
                             </span>
                         </label>
-                    </div> : <></> */}
+                    </div> : <></> }
                 </AlertDialog.Content>
             </AlertDialog.Portal>
         </AlertDialog.Root>

--- a/src/renderer/common/components/customizationProfileModal.tsx
+++ b/src/renderer/common/components/customizationProfileModal.tsx
@@ -11,20 +11,28 @@ import { useTranslator } from "readium-desktop/renderer/common/hooks/useTranslat
 // import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
-// import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
+import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
 import * as stylesAlertModals from "readium-desktop/renderer/assets/styles/components/alert.modals.scss";
+// import * as stylesGlobal from "readium-desktop/renderer/assets/styles/global.scss";
 // import SVG from "readium-desktop/renderer/common/components/SVG";
 // import * as PlusIcon from "readium-desktop/renderer/assets/icons/Plus-bold.svg";
 // import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
+import { customizationActions } from "readium-desktop/common/redux/actions";
+import { useDispatch } from "../hooks/useDispatch";
+// import SVG from "./SVG";
+// import * as CheckIcon from "readium-desktop/renderer/assets/icons/singlecheck-icon.svg";
 
 export const CustomizationProfileModal: React.FC = () => {
 
-    const customizationLock = useSelector((state: ICommonRootState) => state.customization.lock);
-    const open = customizationLock.state !== "IDLE";
+    const customization = useSelector((state: ICommonRootState) => state.customization);
+    const open = customization.lock.state !== "IDLE" || customization.welcomeScreen.enable;
 
-    // const dispatch = useDispatch();
+    const dispatch = useDispatch();
     const [__] = useTranslator();
+
+    // const profileInHistoryFound = customization.history.find(({id}) => id && id === customization.activate.id);
+    // const [checked, setChecked] = React.useState<boolean>((profileInHistoryFound && profileInHistoryFound.welcomeScreenShowAgain) ? profileInHistoryFound.welcomeScreenShowAgain : true);
 
 
     return (
@@ -38,22 +46,58 @@ export const CustomizationProfileModal: React.FC = () => {
                 <AlertDialog.Content className={stylesAlertModals.AlertDialogContent}>
                     <AlertDialog.Title className={stylesAlertModals.AlertDialogTitle}>{__("dialog.customization.splashscreen.title")}</AlertDialog.Title>
                     <AlertDialog.Description className={stylesAlertModals.AlertDialogDescription} style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
-                        <span>STATE={customizationLock.state}</span>
-                        <span>ID={customizationLock.lockInfo?.id === "" && customizationLock.state === "ACTIVATING" ? "THorium Default Profile" : customizationLock.lockInfo?.id || "undefined"}</span>
-                        <span>LOCKINFO={JSON.stringify(customizationLock.lockInfo, null, 4)}</span>
+                        <span>STATE={customization.lock.state}</span>
+                        <span>ID={customization.lock.lockInfo?.id === "" && customization.lock.state === "ACTIVATING" ? "THorium Default Profile" : customization.lock.lockInfo?.id || "undefined"}</span>
+                        <span>LOCKINFO={JSON.stringify(customization.lock.lockInfo, null, 4)}</span>
                     </AlertDialog.Description>
                     <div className={stylesAlertModals.AlertDialogButtonContainer}>
-                        {/* <AlertDialog.Cancel asChild onClick={() => dispatch(annotationActions.importConfirmOrAbort.build("abort"))}>
+                        <AlertDialog.Cancel asChild onClick={() => { dispatch(customizationActions.lock.build("IDLE")); dispatch(customizationActions.activating.build("")); }}>
                             <button className={stylesButtons.button_secondary_blue}>{__("dialog.cancel")}</button>
                         </AlertDialog.Cancel>
                         <AlertDialog.Action asChild>
-                            <button className={stylesButtons.button_primary_blue} onClick={() => dispatch(annotationActions.importConfirmOrAbort.build("importAll"))}>
-                                <SVG ariaHidden svg={PlusIcon} />
-                                {__("dialog.annotations.importAll")}
+                            <button className={stylesButtons.button_primary_blue} onClick={() => { dispatch(customizationActions.welcomeScreen.build(false)); }}>
+                                Enter
                             </button>
                         </AlertDialog.Action>
-                        */}
                     </div>
+                    {/* customization.welcomeScreen.enable && profileInHistoryFound ? <div style={{ display: "flex", alignItems: "center", gap: "10px", position: "absolute", bottom: "30px", left: "30px" }}>
+                        <input type="checkbox" checked={checked} onChange={() => { setChecked(!checked); dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, profileInHistoryFound.version, checked ? true : false)); }} id="wizardCheckbox" name="wizardCheckbox" className={stylesGlobal.checkbox_custom_input} />
+                        <label htmlFor="wizardCheckbox" className={stylesGlobal.checkbox_custom_label}>
+                            <div
+                                tabIndex={0}
+                                role="checkbox"
+                                aria-checked={checked}
+                                aria-label={__("wizard.dontShow")}
+                                onKeyDown={(e) => {
+                                    // if (e.code === "Space") {
+                                    if (e.key === " ") {
+                                        e.preventDefault(); // prevent scroll
+                                    }
+                                }}
+                                onKeyUp={(e) => {
+                                    // Includes screen reader tests:
+                                    // if (e.code === "Space") { WORKS
+                                    // if (e.key === "Space") { DOES NOT WORK
+                                    // if (e.key === "Enter") { WORKS
+                                    if (e.key === " ") { // WORKS
+                                        e.preventDefault();
+                                        setChecked(!checked);
+                                        dispatch(customizationActions.addHistory.build(profileInHistoryFound.id, profileInHistoryFound.version, checked ? true : false));
+                                    }
+                                }}
+                                className={stylesGlobal.checkbox_custom}
+                                style={{ border: checked ? "2px solid transparent" : "2px solid var(--color-primary)", backgroundColor: checked ? "var(--color-blue)" : "transparent" }}>
+                                {checked ?
+                                    <SVG ariaHidden svg={CheckIcon} />
+                                    :
+                                    <></>
+                                }
+                            </div>
+                            <span aria-hidden>
+                                {__("wizard.dontShow")}
+                            </span>
+                        </label>
+                    </div> : <></> */}
                 </AlertDialog.Content>
             </AlertDialog.Portal>
         </AlertDialog.Root>

--- a/src/renderer/library/components/App.tsx
+++ b/src/renderer/library/components/App.tsx
@@ -40,7 +40,7 @@ import NunitoBold from "readium-desktop/renderer/assets/fonts/NunitoSans_10pt-Se
 import { WizardModal } from "./Wizard";
 import { getReduxHistory, getStore } from "../createStore";
 import { getTranslator } from "readium-desktop/common/services/translator";
-import { CustomizationProfileModal } from "readium-desktop/renderer/common/components/customizationProfileModal";
+import { CustomizationProfileDialog } from "readium-desktop/renderer/common/components/customizationProfileDialog";
 // eslintxx-disable-next-line @typescript-eslint/no-unused-expressions
 // globalScssStyle.__LOAD_FILE_SELECTOR_NOT_USED_JUST_TO_TRIGGER_WEBPACK_SCSS_FILE__;
 
@@ -226,7 +226,7 @@ export default class App extends React.Component<{}, undefined> {
                                     <LoaderMainLoad />
                                     <ToastManager />
                                     <WizardModal />
-                                    <CustomizationProfileModal />
+                                    <CustomizationProfileDialog />
                                 </div>;
                             }}
                         </Dropzone>

--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -403,7 +403,7 @@ const Themes = () => {
 const Profiles = () => {
 
     const { provision: packageProfileProvisioned, activate: { id: profileActivatedId } } = useSelector((s: ICommonRootState) => s.customization);
-    const selectedProfile = packageProfileProvisioned.find(({identifier}) => identifier && identifier === profileActivatedId);
+    const selectedProfile = packageProfileProvisioned.find(({id}) => id && id === profileActivatedId);
     const dispatch = useDispatch();
 
     return (
@@ -433,21 +433,21 @@ const Profiles = () => {
 
                         return (
                             <div
-                                key={profile.identifier} // Ajout de la key manquante pour React
+                                key={profile.id} // Ajout de la key manquante pour React
                                 className={stylesSettings.profile_selection_input}
                             >
                                 <input
                                     type="radio"
-                                    id={profile.identifier}
+                                    id={profile.id}
                                     value={profile.fileName}
                                     name="profile_selection"
-                                    checked={selectedProfile?.identifier === profile.identifier}
+                                    checked={selectedProfile?.id === profile.id}
                                     onChange={(e) => {
                                         console.log("PROFILE Input change", e);
-                                        dispatch(customizationActions.activating.build(profile.identifier));
+                                        dispatch(customizationActions.activating.build(profile.id));
                                     }}
                                 />
-                                <label htmlFor={profile.identifier} className={stylesSettings.profile_selection_label}>
+                                <label htmlFor={profile.id} className={stylesSettings.profile_selection_label}>
                                     {/* {logo && logo.type === "image/svg+xml" ? (
                                         <div
                                             className="logo"

--- a/src/renderer/library/redux/middleware/sync.ts
+++ b/src/renderer/library/redux/middleware/sync.ts
@@ -72,6 +72,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     customizationActions.activating.ID,
     customizationActions.acquire.ID,
     customizationActions.lock.ID,
+    customizationActions.addHistory.ID,
 ];
 
 export const reduxSyncMiddleware = syncFactory(SYNCHRONIZABLE_ACTIONS);

--- a/src/renderer/library/redux/reducers/index.ts
+++ b/src/renderer/library/redux/reducers/index.ts
@@ -5,7 +5,7 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { downloadActions } from "readium-desktop/common/redux/actions";
+import { customizationActions, downloadActions } from "readium-desktop/common/redux/actions";
 import { dialogReducer } from "readium-desktop/common/redux/reducers/dialog";
 import { i18nReducer } from "readium-desktop/common/redux/reducers/i18n";
 import { keyboardReducer } from "readium-desktop/common/redux/reducers/keyboard";
@@ -41,6 +41,9 @@ import { noteExportReducer } from "readium-desktop/common/redux/reducers/noteExp
 import { customizationPackageActivatingReducer } from "readium-desktop/common/redux/reducers/customization/activate";
 import { customizationPackageProvisioningReducer } from "readium-desktop/common/redux/reducers/customization/provision";
 import { customizationPackageActivatingLockReducer } from "readium-desktop/common/redux/reducers/customization/lock";
+import { arrayReducer } from "readium-desktop/utils/redux-reducers/array.reducer";
+import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
+import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
 
 export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reducer<Partial<ILibraryRootState>>
     return combineReducers({ // ILibraryRootState
@@ -100,9 +103,23 @@ export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reduc
         lcp: lcpReducer,
         noteExport: noteExportReducer,
         customization: combineReducers({
+            history: arrayReducer<customizationActions.addHistory.TAction, undefined, ICustomizationProfileHistory, Pick<ICustomizationProfileHistory, "id">>(
+                {
+                    add: {
+                        type: customizationActions.addHistory.ID,
+                        selector: (payload, _state) => {
+                            const { id, version } = payload;
+                            return [{ id, version }];
+                        },
+                    },
+                    remove: undefined,
+                    getId: (item) => item.id,
+                },
+            ),
             activate: customizationPackageActivatingReducer,
             provision: customizationPackageProvisioningReducer,
             lock: customizationPackageActivatingLockReducer,
+            welcomeScreen: customizationPackageWelcomeScreenReducer,
         }),
     });
 };

--- a/src/renderer/library/redux/reducers/index.ts
+++ b/src/renderer/library/redux/reducers/index.ts
@@ -44,6 +44,7 @@ import { customizationPackageActivatingLockReducer } from "readium-desktop/commo
 import { arrayReducer } from "readium-desktop/utils/redux-reducers/array.reducer";
 import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
 import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
+import { customizationPackageManifestReducer } from "readium-desktop/common/redux/reducers/customization/manifest";
 
 export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reducer<Partial<ILibraryRootState>>
     return combineReducers({ // ILibraryRootState
@@ -120,6 +121,7 @@ export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reduc
             provision: customizationPackageProvisioningReducer,
             lock: customizationPackageActivatingLockReducer,
             welcomeScreen: customizationPackageWelcomeScreenReducer,
+            manifest: customizationPackageManifestReducer,
         }),
     });
 };

--- a/src/renderer/library/redux/sagas/customization.ts
+++ b/src/renderer/library/redux/sagas/customization.ts
@@ -113,10 +113,12 @@ function* profileActivating(id: string): SagaGenerator<void> {
     debug("MANIFEST FROM ", id, ":");
     debug(manifestJson);
 
+    yield* putTyped(customizationActions.manifest.build(manifestJson));
+
     const profileActivationHistory = yield* selectTyped((state: ICommonRootState) => state.customization.history);
 
     const profileHistoryFound = profileActivationHistory.find((profileHistory) => profileHistory.id === id);
-    const welcomeScreenNeeded = !profileHistoryFound || profileHistoryFound.welcomeScreenShowAgain || profileHistoryFound.version !== manifestJson.version;
+    const welcomeScreenNeeded = !profileHistoryFound || profileHistoryFound.version !== manifestJson.version;
 
     yield* putTyped(customizationActions.welcomeScreen.build(welcomeScreenNeeded));
 
@@ -141,7 +143,7 @@ function* profileActivating(id: string): SagaGenerator<void> {
 
     // dispatch new opds-catalogs to the redux state attached to this profile
 
-    yield* putTyped(customizationActions.addHistory.build(id, manifestJson.version, profileHistoryFound?.welcomeScreenShowAgain || false));
+    yield* putTyped(customizationActions.addHistory.build(id, manifestJson.version));
 }
 
 

--- a/src/renderer/library/redux/sagas/customization.ts
+++ b/src/renderer/library/redux/sagas/customization.ts
@@ -37,6 +37,8 @@ function* profileActivating(id: string): SagaGenerator<void> {
         // THorium vanilla rollback, clear the local redux state
         yield* putTyped(themeActions.setTheme.build(undefined, { enable: false }));
 
+        yield* putTyped(customizationActions.welcomeScreen.build(false));
+
         // TODO: switch to default color css variable
 
 // $color-white: #fff;
@@ -111,6 +113,12 @@ function* profileActivating(id: string): SagaGenerator<void> {
     debug("MANIFEST FROM ", id, ":");
     debug(manifestJson);
 
+    const profileActivationHistory = yield* selectTyped((state: ICommonRootState) => state.customization.history);
+
+    const profileHistoryFound = profileActivationHistory.find((profileHistory) => profileHistory.id === id);
+    const welcomeScreenNeeded = !profileHistoryFound || profileHistoryFound.welcomeScreenShowAgain || profileHistoryFound.version !== manifestJson.version;
+
+    yield* putTyped(customizationActions.welcomeScreen.build(welcomeScreenNeeded));
 
     const logoObj = manifestJson.images?.find((ln) => ln?.rel === "logo");
     debug("Manifest LOGO Obj:", logoObj);
@@ -133,6 +141,7 @@ function* profileActivating(id: string): SagaGenerator<void> {
 
     // dispatch new opds-catalogs to the redux state attached to this profile
 
+    yield* putTyped(customizationActions.addHistory.build(id, manifestJson.version, profileHistoryFound?.welcomeScreenShowAgain || false));
 }
 
 

--- a/src/renderer/reader/redux/reducers/index.ts
+++ b/src/renderer/reader/redux/reducers/index.ts
@@ -35,7 +35,7 @@ import { readerDefaultConfigReducer } from "readium-desktop/common/redux/reducer
 import { themeReducer } from "readium-desktop/common/redux/reducers/theme";
 import { versionUpdateReducer } from "readium-desktop/common/redux/reducers/version-update";
 import { annotationModeEnableReducer } from "./annotationModeEnable";
-import { readerActions } from "readium-desktop/common/redux/actions";
+import { customizationActions, readerActions } from "readium-desktop/common/redux/actions";
 import { readerMediaOverlayReducer } from "./mediaOverlay";
 import { readerTTSReducer } from "./tts";
 import { readerTransientConfigReducer } from "./readerTransientConfig";
@@ -54,6 +54,8 @@ import { noteExportReducer } from "readium-desktop/common/redux/reducers/noteExp
 import { customizationPackageProvisioningReducer } from "readium-desktop/common/redux/reducers/customization/provision";
 import { customizationPackageActivatingReducer } from "readium-desktop/common/redux/reducers/customization/activate";
 import { customizationPackageActivatingLockReducer } from "readium-desktop/common/redux/reducers/customization/lock";
+import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
+import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
 
 export const rootReducer = () => {
 
@@ -211,9 +213,23 @@ export const rootReducer = () => {
         lcp: lcpReducer,
         noteExport: noteExportReducer,
         customization: combineReducers({
+            history: arrayReducer<customizationActions.addHistory.TAction, undefined, ICustomizationProfileHistory, Pick<ICustomizationProfileHistory, "id">>(
+                {
+                    add: {
+                        type: customizationActions.addHistory.ID,
+                        selector: (payload, _state) => {
+                            const { id, version } = payload;
+                            return [{ id, version }];
+                        },
+                    },
+                    remove: undefined,
+                    getId: (item) => item.id,
+                },
+            ),
             activate: customizationPackageActivatingReducer,
             provision: customizationPackageProvisioningReducer,
             lock: customizationPackageActivatingLockReducer,
+            welcomeScreen: customizationPackageWelcomeScreenReducer,
         }),
     });
 };

--- a/src/renderer/reader/redux/reducers/index.ts
+++ b/src/renderer/reader/redux/reducers/index.ts
@@ -56,6 +56,7 @@ import { customizationPackageActivatingReducer } from "readium-desktop/common/re
 import { customizationPackageActivatingLockReducer } from "readium-desktop/common/redux/reducers/customization/lock";
 import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
 import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
+import { ICustomizationManifest } from "readium-desktop/common/readium/customization/manifest";
 
 export const rootReducer = () => {
 
@@ -230,6 +231,7 @@ export const rootReducer = () => {
             provision: customizationPackageProvisioningReducer,
             lock: customizationPackageActivatingLockReducer,
             welcomeScreen: customizationPackageWelcomeScreenReducer,
+            manifest: () => null as ICustomizationManifest,
         }),
     });
 };


### PR DESCRIPTION
Tackle #3153


FIxes also : ICustomizationProfileProvisioned.identifier to ICustomizationProfileProvisioned.id to harmonize profile identiifer variable across redux state

Fixes also : rename customizationProfileModal to customizationProfileDialog

Fixes also : lots of import with "src/..." instead of "readium-desktop/..."

FIxes also : persistence customization finegrained to `history` and `activate` , other field are nullified (undefined)

Add to redux state customization: 3 new fields : 
- history: to persist the profile id attached with the last version, used to keep welcome-screen open when first activation
- manifest: store profile manifest to library state
- welcome-screen: customization profile dialog (splash-screen) maintained as welcome-screen when enable true

What is implemented in this PR: 

- the splash-screen transistion to the welcome-screen (first profile activation or newer version) 
- cancel button (change customization profile state machine to idle and force change to thorium vanilla default profile)
- enter button (acknoledge welcome-screen)
- don't show again checkbox (like the thorium wizard)

TODO: 
- any welcome-screen design
- remove log information to the modal
- keep improving the css
- #3168 How to cancel properly the profile state machine ? 
