### PR TITLE
Reenable footnotes on TTS and MO stop

### DIFF
--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -3020,7 +3020,9 @@ class Reader extends React.Component<IProps, IState> {
             this.setState({ previousReaderConfigAnnotationDefaultDrawView: undefined });
         }
 
-        this.props.setConfig({ noFootnotes: false });
+        if (this.props.readerConfig.noFootnotes) {
+            this.props.setConfig({ noFootnotes: false });
+        }
     }
     private handleTTSStop() {
         ttsClickEnable(false);

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -3019,6 +3019,8 @@ class Reader extends React.Component<IProps, IState> {
             // this.setState({ previousReaderConfigAnnotationDefaultDrawView: this.props.readerConfig.annotation_defaultDrawView });
             this.setState({ previousReaderConfigAnnotationDefaultDrawView: undefined });
         }
+
+        this.props.setConfig({ noFootnotes: false });
     }
     private handleTTSStop() {
         ttsClickEnable(false);


### PR DESCRIPTION
Fixes https://github.com/edrlab/thorium-reader/issues/3399

I haven't built and tried this locally, but the issue seems to be straightforward - footnotes are disabled in the TTS and MO start handlers, but then never reenabled. `restoreAnnotationStateAfterTTSorMOStop` is called from both stop handlers, so resetting `noFootnotes` there should do the trick.