### PR TITLE
introduce publication-data & registry migration/hydration

### DIFF
--- a/src/common/redux/actions/reader/index.ts
+++ b/src/common/redux/actions/reader/index.ts
@@ -24,6 +24,7 @@ import * as setTheLock from "./setTheLock";
 import * as note from "./note";
 import * as pdfConfig from "./pdfConfig";
 import * as setLocator from "./setLocator";
+import * as setConfig from "./setConfig";
 
 export {
     openRequest,
@@ -45,4 +46,5 @@ export {
     print,
     pdfConfig,
     setLocator,
+    setConfig,
 };

--- a/src/common/redux/actions/reader/setConfig.ts
+++ b/src/common/redux/actions/reader/setConfig.ts
@@ -8,7 +8,7 @@
 import { ReaderConfig } from "readium-desktop/common/models/reader";
 import { Action } from "readium-desktop/common/models/redux";
 
-export const ID = "READER_SET_CONFIG_IN_RENDERER";
+export const ID = "READER_SET_CONFIG";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Payload extends Partial<ReaderConfig> {

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -38,6 +38,7 @@ import { LSDManager } from "./services/lsd";
 import { tryCatch } from "readium-desktop/utils/tryCatch";
 import { EOL } from "os";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
+import { PublicationData } from "./storage/publication-data";
 
 // import { streamer } from "readium-desktop/main/streamerHttp";
 // import { Server } from "@r2-streamer-js/http/server";
@@ -48,6 +49,23 @@ const debug = debug_("readium-desktop:main:di");
 export const CONFIGREPOSITORY_REDUX_PERSISTENCE = "CONFIGREPOSITORY_REDUX_PERSISTENCE";
 const capitalizedAppName = _APP_NAME.charAt(0).toUpperCase() + _APP_NAME.substring(1);
 
+import { exec } from "node:child_process";
+
+export let __ulimit_file: number;
+try {
+    if (__TH__IS_DEV__ && process.platform !== "win32") {
+        exec("ulimit -n", { shell: "/bin/sh" }, (err, stdout) => {
+            if (err) {
+                console.error(err);
+                return;
+            }
+            debug("Open file limit:", stdout.trim());
+            __ulimit_file = parseInt(stdout.trim(), 10);
+        });
+    }
+} catch {
+    // nothing
+}
 
 // Normally not required as already initialized by electron
 if (!fs.existsSync(USER_DATA_FOLDER)) {
@@ -120,13 +138,13 @@ export const userVaultConfigPath = path.join(
     configDataFolderPath,
     USER_VAULT_FILENAME,
 );
-const READER_CONFIG_DIRECTORY_NAME = "reader";
-export const readerConfigPath = path.join(
+const PUBLICATION_CONFIG_DIRECTORY_NAME = "publication";
+export const publicationConfigPath = path.join(
     configDataFolderPath,
-    READER_CONFIG_DIRECTORY_NAME,
+    PUBLICATION_CONFIG_DIRECTORY_NAME,
 );
-if (!fs.existsSync(readerConfigPath)) {
-    fs.mkdirSync(readerConfigPath);
+if (!fs.existsSync(publicationConfigPath)) {
+    fs.mkdirSync(publicationConfigPath);
 }
 //
 // Create databases
@@ -272,9 +290,14 @@ container.bind<OpdsFeedViewConverter>(diSymbolTable["opds-feed-view-converter"])
     .to(OpdsFeedViewConverter).inSingletonScope();
 
 // Storage
-const publicationStorage = new PublicationStorage(publicationRepositoryPath, userVaultConfigPath, readerConfigPath);
+const publicationStorage = new PublicationStorage(publicationRepositoryPath, userVaultConfigPath);
 container.bind<PublicationStorage>(diSymbolTable["publication-storage"]).toConstantValue(
     publicationStorage,
+);
+
+const publicationData = new PublicationData(publicationConfigPath);
+container.bind<PublicationData>(diSymbolTable["publication-data"]).toConstantValue(
+    publicationData,
 );
 
 // Bind services
@@ -344,6 +367,7 @@ interface IGet {
     //    (s: "locator-view-converter"): LocatorViewConverter;
     (s: "opds-feed-view-converter"): OpdsFeedViewConverter;
     (s: "publication-storage"): PublicationStorage;
+    (s: "publication-data"): PublicationData;
     // (s: "streamer"): Server;
     (s: "device-id-manager"): DeviceIdManager;
     (s: "lcp-manager"): LcpManager;

--- a/src/main/diSymbolTable.ts
+++ b/src/main/diSymbolTable.ts
@@ -11,6 +11,7 @@ export const diSymbolTable = {
 //    "locator-view-converter": Symbol("locator-view-converter"),
     "opds-feed-view-converter": Symbol("opds-feed-view-converter"),
     "publication-storage": Symbol("publication-storage"),
+    "publication-data": Symbol("publication-data"),
     // "streamer": Symbol("streamer"),
     "device-id-manager": Symbol("device-id-manager"),
     "lcp-manager": Symbol("lcp-manager"),

--- a/src/main/redux/sagas/api/publication/delete.ts
+++ b/src/main/redux/sagas/api/publication/delete.ts
@@ -33,6 +33,10 @@ export function* deletePublication(identifier: string/*, preservePublicationOnFi
         // Remove from storage
         yield call(() => publicationStorage.removePublication(identifier /*, preservePublicationOnFileSystem*/));
 
+        const publicationData = diMainGet("publication-data");
+        // Remove from data storage
+        yield call(() => publicationData.removePublication(identifier));
+
         const publicationViewConverter = diMainGet("publication-view-converter");
         // Remove from memory cache
         yield call(() => publicationViewConverter.removeFromMemoryCache(identifier));

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -256,6 +256,13 @@ function* closeProcess() {
                     } catch (e) {
                         debug("ERROR to persistState", e);
                     }
+
+                    try {
+                        yield call(() => diMainGet("publication-data").destroy());
+                        debug("Success to destroy publication-data");
+                    } catch (e) {
+                        debug("ERROR to destroy publication-data", e);
+                    }
                 }),
                 call(function*() {
 

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -26,7 +26,7 @@ import { publicationActions as publicationActionsFromCommonAction } from "readiu
 import { takeSpawnLatest } from "readium-desktop/common/redux/sagas/takeSpawnLatest";
 import { spawnLeading } from "readium-desktop/common/redux/sagas/spawnLeading";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
-import { PublicationView } from "src/common/views/publication";
+import { PublicationView } from "readium-desktop/common/views/publication";
 
 const filename_ = "readium-desktop:main:redux:sagas:catalog";
 const debug = debug_(filename_);

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -20,6 +20,7 @@ import { readerActions } from "readium-desktop/common/redux/actions";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
+import { AnyJson } from "readium-desktop/typings/json";
 
 const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
 const LOCATOR_DEBOUNCE_TIME = 10 * 1000; // 10 secs
@@ -129,7 +130,7 @@ export function saga() {
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
 
-                const locator = action.payload;
+                const locator = action.payload as unknown as AnyJson;
                 const sender = action.sender as EventPayload["sender"];
 
                 if (sender.type !== SenderType.Renderer) {
@@ -139,8 +140,7 @@ export function saga() {
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 const pubId = reader.publicationIdentifier;
 
-                const locatorSerialize = (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(locator, null, 4) : JSON.stringify(locator);
-                yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locatorSerialize));
+                yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locator));
             },
         ),
         // takeSpawnEvery(

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -136,9 +136,11 @@ export function saga() {
                     return;
                 }
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
-                const pubId = reader.publicationIdentifier;
+                if (reader) {
+                    const pubId = reader.publicationIdentifier;
+                    yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locator));
+                }
 
-                yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locator));
             },
         ),
         // takeSpawnEvery(

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -20,6 +20,7 @@ import { readerActions } from "readium-desktop/common/redux/actions";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
+import { ReaderConfig } from "readium-desktop/common/models/reader";
 
 const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
 const LOCATOR_DEBOUNCE_TIME = 10 * 1000; // 10 secs
@@ -109,7 +110,7 @@ export function saga() {
         takeSpawnLeading(
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
-                const jsonObj = action.payload as unknown as object;
+                const locatorJsonObj = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
 
                 if (sender.type !== SenderType.Renderer) {
@@ -117,9 +118,38 @@ export function saga() {
                     return;
                 }
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                if (!reader) {
+                    debug("no reader sender found in session !!!");
+                    return ;
+                }
                 const pubId = reader.publicationIdentifier;
 
-                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "locator", jsonObj));
+                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "locator", locatorJsonObj));
+            },
+            (e) => debug(e),
+        ),
+        takeSpawnLeading(
+            readerActions.setConfig.ID,
+            function* (action: readerActions.setConfig.TAction) {
+                const configJsonObj = action.payload as unknown as object;
+                const sender = action.sender as EventPayload["sender"];
+
+                debug("SET CONFIG RECEIVED WITH", configJsonObj);
+
+                if (sender.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                if (!reader) {
+                    debug("no reader sender found in session !!!");
+                    return;
+                }
+                const pubId = reader.publicationIdentifier;
+
+                const config: Partial<ReaderConfig> = (yield* callTyped(() => diMainGet("publication-data").getJsonObj(pubId, "config"))) || {};
+                const configUnion = { ...config, ...configJsonObj };
+                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "config", configUnion));
             },
             (e) => debug(e),
         ),

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -23,7 +23,7 @@ import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEver
 import { ReaderConfig } from "readium-desktop/common/models/reader";
 
 const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
-const LOCATOR_DEBOUNCE_TIME = 10 * 1000; // 10 secs
+const PUBLICATION_STORAGE_DEBOUNCE_TIME = 10 * 1000; // 10 secs
 
 // Logger
 const filename_ = "readium-desktop:main:saga:persist";
@@ -108,6 +108,45 @@ export function saga() {
             needToPersistPatch,
         ),
         takeSpawnLeading(
+            winActions.session.setBound.ID,
+            function* (action: winActions.session.setBound.TAction) {
+                const payload = action.payload;
+                const identifier = payload.identifier;
+                const boundJsonObj = payload.bound;
+
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[identifier]);
+                if (!reader) {
+                    debug("no reader sender found in session !!!");
+                    return;
+                }
+                const pubId = reader.publicationIdentifier;
+
+                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", boundJsonObj));
+            },
+            (e) => debug(e),
+        ),
+        takeSpawnLeading(
+            readerActions.disableRTLFlip.ID,
+            function* (action: readerActions.disableRTLFlip.TAction) {
+                const rtlFlipJsonObj = action.payload as unknown as object;
+                const sender = action.sender as EventPayload["sender"];
+
+                if (sender.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                if (!reader) {
+                    debug("no reader sender found in session !!!");
+                    return;
+                }
+                const pubId = reader.publicationIdentifier;
+
+                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "disableRTLFlip", rtlFlipJsonObj));
+            },
+            (e) => debug(e),
+        ),
+        takeSpawnLeading(
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
                 const locatorJsonObj = action.payload as unknown as object;
@@ -120,7 +159,7 @@ export function saga() {
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 if (!reader) {
                     debug("no reader sender found in session !!!");
-                    return ;
+                    return;
                 }
                 const pubId = reader.publicationIdentifier;
 
@@ -133,8 +172,6 @@ export function saga() {
             function* (action: readerActions.setConfig.TAction) {
                 const configJsonObj = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
-
-                debug("SET CONFIG RECEIVED WITH", configJsonObj);
 
                 if (sender.type !== SenderType.Renderer) {
                     debug("sender is not renderer !!!");
@@ -154,10 +191,9 @@ export function saga() {
             (e) => debug(e),
         ),
         debounce(
-            LOCATOR_DEBOUNCE_TIME,
+            PUBLICATION_STORAGE_DEBOUNCE_TIME,
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
-
                 const jsonObj = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
 
@@ -171,6 +207,44 @@ export function saga() {
                     yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "locator", jsonObj));
                 }
 
+            },
+        ),
+        debounce(
+            PUBLICATION_STORAGE_DEBOUNCE_TIME,
+            readerActions.setConfig.ID,
+            function* (action: readerActions.setConfig.TAction) {
+                const configJsonObj = action.payload as unknown as object;
+                const sender = action.sender as EventPayload["sender"];
+
+                if (sender.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                if (reader) {
+                    const pubId = reader.publicationIdentifier;
+                    const config: Partial<ReaderConfig> = (yield* callTyped(() => diMainGet("publication-data").getJsonObj(pubId, "config"))) || {};
+                    const configUnion = { ...config, ...configJsonObj };
+                    yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "config", configUnion));
+                }
+            },
+        ),
+        debounce(
+            PUBLICATION_STORAGE_DEBOUNCE_TIME,
+            readerActions.disableRTLFlip.ID,
+            function* (action: readerActions.disableRTLFlip.TAction) {
+                const rtlFlipJsonObj = action.payload as unknown as object;
+                const sender = action.sender as EventPayload["sender"];
+
+                if (sender.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                if (reader) {
+                    const pubId = reader.publicationIdentifier;
+                    yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "disableRTLFlip", rtlFlipJsonObj));
+                }
             },
         ),
         // takeSpawnEvery(
@@ -198,24 +272,42 @@ export function saga() {
                 const readers = yield* selectTyped((state: RootState) => state.win.session.reader);
                 if (!readers[identifier]) {
                     debug("ERROR NO READER BUT CLOSE ACTION RECEIVED (race condition!?)");
-                    return ;
+                    return;
                 }
                 const pubId = readers[identifier].publicationIdentifier;
                 const readersPubId = Object.values(readers).filter((v) => v.publicationIdentifier === pubId);
                 if (readersPubId.length > 1) {
-                    return ;
+                    return;
                 }
 
-                const jsonObj = diMainGet("publication-data").getJsonObj(pubId, "locator");
+                // TODO: parallelize with Promise.allSettled
                 yield* callTyped(() => diMainGet("publication-data").close(pubId));
 
-                if (jsonObj) {
-                    // finally save locator next to publication storage vault
-                    yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "locator", jsonObj));
+                {
+                    const jsonObj = diMainGet("publication-data").getJsonObj(pubId, "locator");
+                    if (jsonObj) {
+                        // finally save locator next to publication storage vault
+                        yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "locator", jsonObj));
+                    }
                 }
 
+                {
+                    const jsonObj = diMainGet("publication-data").getJsonObj(pubId, "config");
+                    if (jsonObj) {
+                        // finally save config next to publication storage vault
+                        yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "config", jsonObj));
+                    }
+                }
+
+                {
+                    const jsonObj = diMainGet("publication-data").getJsonObj(pubId, "disableRTLFlip");
+                    if (jsonObj) {
+                        // finally save disableRTLFlip next to publication storage vault
+                        yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "disableRTLFlip", jsonObj));
+                    }
+                }
             },
-            // (e) => error(filename_ + ":winClose", e),
+// (e) => error(filename_ + ":winClose", e),
             (e) => debug(e),
         ),
     ]);

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -138,7 +138,7 @@ export function saga() {
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 if (reader) {
                     const pubId = reader.publicationIdentifier;
-                    yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locator));
+                    yield* callTyped(() => diMainGet("publication-storage").write(pubId, "locator", locator));
                 }
 
             },
@@ -181,7 +181,7 @@ export function saga() {
 
                 if (data) {
                     // finally save locator next to publication storage vault
-                    yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", data));
+                    yield* callTyped(() => diMainGet("publication-storage").write(pubId, "locator", data));
                 }
 
             },

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 import * as fs from "fs";
-import { diMainGet, patchFilePath, readerConfigPath, stateFilePath } from "readium-desktop/main/di";
+import { diMainGet, patchFilePath, stateFilePath } from "readium-desktop/main/di";
 import { PersistRootState, RootState } from "readium-desktop/main/redux/states";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { call, debounce, all } from "redux-saga/effects";
@@ -19,13 +19,10 @@ import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLe
 import { readerActions } from "readium-desktop/common/redux/actions";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
-import * as path from "path";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 
 const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
 const LOCATOR_DEBOUNCE_TIME = 10 * 1000; // 10 secs
-
-const locatorFileHandleMap: Map<string, fs.promises.FileHandle> = new Map();
 
 // Logger
 const filename_ = "readium-desktop:main:saga:persist";
@@ -73,17 +70,6 @@ export function* needToPersistFinalState() {
     const nextState = yield* selectTyped((store: RootState) => store);
     yield call(() => persistStateToFs(nextState));
     yield call(() => needToPersistPatch());
-
-    yield* callTyped(async () => {
-        for (const fileHandle of locatorFileHandleMap.values()) {
-            try {
-                await fileHandle.close();
-            } catch (e) {
-                debug(e);
-            }
-        }
-        locatorFileHandleMap.clear(); // thorium is closing
-    });
 }
 
 export function* needToPersistPatch() {
@@ -113,28 +99,6 @@ export function* needToPersistPatch() {
 
 }
 
-function* persistLocatorInReaderConfigDirectory(action: readerActions.setLocator.TAction) {
-    const locator = action.payload;
-    const sender = action.sender as EventPayload["sender"];
-
-    if (sender.type !== SenderType.Renderer) {
-        debug("sender is not renderer !!!");
-        return ;
-    }
-
-    const locatorSerialize = JSON.stringify(locator, null, 4);
-
-    const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
-    const pubId = reader.publicationIdentifier;
-    const locatorDirPath = path.join(readerConfigPath, pubId);
-    const locatorFilePath = path.join(locatorDirPath, "locator.json");
-
-    yield* callTyped(() => locatorFileHandleMap.get(pubId).writeFile(locatorSerialize, { encoding: "utf-8" }));
-    yield* callTyped(() => locatorFileHandleMap.get(pubId).sync());
-    debug("LOCATOR written to", locatorFilePath);
-
-}
-
 export function saga() {
     return all([
         debounce(
@@ -144,7 +108,20 @@ export function saga() {
         ),
         takeSpawnLeading(
             readerActions.setLocator.ID,
-            persistLocatorInReaderConfigDirectory,
+            function* (action: readerActions.setLocator.TAction) {
+                const locator = action.payload;
+                const sender = action.sender as EventPayload["sender"];
+
+                if (sender.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
+                const pubId = reader.publicationIdentifier;
+                
+                const locatorSerialize = (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(locator, null, 4) : JSON.stringify(locator);
+                yield* callTyped(() => diMainGet("publication-data").write(pubId, "locator", locatorSerialize));
+            },
             (e) => debug(e),
         ),
         debounce(
@@ -166,42 +143,18 @@ export function saga() {
                 yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locatorSerialize));
             },
         ),
-        takeSpawnEvery(
-            winActions.reader.openRequest.ID,
-            function* (action: winActions.reader.openRequest.TAction) {
-                const { publicationIdentifier: pubId } = action.payload;
+        // takeSpawnEvery(
+        //     winActions.reader.openRequest.ID,
+        //     function* (action: winActions.reader.openRequest.TAction) {
+        //         const { publicationIdentifier: pubId } = action.payload;
 
-                const locatorDirPath = path.join(readerConfigPath, pubId);
-                const locatorFilePath = path.join(locatorDirPath, "locator.json");
+        //         // not needed // read/write lazy open
+        //         // yield* callTyped(() => diMainGet("publication-data").open(pubId, "locator"));
 
-                while (1) {
-                    try {
-                        if (!locatorFileHandleMap.has(pubId)) {
-                            locatorFileHandleMap.set(pubId, yield* callTyped(() => fs.promises.open(locatorFilePath, "w+", 0o600)));
-                            debug("locator file open and ready to be written: ", locatorFilePath);
-
-                            debug("There are currently", locatorFileHandleMap.size, "open locator file(s)");
-                            debug([...locatorFileHandleMap.keys()]);
-                        }
-                    } catch (e: any) {
-                        debug(JSON.stringify(e, null, 4));
-                        debug("Error to persist locator in reader config directory");
-                        if (e.code === "ENOENT") {
-                            try {
-                                debug("create directory", locatorDirPath);
-                                yield* callTyped(() => fs.promises.mkdir(locatorDirPath, { recursive: false, mode: 0o600 }));
-                                continue;
-                            } catch (e) {
-                                debug(e);
-                            }
-                        }
-                    }
-                    break; // important
-                }
-            },
-            // (e) => error(filename_ + ":createReaderWindow", e),
-            (e) => debug(e),
-        ),
+        //     },
+        //     // (e) => error(filename_ + ":createReaderWindow", e),
+        //     (e) => debug(e),
+        // ),
         // takeSpawnEvery(
         //     winActions.reader.openSucess.ID,
         //     winOpen,
@@ -212,23 +165,24 @@ export function saga() {
             function* (action: winActions.reader.closed.TAction) {
                 const { identifier } = action.payload;
 
-                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[identifier]);
-                const pubId = reader.publicationIdentifier;
-
-                if (locatorFileHandleMap.has(pubId)) {
-                    const fd = locatorFileHandleMap.get(pubId);
-                    locatorFileHandleMap.delete(pubId);
-                    try {
-                        yield* callTyped(() => fd.close());
-                    } catch (e) {
-                        debug(e);
-                    }
-                    debug("locator file closed and deleted for", pubId);
+                const readers = yield* selectTyped((state: RootState) => state.win.session.reader);
+                if (!readers[identifier]) {
+                    debug("ERROR NO READER BUT CLOSE ACTION RECEIVED (race condition!?)");
+                    return ;
+                }
+                const pubId = readers[identifier].publicationIdentifier;
+                const readersPubId = Object.values(readers).filter((v) => v.publicationIdentifier === pubId);
+                if (readersPubId.length > 1) {
+                    return ;
                 }
 
-                const locator = reader.reduxState.locator;
-                const locatorSerialize = (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(locator, null, 4) : JSON.stringify(locator);
-                yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", locatorSerialize));
+                const data = diMainGet("publication-data").getDataRead(pubId, "locator");
+                yield* callTyped(() => diMainGet("publication-data").close(pubId));
+
+                if (data) {
+                    // finally save locator next to publication storage vault
+                    yield* callTyped(() => diMainGet("publication-storage").writeData(pubId, "locator", data));
+                }
 
             },
             // (e) => error(filename_ + ":winClose", e),

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -20,7 +20,6 @@ import { readerActions } from "readium-desktop/common/redux/actions";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
-import { AnyJson } from "readium-desktop/typings/json";
 
 const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
 const LOCATOR_DEBOUNCE_TIME = 10 * 1000; // 10 secs
@@ -120,8 +119,7 @@ export function saga() {
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 const pubId = reader.publicationIdentifier;
                 
-                const locatorSerialize = (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(locator, null, 4) : JSON.stringify(locator);
-                yield* callTyped(() => diMainGet("publication-data").write(pubId, "locator", locatorSerialize));
+                yield* callTyped(() => diMainGet("publication-data").write(pubId, "locator", locator));
             },
             (e) => debug(e),
         ),
@@ -130,7 +128,7 @@ export function saga() {
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
 
-                const locator = action.payload as unknown as AnyJson;
+                const locator = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
 
                 if (sender.type !== SenderType.Renderer) {

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -109,7 +109,7 @@ export function saga() {
         takeSpawnLeading(
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
-                const locator = action.payload;
+                const jsonObj = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
 
                 if (sender.type !== SenderType.Renderer) {
@@ -118,8 +118,8 @@ export function saga() {
                 }
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 const pubId = reader.publicationIdentifier;
-                
-                yield* callTyped(() => diMainGet("publication-data").write(pubId, "locator", locator));
+
+                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "locator", jsonObj));
             },
             (e) => debug(e),
         ),
@@ -128,7 +128,7 @@ export function saga() {
             readerActions.setLocator.ID,
             function* (action: readerActions.setLocator.TAction) {
 
-                const locator = action.payload as unknown as object;
+                const jsonObj = action.payload as unknown as object;
                 const sender = action.sender as EventPayload["sender"];
 
                 if (sender.type !== SenderType.Renderer) {
@@ -138,7 +138,7 @@ export function saga() {
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[sender.identifier]);
                 if (reader) {
                     const pubId = reader.publicationIdentifier;
-                    yield* callTyped(() => diMainGet("publication-storage").write(pubId, "locator", locator));
+                    yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "locator", jsonObj));
                 }
 
             },
@@ -176,12 +176,12 @@ export function saga() {
                     return ;
                 }
 
-                const data = diMainGet("publication-data").getDataRead(pubId, "locator");
+                const jsonObj = diMainGet("publication-data").getJsonObj(pubId, "locator");
                 yield* callTyped(() => diMainGet("publication-data").close(pubId));
 
-                if (data) {
+                if (jsonObj) {
                     // finally save locator next to publication storage vault
-                    yield* callTyped(() => diMainGet("publication-storage").write(pubId, "locator", data));
+                    yield* callTyped(() => diMainGet("publication-storage").writeJsonObj(pubId, "locator", jsonObj));
                 }
 
             },

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -30,6 +30,7 @@ import { TAnnotationState } from "readium-desktop/common/redux/states/renderer/a
 import { sqliteInitTableNote, sqliteTableNoteDeleteWherePubId, sqliteTableNoteInsert, sqliteTableSelectLastModifiedDateWherePubId } from "readium-desktop/main/db/sqlite/note";
 import { sqliteInitialisation } from "readium-desktop/main/db/sqlite";
 import { IReaderStateReaderSession } from "readium-desktop/common/redux/states/renderer/readerRootState";
+import { AnyJson } from "readium-desktop/typings/json";
 
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;
@@ -480,7 +481,7 @@ export async function initStore()
                 const publicationStorage = diMainGet("publication-storage");
                 if (state?.reduxState?.locator) {
                     debug("\t => locator");
-                    const data = JSON.stringify(state.reduxState.locator);
+                    const data = state.reduxState.locator as unknown as AnyJson;
                     try {
                         await publicationData.write(pubId, "locator", data);
                     } catch (e) {
@@ -494,7 +495,7 @@ export async function initStore()
                 }
                 if (state?.reduxState?.config) {
                     debug("\t => config");
-                    const data = JSON.stringify(state.reduxState.config);
+                    const data = state.reduxState.config as unknown as AnyJson;
                     try {
                         await publicationData.write(pubId, "config", data);
                     } catch (e) {
@@ -508,7 +509,7 @@ export async function initStore()
                 }
                 if (state?.reduxState?.disableRTLFlip) {
                     debug("\t => disableRTLFlip");
-                    const data = JSON.stringify(state.reduxState.disableRTLFlip);
+                    const data = state.reduxState.disableRTLFlip as unknown as AnyJson;
                     try {
                         await publicationData.write(pubId, "disableRTLFlip", data);
                     } catch (e) {
@@ -522,7 +523,7 @@ export async function initStore()
                 }
                 if (state?.windowBound) {
                     debug("\t => bound");
-                    const data = JSON.stringify(state.windowBound);
+                    const data = state.windowBound as unknown as AnyJson;
                     try {
                         await publicationData.write(pubId, "bound", data);
                     } catch (e) {
@@ -561,21 +562,21 @@ export async function initStore()
             debug("PubID", pubId);
             preloadedState.win.registry.reader[pubId] = {} as any;
 
-            const locatorData = await tryCatch(async () => await publicationData.read(pubId, "locator"), _dbgn) || "";
-            const configData = await tryCatch(async () => await publicationData.read(pubId, "config"), _dbgn) || "";
-            const disableRTLFlipData = await tryCatch(async () => await publicationData.read(pubId, "disableRTLFlip"), _dbgn) || "";
+            const locator = await tryCatch(async () => await publicationData.read(pubId, "locator"), _dbgn) as unknown as any;
+            const config = await tryCatch(async () => await publicationData.read(pubId, "config"), _dbgn) as unknown as any;
+            const disableRTLFlip = await tryCatch(async () => await publicationData.read(pubId, "disableRTLFlip"), _dbgn) as unknown as any;
 
             preloadedState.win.registry.reader[pubId].reduxState = {
-                locator: locatorData ? JSON.parse(locatorData): undefined,
-                config: configData ? JSON.parse(configData) : undefined,
-                disableRTLFlip: disableRTLFlipData ? JSON.parse(disableRTLFlipData) : undefined,
+                locator,
+                config,
+                disableRTLFlip,
             };
 
-            const boundData =await tryCatch(async () => await publicationData.read(pubId, "bound"), _dbgn) || "";
+            const bound = await tryCatch(async () => await publicationData.read(pubId, "bound"), _dbgn);
 
-            preloadedState.win.registry.reader[pubId].windowBound = boundData ? JSON.parse(boundData) : undefined;
+            preloadedState.win.registry.reader[pubId].windowBound = bound as unknown as Electron.Rectangle;
 
-            debug(`\t => reduxState loaded with ${!!locatorData}, ${!!configData}, ${!disableRTLFlipData}, ${!!boundData}`);
+            debug(`\t => reduxState loaded with ${!!locator}, ${!!config}, ${!disableRTLFlip}, ${!!bound}`);
             try {
                 await publicationData.close(pubId);
             } catch (e) {

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -9,7 +9,7 @@ import debug_ from "debug";
 import * as fs from "fs";
 import { deepStrictEqual, ok } from "readium-desktop/common/utils/assert";
 import {
-    backupStateFilePathFn, memoryLoggerFilename, patchFilePath, runtimeStateFilePath, stateFilePath,
+    backupStateFilePathFn, diMainGet, memoryLoggerFilename, patchFilePath, runtimeStateFilePath, stateFilePath,
 } from "readium-desktop/main/di";
 import { reduxSyncMiddleware } from "readium-desktop/main/redux/middleware/sync";
 import { rootReducer } from "readium-desktop/main/redux/reducers";
@@ -34,7 +34,8 @@ import { IReaderStateReaderSession } from "readium-desktop/common/redux/states/r
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;
 
-const debugStdout = debug_("readium-desktop:main:store:memory");
+const _dbgn = "readium-desktop:main:store:memory";
+const debugStdout = debug_(_dbgn);
 // Logger
 const debug = (...a: Parameters<debug_.Debugger>) => {
     debugStdout(...a);
@@ -251,8 +252,14 @@ export async function initStore()
     sqliteInitTableNote();
 
     if (preloadedState.win?.registry?.reader) {
-        for (const id in preloadedState.win.registry.reader) {
-            const state = preloadedState.win.registry.reader[id];
+
+        let pubIds: string[];
+        if (preloadedState?.publication?.db) {
+            pubIds = Object.keys(preloadedState.publication.db); 
+        }
+
+        for (const pubId in preloadedState.win.registry.reader) {
+            const state = preloadedState.win.registry.reader[pubId];
 
             if (state?.reduxState?.locator) {
                 const locatorExtended = state.reduxState.locator as LocatorExtended;
@@ -359,7 +366,7 @@ export async function initStore()
                 } else if ((state.reduxState as Partial<IReaderStateReaderSession>).note?.length) {
 
 
-                    debug("We are checking notes (", (state.reduxState as Partial<IReaderStateReaderSession>).note?.length, "); json to sqlite migration for pubicationId=", id);
+                    debug("We are checking notes (", (state.reduxState as Partial<IReaderStateReaderSession>).note?.length, "); json to sqlite migration for pubicationId=", pubId);
 
                     const lastNoteModifiedEpochFromJson = (state.reduxState as Partial<IReaderStateReaderSession>).note.reduce((acc, cv) => {
 
@@ -371,7 +378,7 @@ export async function initStore()
 
                     }, 0);
 
-                    const lastNotesModifiedEpochFromSqlite = sqliteTableSelectLastModifiedDateWherePubId(id);
+                    const lastNotesModifiedEpochFromSqlite = sqliteTableSelectLastModifiedDateWherePubId(pubId);
 
 
                     debug("lastNoteModifiedEpochFromJson=", lastNoteModifiedEpochFromJson, "lastNotesModifiedEpochFromSqlite=", lastNotesModifiedEpochFromSqlite);
@@ -380,14 +387,14 @@ export async function initStore()
                         debug("SQLITE WON, no migration");
                     } else {
                         debug("JSON WON, migration needed!!");
-                        if (sqliteTableNoteDeleteWherePubId(id)) {
-                            if (sqliteTableNoteInsert(id, (state.reduxState as any).note)) {
-                                debug("SQLITE NOTE MIGRATION DONE for this publicationId=", id);
+                        if (sqliteTableNoteDeleteWherePubId(pubId)) {
+                            if (sqliteTableNoteInsert(pubId, (state.reduxState as any).note)) {
+                                debug("SQLITE NOTE MIGRATION DONE for this publicationId=", pubId);
                             } else {
-                                debug("ERROR on SQLITE NOTE MIGRATION, publicationId=", id);
+                                debug("ERROR on SQLITE NOTE MIGRATION, publicationId=", pubId);
                             }
                         } else {
-                            debug("ERROR cannot delete note attached to pubId=", id);
+                            debug("ERROR cannot delete note attached to pubId=", pubId);
                         }
                     }
                 }
@@ -422,7 +429,7 @@ export async function initStore()
                         group: "bookmark",
                     };
 
-                    sqliteTableNoteInsert(id, [ note ]);
+                    sqliteTableNoteInsert(pubId, [ note ]);
                 }
                 (state.reduxState as any).bookmark = undefined;
 
@@ -453,7 +460,7 @@ export async function initStore()
                         group: "annotation",
                     };
 
-                    sqliteTableNoteInsert(id, [ note ]);
+                    sqliteTableNoteInsert(pubId, [ note ]);
                 }
                 (state.reduxState as any).annotation = undefined;
 
@@ -465,7 +472,115 @@ export async function initStore()
                 state.reduxState.noteTotalCount.state = noteTotalCount;
             }
 
+            if (pubIds.includes(pubId)) {
+                debug("MIGRATION TO Publication-data file storage ->", pubId);
 
+                // TODO: parallel !? libuv = 4 threads
+                const publicationData = diMainGet("publication-data");
+                const publicationStorage = diMainGet("publication-storage");
+                if (state?.reduxState?.locator) {
+                    debug("\t => locator");
+                    const data = JSON.stringify(state.reduxState.locator);
+                    try {
+                        await publicationData.write(pubId, "locator", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                    try {
+                        await publicationStorage.writeData(pubId, "locator", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
+                if (state?.reduxState?.config) {
+                    debug("\t => config");
+                    const data = JSON.stringify(state.reduxState.config);
+                    try {
+                        await publicationData.write(pubId, "config", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                    try {
+                        await publicationStorage.writeData(pubId, "config", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
+                if (state?.reduxState?.disableRTLFlip) {
+                    debug("\t => disableRTLFlip");
+                    const data = JSON.stringify(state.reduxState.disableRTLFlip);
+                    try {
+                        await publicationData.write(pubId, "disableRTLFlip", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                    try {
+                        await publicationStorage.writeData(pubId, "disableRTLFlip", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
+                if (state?.windowBound) {
+                    debug("\t => bound");
+                    const data = JSON.stringify(state.windowBound);
+                    try {
+                        await publicationData.write(pubId, "bound", data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
+    
+                try {
+                    await publicationData.close(pubId);
+                } catch (e) {
+                    debug(e);
+                }
+            } else {
+                debug("MIGRATION TO Publication-data file storage ->", pubId, "IMPOSSIBLE BECAUSE PUBID NOT FOUND IN publication.db !!!");
+            }
+        }
+    } else {
+        
+        if (!preloadedState.win) { 
+            preloadedState.win = {} as any;
+        }
+        if (!preloadedState.win.registry) {
+            preloadedState.win.registry = {} as any;
+        }
+        if (!preloadedState.win.registry.reader) {
+            preloadedState.win.registry.reader = {};
+        }
+
+        debug("redux state hydration from publication-data (state.js) migrated and win.registry.reader not saved");
+
+        // list publication db
+        // read publication-data files and hydrate redux state
+        const publicationData = diMainGet("publication-data");
+        const pubIds = await publicationData.listPublication();
+        for (const pubId of pubIds) {
+            debug("PubID", pubId);
+            preloadedState.win.registry.reader[pubId] = {} as any;
+
+            const locatorData = await tryCatch(async () => await publicationData.read(pubId, "locator"), _dbgn) || "";
+            const configData = await tryCatch(async () => await publicationData.read(pubId, "config"), _dbgn) || "";
+            const disableRTLFlipData = await tryCatch(async () => await publicationData.read(pubId, "disableRTLFlip"), _dbgn) || "";
+
+            preloadedState.win.registry.reader[pubId].reduxState = {
+                locator: locatorData ? JSON.parse(locatorData): undefined,
+                config: configData ? JSON.parse(configData) : undefined,
+                disableRTLFlip: disableRTLFlipData ? JSON.parse(disableRTLFlipData) : undefined,
+            };
+
+            const boundData =await tryCatch(async () => await publicationData.read(pubId, "bound"), _dbgn) || "";
+
+            preloadedState.win.registry.reader[pubId].windowBound = boundData ? JSON.parse(boundData) : undefined;
+
+            debug(`\t => reduxState loaded with ${!!locatorData}, ${!!configData}, ${!disableRTLFlipData}, ${!!boundData}`);
+            try {
+                await publicationData.close(pubId);
+            } catch (e) {
+                debug(e);
+            }
         }
     }
 

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -23,13 +23,16 @@ import { applyPatch } from "rfc6902";
 import { reduxPersistMiddleware } from "../middleware/persistence";
 import { readerConfigInitialState } from "readium-desktop/common/redux/states/reader";
 import { LocatorExtended } from "@r2-navigator-js/electron/renderer";
-import { minimizeLocatorExtended } from "readium-desktop/common/redux/states/locatorInitialState";
+import { MiniLocatorExtended, minimizeLocatorExtended } from "readium-desktop/common/redux/states/locatorInitialState";
 import { EDrawType, INoteState, NOTE_DEFAULT_COLOR_OBJ, TDrawType } from "readium-desktop/common/redux/states/renderer/note";
 import { TBookmarkState } from "readium-desktop/common/redux/states/bookmark";
 import { TAnnotationState } from "readium-desktop/common/redux/states/renderer/annotation";
 import { sqliteInitTableNote, sqliteTableNoteDeleteWherePubId, sqliteTableNoteInsert, sqliteTableSelectLastModifiedDateWherePubId } from "readium-desktop/main/db/sqlite/note";
 import { sqliteInitialisation } from "readium-desktop/main/db/sqlite";
 import { IReaderStateReaderSession } from "readium-desktop/common/redux/states/renderer/readerRootState";
+import { IWinRegistryReaderState } from "readium-desktop/main/redux/states/win/registry/reader";
+import { ReaderConfig } from "readium-desktop/common/models/reader";
+import { IRTLFlipState } from "readium-desktop/common/redux/states/renderer/rtlFlip";
 
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;
@@ -255,7 +258,7 @@ export async function initStore()
 
         let pubIds: string[];
         if (preloadedState?.publication?.db) {
-            pubIds = Object.keys(preloadedState.publication.db); 
+            pubIds = Object.keys(preloadedState.publication.db);
         }
 
         for (const pubId in preloadedState.win.registry.reader) {
@@ -480,56 +483,56 @@ export async function initStore()
                 const publicationStorage = diMainGet("publication-storage");
                 if (state?.reduxState?.locator) {
                     debug("\t => locator");
-                    const data = state.reduxState.locator as unknown as object;
+                    const jsonObj = state.reduxState.locator as unknown as object;
                     try {
-                        await publicationData.write(pubId, "locator", data);
+                        await publicationData.writeJsonObj(pubId, "locator", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                     try {
-                        await publicationStorage.write(pubId, "locator", data);
+                        await publicationStorage.writeJsonObj(pubId, "locator", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                 }
                 if (state?.reduxState?.config) {
                     debug("\t => config");
-                    const data = state.reduxState.config as unknown as object;
+                    const jsonObj = state.reduxState.config as unknown as object;
                     try {
-                        await publicationData.write(pubId, "config", data);
+                        await publicationData.writeJsonObj(pubId, "config", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                     try {
-                        await publicationStorage.write(pubId, "config", data);
+                        await publicationStorage.writeJsonObj(pubId, "config", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                 }
                 if (state?.reduxState?.disableRTLFlip) {
                     debug("\t => disableRTLFlip");
-                    const data = state.reduxState.disableRTLFlip as unknown as object;
+                    const jsonObj = state.reduxState.disableRTLFlip as unknown as object;
                     try {
-                        await publicationData.write(pubId, "disableRTLFlip", data);
+                        await publicationData.writeJsonObj(pubId, "disableRTLFlip", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                     try {
-                        await publicationStorage.write(pubId, "disableRTLFlip", data);
+                        await publicationStorage.writeJsonObj(pubId, "disableRTLFlip", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                 }
                 if (state?.windowBound) {
                     debug("\t => bound");
-                    const data = state.windowBound as unknown as object;
+                    const jsonObj = state.windowBound as unknown as object;
                     try {
-                        await publicationData.write(pubId, "bound", data);
+                        await publicationData.writeJsonObj(pubId, "bound", jsonObj);
                     } catch (e) {
                         debug(e);
                     }
                 }
-    
+
                 try {
                     await publicationData.close(pubId);
                 } catch (e) {
@@ -540,8 +543,8 @@ export async function initStore()
             }
         }
     } else {
-        
-        if (!preloadedState.win) { 
+
+        if (!preloadedState.win) {
             preloadedState.win = {} as any;
         }
         if (!preloadedState.win.registry) {
@@ -559,11 +562,16 @@ export async function initStore()
         const pubIds = await publicationData.listPublication();
         for (const pubId of pubIds) {
             debug("PubID", pubId);
-            preloadedState.win.registry.reader[pubId] = {} as any;
+            preloadedState.win.registry.reader[pubId] = {} as IWinRegistryReaderState;
 
-            const locator = await tryCatch(async () => await publicationData.read(pubId, "locator"), _dbgn) as unknown as any;
-            const config = await tryCatch(async () => await publicationData.read(pubId, "config"), _dbgn) as unknown as any;
-            const disableRTLFlip = await tryCatch(async () => await publicationData.read(pubId, "disableRTLFlip"), _dbgn) as unknown as any;
+            // can be undefined!
+            const locator = await tryCatch(async () => await publicationData.readJsonObj(pubId, "locator"), _dbgn) as unknown as MiniLocatorExtended;
+
+            // can be undefined!
+            const config = await tryCatch(async () => await publicationData.readJsonObj(pubId, "config"), _dbgn) as unknown as ReaderConfig;
+
+            // can be undefined!
+            const disableRTLFlip = await tryCatch(async () => await publicationData.readJsonObj(pubId, "disableRTLFlip"), _dbgn) as unknown as IRTLFlipState;
 
             preloadedState.win.registry.reader[pubId].reduxState = {
                 locator,
@@ -571,7 +579,8 @@ export async function initStore()
                 disableRTLFlip,
             };
 
-            const bound = await tryCatch(async () => await publicationData.read(pubId, "bound"), _dbgn);
+            // can be undefined!
+            const bound = await tryCatch(async () => await publicationData.readJsonObj(pubId, "bound"), _dbgn);
 
             preloadedState.win.registry.reader[pubId].windowBound = bound as unknown as Electron.Rectangle;
 

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -30,7 +30,6 @@ import { TAnnotationState } from "readium-desktop/common/redux/states/renderer/a
 import { sqliteInitTableNote, sqliteTableNoteDeleteWherePubId, sqliteTableNoteInsert, sqliteTableSelectLastModifiedDateWherePubId } from "readium-desktop/main/db/sqlite/note";
 import { sqliteInitialisation } from "readium-desktop/main/db/sqlite";
 import { IReaderStateReaderSession } from "readium-desktop/common/redux/states/renderer/readerRootState";
-import { AnyJson } from "readium-desktop/typings/json";
 
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;
@@ -481,7 +480,7 @@ export async function initStore()
                 const publicationStorage = diMainGet("publication-storage");
                 if (state?.reduxState?.locator) {
                     debug("\t => locator");
-                    const data = state.reduxState.locator as unknown as AnyJson;
+                    const data = state.reduxState.locator as unknown as object;
                     try {
                         await publicationData.write(pubId, "locator", data);
                     } catch (e) {
@@ -495,7 +494,7 @@ export async function initStore()
                 }
                 if (state?.reduxState?.config) {
                     debug("\t => config");
-                    const data = state.reduxState.config as unknown as AnyJson;
+                    const data = state.reduxState.config as unknown as object;
                     try {
                         await publicationData.write(pubId, "config", data);
                     } catch (e) {
@@ -509,7 +508,7 @@ export async function initStore()
                 }
                 if (state?.reduxState?.disableRTLFlip) {
                     debug("\t => disableRTLFlip");
-                    const data = state.reduxState.disableRTLFlip as unknown as AnyJson;
+                    const data = state.reduxState.disableRTLFlip as unknown as object;
                     try {
                         await publicationData.write(pubId, "disableRTLFlip", data);
                     } catch (e) {
@@ -523,7 +522,7 @@ export async function initStore()
                 }
                 if (state?.windowBound) {
                     debug("\t => bound");
-                    const data = state.windowBound as unknown as AnyJson;
+                    const data = state.windowBound as unknown as object;
                     try {
                         await publicationData.write(pubId, "bound", data);
                     } catch (e) {

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -487,7 +487,7 @@ export async function initStore()
                         debug(e);
                     }
                     try {
-                        await publicationStorage.writeData(pubId, "locator", data);
+                        await publicationStorage.write(pubId, "locator", data);
                     } catch (e) {
                         debug(e);
                     }
@@ -501,7 +501,7 @@ export async function initStore()
                         debug(e);
                     }
                     try {
-                        await publicationStorage.writeData(pubId, "config", data);
+                        await publicationStorage.write(pubId, "config", data);
                     } catch (e) {
                         debug(e);
                     }
@@ -515,7 +515,7 @@ export async function initStore()
                         debug(e);
                     }
                     try {
-                        await publicationStorage.writeData(pubId, "disableRTLFlip", data);
+                        await publicationStorage.write(pubId, "disableRTLFlip", data);
                     } catch (e) {
                         debug(e);
                     }

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -96,7 +96,7 @@ export class PublicationData {
             debug("Publication-data destroy() done");
             debug(res);
         } catch (e) {
-            debug(e);
+            debug(`${e}`);
         }
     }
 
@@ -128,7 +128,7 @@ export class PublicationData {
                     try {
                         await fileHandle.close();
                     } catch (e) {
-                        debug(e);
+                        debug(`${e}`);
                     }
                     return; // already open
                 }
@@ -147,26 +147,28 @@ export class PublicationData {
                     try {
                         const jsonStr = await fileHandle.readFile({ encoding: "utf-8" });
                         try {
-                            const jsonObj = JSON.parse(jsonStr);
-                            file.jsonObj = jsonObj;
+                            if (jsonStr) {
+                                const jsonObj = JSON.parse(jsonStr);
+                                file.jsonObj = jsonObj;
+                            }
                         } catch (e) {
-                            debug(e);
+                            debug(`${e}`);
                         }
                         debug(`${type} file opened on ${pubId}`);
                     } catch (e) {
-                        debug(e);
+                        debug(`${e}`);
                     }
                 });
                 await file.mutex;
             } catch (e) {
-                debug(e);
+                debug(`${e}`);
                 if (e.code === "ENOENT") {
                     try {
                         debug("create directory", publicationPath);
                         await fs.promises.mkdir(publicationPath /* DEFAULTS: , { recursive: false, mode: 0o777 } */);
                         continue;
                     } catch (e) {
-                        debug(e);
+                        debug(`${e}`);
                     }
                 }
             }
@@ -227,15 +229,17 @@ export class PublicationData {
                 // flush before read
                 await file.fileHandle.sync();
             } catch (e) {
-                debug(e);
+                debug(`${e}`);
             }
             try {
                 const jsonStr = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
                 try {
-                    const jsonObj = JSON.parse(jsonStr);
-                    file.jsonObj = jsonObj;
+                    if (jsonStr) {
+                        const jsonObj = JSON.parse(jsonStr);
+                        file.jsonObj = jsonObj;
+                    }
                 } catch (e) {
-                    debug(e);
+                    debug(`${e}`);
                     try {
                         await this.writeJsonObj(pubId, type, file.jsonObj);
                     } catch (e) {
@@ -244,7 +248,7 @@ export class PublicationData {
                 }
 
             } catch (e) {
-                debug(e);
+                debug(`${e}`);
             }
         });
         await file.mutex;
@@ -275,7 +279,7 @@ export class PublicationData {
                 }
                 await file.fileHandle.close();
             } catch (e) {
-                debug(e);
+                debug(`${e}`);
             }
         }
 

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -144,7 +144,7 @@ export class PublicationData {
                 if (e.code === "ENOENT") {
                     try {
                         debug("create directory", publicationPath);
-                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o666 });
+                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o777 });
                         continue;
                     } catch (e) {
                         debug(e);

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -125,7 +125,7 @@ export class PublicationData {
                 };
                 this.files.push(file);
 
-                await file.mutex.then(async () => {
+                file.mutex = file.mutex.then(async () => {
                     try {
                         const dataStr = await fileHandle.readFile({ encoding: "utf-8" });
                         try {
@@ -139,6 +139,7 @@ export class PublicationData {
                         debug(e);
                     }
                 });
+                await file.mutex;
             } catch (e) {
                 debug(e);
                 if (e.code === "ENOENT") {
@@ -171,7 +172,7 @@ export class PublicationData {
             }
         }
 
-        return await file.mutex.then(async () => {
+        file.mutex = file.mutex.then(async () => {
             const dataStr = jsonstr(data);
             try {
                 await file.fileHandle.truncate(dataStr.length);
@@ -184,6 +185,7 @@ export class PublicationData {
             }
 
         });
+        await file.mutex;
     }
 
     public async read(pubId: string, type: TFileType): Promise<object | undefined> {
@@ -202,7 +204,7 @@ export class PublicationData {
             }
         }
 
-        return await file.mutex.then(async () => {
+        file.mutex = file.mutex.then(async () => {
             try {
                 // flush before read
                 await file.fileHandle.sync();
@@ -213,9 +215,6 @@ export class PublicationData {
                 const dataStr = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
                 try {
                     const data = JSON.parse(dataStr);
-                    if (data === file.data) {
-                        return file.data;
-                    }
                     file.data = data;
                 } catch (e) {
                     debug(e);
@@ -229,8 +228,9 @@ export class PublicationData {
             } catch (e) {
                 debug(e);
             }
-            return file.data;
         });
+        await file.mutex;
+        return file.data;
     }
 
     public async close(pubId: string) {

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -73,7 +73,7 @@ export class PublicationData {
         this.files = [];
         const filePromises = [];
         for (const file of files) {
-            filePromises.push(async () => {
+            filePromises.push((async () => {
                 try {
                     await Promise.race([file.mutex, new Promise<void>((_resolve, reject) => setTimeout(() => reject("TIMEOUT"), 100))]);
                 } catch (e) {
@@ -89,7 +89,7 @@ export class PublicationData {
                 } catch (e) {
                     debug(e);
                 }
-            });
+            })());
         }
         try {
             const res = await Promise.allSettled(filePromises);

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -107,6 +107,15 @@ export class PublicationData {
         for (let step = 0; step < 2; step++) {
             try {
                 const fileHandle = await fs.promises.open(filePath, fs.constants.O_RDWR | fs.constants.O_CREAT, 0o644);
+                const file_ = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+                if (file_) {
+                    try {
+                        await fileHandle.close();
+                    } catch (e) {
+                        debug(e);
+                    }
+                    return; // already open
+                }
                 const file = {
                     pubId,
                     type,

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -37,7 +37,7 @@ export class PublicationData {
      */
     private publicationConfigPath: string;
 
-    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: object, mutex: Promise<void>}>;
+    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: object | undefined, mutex: Promise<void>}>;
 
     private filterFilesByType = (t: TFileType) => this.files.filter(({type}) => type === t);
 
@@ -115,20 +115,25 @@ export class PublicationData {
                     }
                     return; // already open
                 }
+                const data: object | undefined = undefined;
                 const file = {
                     pubId,
                     type,
                     fileHandle,
-                    data: "",
+                    data,
                     mutex: Promise.resolve(),
                 };
                 this.files.push(file);
 
                 await file.mutex.then(async () => {
                     try {
-                        const data = await fileHandle.readFile({ encoding: "utf-8" });
-                        file.data = data;
-                        debug("READ", data);
+                        const dataStr = await fileHandle.readFile({ encoding: "utf-8" });
+                        try {
+                            const data = JSON.parse(dataStr);
+                            file.data = data;
+                        } catch (e) {
+                            debug(e);
+                        }
                         debug(`${type} file opened on ${pubId}`);
                     } catch (e) {
                         debug(e);
@@ -172,6 +177,7 @@ export class PublicationData {
                 await file.fileHandle.truncate(dataStr.length);
                 await file.fileHandle.write(dataStr, 0, "utf-8");
 
+                // Wait the end of the write to set it as local reference
                 file.data = data;
             } catch (e) {
                 debug(e);

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -71,22 +71,32 @@ export class PublicationData {
         this.lock = true;
         const files = [...this.files];
         this.files = [];
+        const filePromises = [];
         for (const file of files) {
-            try {
-                await Promise.race([file.mutex, new Promise<void>((resolve) => setTimeout(resolve, 100))]);
-            } catch (e) {
-                debug(e);
-            }
-            try {
-                const p1 = (async () => {
-                    await file.fileHandle.sync();
-                    await file.fileHandle.close();
-                })();
-                const p2 = new Promise<void>((resolve) => setTimeout(resolve, 100));
-                await Promise.race([p1, p2]);
-            } catch (e) {
-                debug(e);
-            }
+            filePromises.push(async () => {
+                try {
+                    await Promise.race([file.mutex, new Promise<void>((_resolve, reject) => setTimeout(() => reject("TIMEOUT"), 100))]);
+                } catch (e) {
+                    debug(e);
+                }
+                try {
+                    const p1 = (async () => {
+                        await file.fileHandle.sync();
+                        await file.fileHandle.close();
+                    })();
+                    const p2 = new Promise<void>((_resolve, reject) => setTimeout(() => reject("TIMEOUT"), 100));
+                    await Promise.race([p1, p2]);
+                } catch (e) {
+                    debug(e);
+                }
+            });
+        }
+        try {
+            const res = await Promise.allSettled(filePromises);
+            debug("Publication-data destroy() done");
+            debug(res);
+        } catch (e) {
+            debug(e);
         }
     }
 

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -1,0 +1,224 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { injectable } from "inversify";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import debug_ from "debug";
+import { __ulimit_file } from "../di";
+
+const debug = debug_("readium-desktop:main/storage/pub-data");
+
+const rmrf = async (dir: string) => {
+    return await fs.promises.rm(dir, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });
+};
+
+const isUUIDv4 = (uuid: string) => /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/.test(uuid);
+const assertUUIDv4 = (uuid: string) => {
+    if (!isUUIDv4(uuid)) {
+        throw new Error("not an uuidv4 identifier !");
+    }
+};
+
+export type TFileType = "locator" | "config" | "disableRTLFlip" | "bound";
+
+@injectable()
+export class PublicationData {
+    private lock: boolean = false;
+    /**
+     * publication reader config directory from configDataFolderPath
+     * aka: %appData%\config-data-json{-dev}/publication/<uuid>/
+     */
+    private publicationConfigPath: string;
+
+    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: string, }>;
+
+    private filterFilesByType = (t: TFileType) => this.files.filter(({type}) => type === t);
+
+    private assertAndGetFileName = (type: TFileType) => {
+        const fileName = type === "locator" ? "locator.json" : type === "config" ? "config.json" : type === "disableRTLFlip" ? "disableRTLFlip.json" : type === "bound" ? "bound.json" : "";
+        if (!fileName) {
+            throw new Error("fileType not found");
+        }
+        return fileName;
+    };
+
+    public constructor(publicationConfigPath: string) {
+        this.publicationConfigPath = publicationConfigPath;
+        this.files = [];
+    }
+
+    public getDataRead(pubId: string, type: TFileType) {
+        assertUUIDv4(pubId);
+        const file = this.filterFilesByType(type).find((a) => a.pubId === pubId);
+        return file?.data;
+    }
+
+    public async destroy() {
+        this.lock = true;
+        const files = [...this.files];
+        this.files = [];
+        for (const file of files) {
+            try {
+                await file.fileHandle.close();
+            } catch (e) {
+                debug(e);
+            }
+        }
+    }
+
+    public async open(pubId: string, type: TFileType) {
+        if (this.lock) return ;
+        assertUUIDv4(pubId);
+
+        const fileName = this.assertAndGetFileName(type);
+
+        if (__ulimit_file && this.files.length > __ulimit_file - 50) {
+            debug(`BE CAREFUL, ULIMIT is soon reached, currently: ${this.files.length} files opened and ulimit is set to ${__ulimit_file}`);
+        }
+
+        debug(`${this.files.length} file(s) currently opened`);
+
+        const file = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+        if (file) {
+            return ; // already open
+        }
+
+        const publicationPath = path.join(this.publicationConfigPath, pubId);
+        const filePath = path.join(publicationPath, fileName);
+
+        for (let step = 0; step < 2; step++) {
+            try {
+                const fileHandle = await fs.promises.open(filePath, fs.constants.O_RDWR | fs.constants.O_CREAT, 0o644);
+                const file = {
+                    pubId,
+                    type,
+                    fileHandle,
+                    data: "",
+                };
+                this.files.push(file);
+                const data = await fileHandle.readFile({ encoding: "utf-8" });
+                file.data = data;
+                debug(`${type} file opened on ${pubId}`);
+            } catch (e) {
+                debug(e);
+                if (e.code === "ENOENT") {
+                    try {
+                        debug("create directory", publicationPath);
+                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o644 });
+                        continue;
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    public async write(pubId: string, type: TFileType, data: string) {
+        if (this.lock) return ;
+        assertUUIDv4(pubId);
+
+        this.assertAndGetFileName(type);
+
+        let file = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+        if (!file) {
+            await this.open(pubId, type);
+            file = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+            if (!file) {
+                debug("Error to write data to", type, "on", pubId);
+                return ;
+            }
+        }
+        
+        file.data = data;
+
+        try {
+            await fs.promises.writeFile(file.fileHandle, data, { encoding: "utf-8", flush: true });
+        } catch (e) {
+            debug(e);
+        }
+    }
+
+    public async read(pubId: string, type: TFileType): Promise<string | undefined> {
+        if (this.lock) return undefined;
+        assertUUIDv4(pubId);
+
+        this.assertAndGetFileName(type);
+
+        let file = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+        if (!file) {
+            await this.open(pubId, type);
+            file = this.filterFilesByType(type).find((a) => pubId === a.pubId);
+            if (!file) {
+                debug("Error to write data to", type, "on", pubId);
+                return undefined;
+            }
+        }
+
+        try {
+            const data = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
+            if (data === file.data) {
+                return file.data;
+            }
+            file.data = data;
+        } catch (e) {
+            debug(e);
+        }
+
+        return file.data;
+    }
+
+    public async close(pubId: string) {
+        if (this.lock) return ;
+
+        debug(`${this.files.length} file(s) currently opened before closing ${pubId}`);
+
+        const files = this.files.filter((a) => a.pubId === pubId);
+        this.files = this.files.filter((a) => a.pubId !== pubId);
+
+        debug(`${files.length} file(s) will be closed because attached to ${pubId}`);
+
+        for (const file of files) {
+            try {
+                await file.fileHandle.close();
+            } catch (e) {
+                debug(e);
+            }
+        }
+
+        debug(`${this.files.length} file(s) currently opened now`);
+    }
+
+    public async removePublication(pubId: string) {
+        assertUUIDv4(pubId);
+
+        await this.close(pubId);
+        const publicationPath = path.join(this.publicationConfigPath, pubId);
+        await rmrf(publicationPath);
+    }
+
+    public async listPublication() {
+
+        const files = await fs.promises.readdir(this.publicationConfigPath, { withFileTypes: true} );
+        debug("List publications from:", this.publicationConfigPath);
+        const pubIds = [];
+        for (const file of files) {
+            try {
+                debug(`\t${file.name} isDirectory=${file.isDirectory()} isFile=${file.isFile()}`);
+                if (isUUIDv4(file.name) && file.isDirectory()) {
+                    pubIds.push(file.name);
+                }
+            } catch {
+                // ignore
+            }
+        }
+
+        return pubIds;
+    }
+}

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -10,7 +10,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import debug_ from "debug";
 import { __ulimit_file } from "../di";
-import { AnyJson } from "readium-desktop/typings/json";
 
 const debug = debug_("readium-desktop:main/storage/pub-data");
 
@@ -38,7 +37,7 @@ export class PublicationData {
      */
     private publicationConfigPath: string;
 
-    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: AnyJson, mutex: Promise<void>}>;
+    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: object, mutex: Promise<void>}>;
 
     private filterFilesByType = (t: TFileType) => this.files.filter(({type}) => type === t);
 
@@ -106,7 +105,7 @@ export class PublicationData {
 
         for (let step = 0; step < 2; step++) {
             try {
-                const fileHandle = await fs.promises.open(filePath, fs.constants.O_RDWR | fs.constants.O_CREAT, 0o644);
+                const fileHandle = await fs.promises.open(filePath, fs.constants.O_RDWR | fs.constants.O_CREAT, 0o666);
                 const file_ = this.filterFilesByType(type).find((a) => pubId === a.pubId);
                 if (file_) {
                     try {
@@ -140,7 +139,7 @@ export class PublicationData {
                 if (e.code === "ENOENT") {
                     try {
                         debug("create directory", publicationPath);
-                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o644 });
+                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o666 });
                         continue;
                     } catch (e) {
                         debug(e);
@@ -151,7 +150,7 @@ export class PublicationData {
         }
     }
 
-    public async write(pubId: string, type: TFileType, data: AnyJson) {
+    public async write(pubId: string, type: TFileType, data: object) {
         if (this.lock) return ;
         assertUUIDv4(pubId);
 
@@ -169,10 +168,9 @@ export class PublicationData {
 
         return await file.mutex.then(async () => {
             const dataStr = jsonstr(data);
-            const dataBuffer = Buffer.from(dataStr, "utf-8");
             try {
-                await file.fileHandle.truncate(dataBuffer.byteLength);
-                await file.fileHandle.write(dataBuffer, 0, dataBuffer.length, 0);
+                await file.fileHandle.truncate(dataStr.length);
+                await file.fileHandle.write(dataStr, 0, "utf-8");
 
                 file.data = data;
             } catch (e) {
@@ -182,7 +180,7 @@ export class PublicationData {
         });
     }
 
-    public async read(pubId: string, type: TFileType): Promise<AnyJson | undefined> {
+    public async read(pubId: string, type: TFileType): Promise<object | undefined> {
         if (this.lock) return undefined;
         assertUUIDv4(pubId);
 

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -17,7 +17,7 @@ const rmrf = async (dir: string) => {
     return await fs.promises.rm(dir, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });
 };
 
-const jsonstr = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
+const jsonStringify = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
 
 const isUUIDv4 = (uuid: string) => /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/.test(uuid);
 const assertUUIDv4 = (uuid: string) => {
@@ -26,7 +26,14 @@ const assertUUIDv4 = (uuid: string) => {
     }
 };
 
-export type TFileType = "locator" | "config" | "disableRTLFlip" | "bound";
+export type TFileTypePubData = "locator" | "config" | "disableRTLFlip" | "bound";
+type TFileStructPubData = {
+    pubId: string,
+    type: TFileTypePubData,
+    fileHandle: fs.promises.FileHandle,
+    jsonObj: object | undefined,
+    mutex: Promise<void>,
+};
 
 @injectable()
 export class PublicationData {
@@ -37,11 +44,11 @@ export class PublicationData {
      */
     private publicationConfigPath: string;
 
-    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: object | undefined, mutex: Promise<void>}>;
+    private files: Array<TFileStructPubData>;
 
-    private filterFilesByType = (t: TFileType) => this.files.filter(({type}) => type === t);
+    private filterFilesByType = (t: TFileTypePubData) => this.files!.filter(({type}) => type === t);
 
-    private assertAndGetFileName = (type: TFileType) => {
+    private assertAndGetFileName = (type: TFileTypePubData) => {
         const fileName = type === "locator" ? "locator.json" : type === "config" ? "config.json" : type === "disableRTLFlip" ? "disableRTLFlip.json" : type === "bound" ? "bound.json" : "";
         if (!fileName) {
             throw new Error("fileType not found");
@@ -54,10 +61,10 @@ export class PublicationData {
         this.files = [];
     }
 
-    public getDataRead(pubId: string, type: TFileType) {
+    public getJsonObj(pubId: string, type: TFileTypePubData): object | undefined {
         assertUUIDv4(pubId);
         const file = this.filterFilesByType(type).find((a) => a.pubId === pubId);
-        return file?.data;
+        return file?.jsonObj;
     }
 
     public async destroy() {
@@ -83,7 +90,7 @@ export class PublicationData {
         }
     }
 
-    public async open(pubId: string, type: TFileType) {
+    public async open(pubId: string, type: TFileTypePubData) {
         if (this.lock) return ;
         assertUUIDv4(pubId);
 
@@ -115,22 +122,23 @@ export class PublicationData {
                     }
                     return; // already open
                 }
-                const data: object | undefined = undefined;
+
                 const file = {
                     pubId,
                     type,
                     fileHandle,
-                    data,
+                    jsonObj: undefined as TFileStructPubData["jsonObj"],
                     mutex: Promise.resolve(),
-                };
+                } satisfies TFileStructPubData;
+
                 this.files.push(file);
 
                 file.mutex = file.mutex.then(async () => {
                     try {
-                        const dataStr = await fileHandle.readFile({ encoding: "utf-8" });
+                        const jsonStr = await fileHandle.readFile({ encoding: "utf-8" });
                         try {
-                            const data = JSON.parse(dataStr);
-                            file.data = data;
+                            const jsonObj = JSON.parse(jsonStr);
+                            file.jsonObj = jsonObj;
                         } catch (e) {
                             debug(e);
                         }
@@ -145,7 +153,7 @@ export class PublicationData {
                 if (e.code === "ENOENT") {
                     try {
                         debug("create directory", publicationPath);
-                        await fs.promises.mkdir(publicationPath, { recursive: false, mode: 0o777 });
+                        await fs.promises.mkdir(publicationPath /* DEFAULTS: , { recursive: false, mode: 0o777 } */);
                         continue;
                     } catch (e) {
                         debug(e);
@@ -156,7 +164,7 @@ export class PublicationData {
         }
     }
 
-    public async write(pubId: string, type: TFileType, data: object) {
+    public async writeJsonObj(pubId: string, type: TFileTypePubData, jsonObj: object) {
         if (this.lock) return ;
         assertUUIDv4(pubId);
 
@@ -173,13 +181,13 @@ export class PublicationData {
         }
 
         file.mutex = file.mutex.then(async () => {
-            const dataStr = jsonstr(data);
+            const jsonStr = jsonStringify(jsonObj);
             try {
-                await file.fileHandle.truncate(dataStr.length);
-                await file.fileHandle.write(dataStr, 0, "utf-8");
+                await file.fileHandle.truncate(jsonStr.length);
+                await file.fileHandle.write(jsonStr, 0, "utf-8");
 
                 // Wait the end of the write to set it as local reference
-                file.data = data;
+                file.jsonObj = jsonObj;
             } catch (e) {
                 debug(e);
             }
@@ -188,7 +196,7 @@ export class PublicationData {
         await file.mutex;
     }
 
-    public async read(pubId: string, type: TFileType): Promise<object | undefined> {
+    public async readJsonObj(pubId: string, type: TFileTypePubData): Promise<object | undefined> {
         if (this.lock) return undefined;
         assertUUIDv4(pubId);
 
@@ -212,14 +220,14 @@ export class PublicationData {
                 debug(e);
             }
             try {
-                const dataStr = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
+                const jsonStr = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
                 try {
-                    const data = JSON.parse(dataStr);
-                    file.data = data;
+                    const jsonObj = JSON.parse(jsonStr);
+                    file.jsonObj = jsonObj;
                 } catch (e) {
                     debug(e);
                     try {
-                        await this.write(pubId, type, file.data);
+                        await this.writeJsonObj(pubId, type, file.jsonObj);
                     } catch (e) {
                         debug(e);
                     }
@@ -230,11 +238,11 @@ export class PublicationData {
             }
         });
         await file.mutex;
-        return file.data;
+        return file.jsonObj;
     }
 
     public async close(pubId: string) {
-        if (this.lock) return ;
+        if (this.lock) return;
 
         debug(`${this.files.length} file(s) currently opened before closing ${pubId}`);
 

--- a/src/main/storage/publication-data.ts
+++ b/src/main/storage/publication-data.ts
@@ -10,12 +10,15 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import debug_ from "debug";
 import { __ulimit_file } from "../di";
+import { AnyJson } from "readium-desktop/typings/json";
 
 const debug = debug_("readium-desktop:main/storage/pub-data");
 
 const rmrf = async (dir: string) => {
     return await fs.promises.rm(dir, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });
 };
+
+const jsonstr = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
 
 const isUUIDv4 = (uuid: string) => /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/.test(uuid);
 const assertUUIDv4 = (uuid: string) => {
@@ -35,7 +38,7 @@ export class PublicationData {
      */
     private publicationConfigPath: string;
 
-    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: string, }>;
+    private files: Array<{pubId: string, type: TFileType, fileHandle: fs.promises.FileHandle, data: AnyJson, mutex: Promise<void>}>;
 
     private filterFilesByType = (t: TFileType) => this.files.filter(({type}) => type === t);
 
@@ -64,7 +67,17 @@ export class PublicationData {
         this.files = [];
         for (const file of files) {
             try {
-                await file.fileHandle.close();
+                await Promise.race([file.mutex, new Promise<void>((resolve) => setTimeout(resolve, 100))]);
+            } catch (e) {
+                debug(e);
+            }
+            try {
+                const p1 = (async () => {
+                    await file.fileHandle.sync();
+                    await file.fileHandle.close();
+                })();
+                const p2 = new Promise<void>((resolve) => setTimeout(resolve, 100));
+                await Promise.race([p1, p2]);
             } catch (e) {
                 debug(e);
             }
@@ -99,11 +112,20 @@ export class PublicationData {
                     type,
                     fileHandle,
                     data: "",
+                    mutex: Promise.resolve(),
                 };
                 this.files.push(file);
-                const data = await fileHandle.readFile({ encoding: "utf-8" });
-                file.data = data;
-                debug(`${type} file opened on ${pubId}`);
+
+                await file.mutex.then(async () => {
+                    try {
+                        const data = await fileHandle.readFile({ encoding: "utf-8" });
+                        file.data = data;
+                        debug("READ", data);
+                        debug(`${type} file opened on ${pubId}`);
+                    } catch (e) {
+                        debug(e);
+                    }
+                });
             } catch (e) {
                 debug(e);
                 if (e.code === "ENOENT") {
@@ -120,7 +142,7 @@ export class PublicationData {
         }
     }
 
-    public async write(pubId: string, type: TFileType, data: string) {
+    public async write(pubId: string, type: TFileType, data: AnyJson) {
         if (this.lock) return ;
         assertUUIDv4(pubId);
 
@@ -135,17 +157,23 @@ export class PublicationData {
                 return ;
             }
         }
-        
-        file.data = data;
 
-        try {
-            await fs.promises.writeFile(file.fileHandle, data, { encoding: "utf-8", flush: true });
-        } catch (e) {
-            debug(e);
-        }
+        return await file.mutex.then(async () => {
+            const dataStr = jsonstr(data);
+            const dataBuffer = Buffer.from(dataStr, "utf-8");
+            try {
+                await file.fileHandle.truncate(dataBuffer.byteLength);
+                await file.fileHandle.write(dataBuffer, 0, dataBuffer.length, 0);
+
+                file.data = data;
+            } catch (e) {
+                debug(e);
+            }
+
+        });
     }
 
-    public async read(pubId: string, type: TFileType): Promise<string | undefined> {
+    public async read(pubId: string, type: TFileType): Promise<AnyJson | undefined> {
         if (this.lock) return undefined;
         assertUUIDv4(pubId);
 
@@ -161,17 +189,35 @@ export class PublicationData {
             }
         }
 
-        try {
-            const data = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
-            if (data === file.data) {
-                return file.data;
+        return await file.mutex.then(async () => {
+            try {
+                // flush before read
+                await file.fileHandle.sync();
+            } catch (e) {
+                debug(e);
             }
-            file.data = data;
-        } catch (e) {
-            debug(e);
-        }
+            try {
+                const dataStr = await fs.promises.readFile(file.fileHandle, { encoding: "utf-8" });
+                try {
+                    const data = JSON.parse(dataStr);
+                    if (data === file.data) {
+                        return file.data;
+                    }
+                    file.data = data;
+                } catch (e) {
+                    debug(e);
+                    try {
+                        await this.write(pubId, type, file.data);
+                    } catch (e) {
+                        debug(e);
+                    }
+                }
 
-        return file.data;
+            } catch (e) {
+                debug(e);
+            }
+            return file.data;
+        });
     }
 
     public async close(pubId: string) {
@@ -186,6 +232,16 @@ export class PublicationData {
 
         for (const file of files) {
             try {
+                try {
+                    await file.mutex;
+                } catch (e) {
+                    debug(e);
+                }
+                try {
+                    await file.fileHandle.sync();
+                } catch (e) {
+                    debug(e);
+                }
                 await file.fileHandle.close();
             } catch (e) {
                 debug(e);

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -24,7 +24,7 @@ import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
-export type TFileType = "locator" | "config" | "disableRTLFlip";
+export type TFileTypePubStorage = "locator" | "config" | "disableRTLFlip";
 
 const rmrf = async (dir: string) => {
     return await fs.promises.rm(dir, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });
@@ -37,7 +37,7 @@ const assertUUIDv4 = (uuid: string) => {
     }
 };
 
-const jsonstr = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
+const jsonStringify = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
 
 // Store pubs in a repository on filesystem
 // Each file of publication is stored in a directory whose name is the
@@ -72,7 +72,7 @@ export class PublicationStorage {
      */
     private userVaultConfigPath: string;
 
-    private assertAndGetFileName = (type: TFileType) => {
+    private assertAndGetFileName = (type: TFileTypePubStorage) => {
         const fileName = type === "locator" ? "locator.json" : type === "config" ? "config.json" : type === "disableRTLFlip" ? "disableRTLFlip.json" : "";
         if (!fileName) {
             throw new Error("fileType not found");
@@ -89,9 +89,9 @@ export class PublicationStorage {
     private async readUserVault(): Promise<string> {
         let userVaultPath = "";
         try {
-            const strData = await fs.promises.readFile(this.userVaultConfigPath, { encoding: "utf-8" });
-            const jsonData = JSON.parse(strData);
-            userVaultPath = Array.isArray(jsonData.vault) ? jsonData.vault[0] : "";
+            const jsonStr = await fs.promises.readFile(this.userVaultConfigPath, { encoding: "utf-8" });
+            const jsonObj = JSON.parse(jsonStr);
+            userVaultPath = Array.isArray(jsonObj.vault) ? jsonObj.vault[0] : "";
         } catch {
             // ignore
         }
@@ -130,9 +130,9 @@ export class PublicationStorage {
             return;
         }
 
-        const jsonData = { vault: [directoryPath] };
-        const strData = JSON.stringify(jsonData, null, 4);
-        fs.promises.writeFile(this.userVaultConfigPath, strData, { encoding: "utf-8" });
+        const jsonObj = { vault: [directoryPath] };
+        const jsonStr = JSON.stringify(jsonObj, null, 4);
+        await fs.promises.writeFile(this.userVaultConfigPath, jsonStr, { encoding: "utf-8" });
     }
 
     // private only
@@ -143,23 +143,23 @@ export class PublicationStorage {
         return (await this.userVaultPath) || this.defaultVaultPath;
     }
 
-    public async write(
+    public async writeJsonObj(
         identifier: string,
-        type: TFileType,
-        data: object,
+        type: TFileTypePubStorage,
+        jsonObj: object,
     ) {
         assertUUIDv4(identifier);
 
         const fileName = this.assertAndGetFileName(type);
 
         const pubPath = await this.findPublicationPath(identifier);
-        const filePath =path.join(pubPath, fileName);
+        const filePath = path.join(pubPath, fileName);
 
         try {
-            const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
-            const dataStr = JSON.stringify(data);
-            const readDataStr = JSON.stringify(JSON.parse(readData));
-            if (readDataStr === dataStr) {
+            const jsonStrExisting_ = await fs.promises.readFile(filePath, { encoding: "utf-8" });
+            const jsonStrExisting = JSON.stringify(JSON.parse(jsonStrExisting_));
+            const jsonStr = JSON.stringify(jsonObj);
+            if (jsonStrExisting === jsonStr) {
                 debug("LOCATOR Storage same as LOCATOR Serialized, already persisted");
                 return;
             }
@@ -169,20 +169,22 @@ export class PublicationStorage {
 
         await using dir = await fs.promises.mkdtempDisposable(pubPath); // same as defer and RAII: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/await_using
         const tmpFilePath = path.join(dir.path, "locator.json");
-        const dataStr = jsonstr(data);
-        await fs.promises.writeFile(tmpFilePath, dataStr, { encoding: "utf-8", flush: true, mode: 0o666}); // owner read/write group/all read
-        const readStr = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
-        if (readStr === dataStr) {
+        const jsonStr = jsonStringify(jsonObj);
+        await fs.promises.writeFile(tmpFilePath, jsonStr, { encoding: "utf-8", flush: true, mode: 0o666}); // owner read/write group/all read
+        const jsonStrCheck = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
+        if (jsonStrCheck === jsonStr) {
             await fs.promises.rename(tmpFilePath, filePath);
             debug("LOCATOR written to", filePath);
+        } else {
+            debug("LOCATOR diff, NOT written to", filePath, " --- ", jsonStrCheck, " !== ", jsonStr);
         }
     }
 
-        public async read(
+    public async readJsonObj(
         identifier: string,
-        type: TFileType,
-    ): Promise<object> {
-        
+        type: TFileTypePubStorage,
+    ): Promise<object | undefined> {
+
         assertUUIDv4(identifier);
 
         const fileName = this.assertAndGetFileName(type);
@@ -191,10 +193,10 @@ export class PublicationStorage {
         const filePath = path.join(pubPath, fileName);
 
         try {
-            const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
+            const jsonStr = await fs.promises.readFile(filePath, { encoding: "utf-8" });
             try {
-                const data = JSON.parse(readData);
-                return data;
+                const jsonObj = JSON.parse(jsonStr);
+                return jsonObj;
             } catch (e) {
                 debug(e);
             }
@@ -316,6 +318,7 @@ export class PublicationStorage {
 
         assertUUIDv4(identifier);
 
+        // TODO: if map.get() is as expensive as map.has() then simply: const val = map.get(key); if (!!val) return val;
         if (this.__publicationEpubPathMap.has(identifier)) {
             return this.__publicationEpubPathMap.get(identifier);
         }

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -160,7 +160,7 @@ export class PublicationStorage {
             const jsonStrExisting = JSON.stringify(JSON.parse(jsonStrExisting_));
             const jsonStr = JSON.stringify(jsonObj);
             if (jsonStrExisting === jsonStr) {
-                debug("LOCATOR Storage same as LOCATOR Serialized, already persisted");
+                debug("JSONObj Storage same as JSONObj Serialized, already persisted");
                 return;
             }
         } catch {
@@ -174,9 +174,9 @@ export class PublicationStorage {
         const jsonStrCheck = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
         if (jsonStrCheck === jsonStr) {
             await fs.promises.rename(tmpFilePath, filePath);
-            debug("LOCATOR written to", filePath);
+            debug("JSONObj written to", filePath);
         } else {
-            debug("LOCATOR diff, NOT written to", filePath, " --- ", jsonStrCheck, " !== ", jsonStr);
+            debug("JSONObj diff, NOT written to", filePath, " --- ", jsonStrCheck, " !== ", jsonStr);
         }
     }
 

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -21,7 +21,6 @@ import { IZip } from "@r2-utils-js/_utils/zip/zip";
 import debug_ from "debug";
 import { sanitizeForFilename } from "readium-desktop/common/safe-filename";
 import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
-import { AnyJson } from "readium-desktop/typings/json";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
@@ -147,7 +146,7 @@ export class PublicationStorage {
     public async writeData(
         identifier: string,
         type: TFileType,
-        data: AnyJson,
+        data: object,
     ) {
         assertUUIDv4(identifier);
 
@@ -158,7 +157,9 @@ export class PublicationStorage {
 
         try {
             const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
-            if (readData === data) {
+            const dataStr = JSON.stringify(data);
+            const readDataStr = JSON.stringify(JSON.parse(readData));
+            if (readDataStr === dataStr) {
                 debug("LOCATOR Storage same as LOCATOR Serialized, already persisted");
                 return;
             }
@@ -169,7 +170,7 @@ export class PublicationStorage {
         await using dir = await fs.promises.mkdtempDisposable(pubPath); // same as defer and RAII: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/await_using
         const tmpFilePath = path.join(dir.path, "locator.json");
         const dataStr = jsonstr(data);
-        await fs.promises.writeFile(tmpFilePath, dataStr, { encoding: "utf-8", flush: true, mode: 0o644}); // owner read/write group/all read
+        await fs.promises.writeFile(tmpFilePath, dataStr, { encoding: "utf-8", flush: true, mode: 0o666}); // owner read/write group/all read
         const read = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
         if (read === dataStr) {
             await fs.promises.rename(tmpFilePath, filePath);
@@ -180,7 +181,7 @@ export class PublicationStorage {
         public async readData(
         identifier: string,
         type: TFileType,
-    ): Promise<AnyJson> {
+    ): Promise<object> {
         
         assertUUIDv4(identifier);
 

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -24,6 +24,8 @@ import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
+export type TFileType = "locator" | "config" | "disableRTLFlip";
+
 const rmrf = async (dir: string) => {
     return await fs.promises.rm(dir, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });
 };
@@ -53,12 +55,6 @@ export class PublicationStorage {
     // private configDataFolderPath: string;
 
     /**
-     * publication reader config directory from configDataFolderPath
-     * aka: %appData%\config-data-json{-dev}\reader\<uuid>\
-     */
-    private readerConfigPath: string; // %appData%\config-data
-
-    /**
      * appData/userData default publication storage directory path
      * aka: %appData%\publications{-dev}\<uuid>
      */
@@ -74,9 +70,16 @@ export class PublicationStorage {
      */
     private userVaultConfigPath: string;
 
-    public constructor(rootPath: string, userVaultConfigPath: string, readerConfigPath: string) {
+    private assertAndGetFileName = (type: TFileType) => {
+        const fileName = type === "locator" ? "locator.json" : type === "config" ? "config.json" : type === "disableRTLFlip" ? "disableRTLFlip.json" : "";
+        if (!fileName) {
+            throw new Error("fileType not found");
+        }
+        return fileName;
+    };
+
+    public constructor(rootPath: string, userVaultConfigPath: string) {
         this.userVaultConfigPath = userVaultConfigPath;
-        this.readerConfigPath = readerConfigPath;
         this.defaultVaultPath = rootPath;
         this.userVaultPath = this.readUserVault();
     }
@@ -140,14 +143,15 @@ export class PublicationStorage {
 
     public async writeData(
         identifier: string,
-        fileName: "locator",
+        type: TFileType,
         data: string,
     ) {
-
         assertUUIDv4(identifier);
 
+        const fileName = this.assertAndGetFileName(type);
+
         const pubPath = await this.findPublicationPath(identifier);
-        const filePath = fileName === "locator" ? path.join(pubPath, "locator.json") : "";
+        const filePath =path.join(pubPath, fileName);
 
         try {
             const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
@@ -171,13 +175,15 @@ export class PublicationStorage {
 
         public async readData(
         identifier: string,
-        fileName: "locator",
+        type: TFileType,
     ) {
         
         assertUUIDv4(identifier);
 
+        const fileName = this.assertAndGetFileName(type);
+
         const pubPath = await this.findPublicationPath(identifier);
-        const filePath = fileName === "locator" ? path.join(pubPath, "locator.json") : "";
+        const filePath = path.join(pubPath, fileName);
 
         try {
             const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
@@ -217,26 +223,6 @@ export class PublicationStorage {
                 try {
                     await rmrf(pubDirPath);
                     await fs.promises.mkdir(pubDirPath);
-                } catch (e) {
-                    debug(e);
-                }
-            }
-        }
-
-        const configPubDirPath = path.join(this.readerConfigPath, identifier);
-
-        try {
-            await fs.promises.mkdir(configPubDirPath);
-        } catch (e: any) {
-            debug(`mkdir ${configPubDirPath}: ${e}`);
-            if (e.code === "EEXIST") {
-                debug("Directory already exists");
-                debug("How to handle this error?");
-                debug("Do we have to clean the directory before using it?");
-                debug("For the moment let's remove the directory");
-                try {
-                    await rmrf(configPubDirPath);
-                    await fs.promises.mkdir(configPubDirPath);
                 } catch (e) {
                     debug(e);
                 }

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -143,7 +143,7 @@ export class PublicationStorage {
         return (await this.userVaultPath) || this.defaultVaultPath;
     }
 
-    public async writeData(
+    public async write(
         identifier: string,
         type: TFileType,
         data: object,
@@ -171,14 +171,14 @@ export class PublicationStorage {
         const tmpFilePath = path.join(dir.path, "locator.json");
         const dataStr = jsonstr(data);
         await fs.promises.writeFile(tmpFilePath, dataStr, { encoding: "utf-8", flush: true, mode: 0o666}); // owner read/write group/all read
-        const read = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
-        if (read === dataStr) {
+        const readStr = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
+        if (readStr === dataStr) {
             await fs.promises.rename(tmpFilePath, filePath);
             debug("LOCATOR written to", filePath);
         }
     }
 
-        public async readData(
+        public async read(
         identifier: string,
         type: TFileType,
     ): Promise<object> {

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -21,6 +21,7 @@ import { IZip } from "@r2-utils-js/_utils/zip/zip";
 import debug_ from "debug";
 import { sanitizeForFilename } from "readium-desktop/common/safe-filename";
 import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
+import { AnyJson } from "readium-desktop/typings/json";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
@@ -36,6 +37,8 @@ const assertUUIDv4 = (uuid: string) => {
         throw new Error("not an uuidv4 identifier !");
     }
 };
+
+const jsonstr = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
 
 // Store pubs in a repository on filesystem
 // Each file of publication is stored in a directory whose name is the
@@ -144,7 +147,7 @@ export class PublicationStorage {
     public async writeData(
         identifier: string,
         type: TFileType,
-        data: string,
+        data: AnyJson,
     ) {
         assertUUIDv4(identifier);
 
@@ -165,9 +168,10 @@ export class PublicationStorage {
 
         await using dir = await fs.promises.mkdtempDisposable(pubPath); // same as defer and RAII: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/await_using
         const tmpFilePath = path.join(dir.path, "locator.json");
-        await fs.promises.writeFile(tmpFilePath, data, { encoding: "utf-8", flush: true, mode: 0o644}); // owner read/write group/all read
+        const dataStr = jsonstr(data);
+        await fs.promises.writeFile(tmpFilePath, dataStr, { encoding: "utf-8", flush: true, mode: 0o644}); // owner read/write group/all read
         const read = await fs.promises.readFile(tmpFilePath, { encoding: "utf-8" });
-        if (read === data) {
+        if (read === dataStr) {
             await fs.promises.rename(tmpFilePath, filePath);
             debug("LOCATOR written to", filePath);
         }
@@ -176,8 +180,8 @@ export class PublicationStorage {
         public async readData(
         identifier: string,
         type: TFileType,
-    ) {
-
+    ): Promise<AnyJson> {
+        
         assertUUIDv4(identifier);
 
         const fileName = this.assertAndGetFileName(type);
@@ -187,11 +191,17 @@ export class PublicationStorage {
 
         try {
             const readData = await fs.promises.readFile(filePath, { encoding: "utf-8" });
-            const data = JSON.parse(readData);
-            return data;
+            try {
+                const data = JSON.parse(readData);
+                return data;
+            } catch (e) {
+                debug(e);
+            }
         } catch (e) {
             debug(e);
         }
+
+        return undefined;
     }
 
     /**

--- a/src/renderer/common/hooks/useReaderConfig.ts
+++ b/src/renderer/common/hooks/useReaderConfig.ts
@@ -10,10 +10,11 @@ import { useSelector } from "./useSelector";
 import { ReaderConfig, ReaderConfigPublisher } from "readium-desktop/common/models/reader";
 import { useDispatch } from "./useDispatch";
 import * as React from "react";
-import { readerLocalActionSetConfig, readerLocalActionSetTransientConfig } from "readium-desktop/renderer/reader/redux/actions";
+import { readerLocalActionSetTransientConfig } from "readium-desktop/renderer/reader/redux/actions";
 import debounce from "debounce";
 import { equals } from "ramda";
 import { ObjectKeys } from "readium-desktop/utils/object-keys-values";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 export const useReaderConfigAll = () => {
     const config = useSelector((state: IReaderRootState) => state.reader.config);
@@ -37,7 +38,7 @@ export const useSaveReaderConfig = () => {
     const cb = React.useCallback(
         (state: Partial<ReaderConfig>) => {
 
-            dispatch(readerLocalActionSetConfig.build(state));
+            dispatch(readerActions.setConfig.build(state));
         }, [dispatch]);
 
     return cb;

--- a/src/renderer/library/components/opds/CatalogHeader.tsx
+++ b/src/renderer/library/components/opds/CatalogHeader.tsx
@@ -12,7 +12,7 @@ import * as ChevronRight from "readium-desktop/renderer/assets/icons/chevron-rig
 import SVG from "readium-desktop/renderer/common/components/SVG";
 import { Link } from "react-router-dom";
 import { DisplayType } from "readium-desktop/renderer/library/routing";
-import { IBreadCrumbItem } from "src/common/redux/states/renderer/breadcrumbItem";
+import { IBreadCrumbItem } from "readium-desktop/common/redux/states/renderer/breadcrumbItem";
 
 export const CatalogHeader: React.FC<React.PropsWithChildren<{ currentLocation: IBreadCrumbItem, previousLocation: IBreadCrumbItem}>> = (props) => {
 

--- a/src/renderer/library/redux/sagas/opds.ts
+++ b/src/renderer/library/redux/sagas/opds.ts
@@ -23,7 +23,7 @@ import { ContentType } from "readium-desktop/utils/contentType";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { call, delay, put, take } from "redux-saga/effects";
 import { race as raceTyped, select as selectTyped } from "typed-redux-saga/macro";
-import { IOpdsHeaderState } from "src/common/redux/states/renderer/opds";
+import { IOpdsHeaderState } from "readium-desktop/common/redux/states/renderer/opds";
 
 export const BROWSE_OPDS_API_REQUEST_ID = "browseOpdsApiResult";
 export const SEARCH_OPDS_API_REQUEST_ID = "searchOpdsApiResult";

--- a/src/renderer/reader/components/AnnotationEdit.tsx
+++ b/src/renderer/reader/components/AnnotationEdit.tsx
@@ -24,7 +24,6 @@ import * as TextStrikeThroughtIcon from "readium-desktop/renderer/assets/icons/T
 import * as TextOutlineIcon from "readium-desktop/renderer/assets/icons/TextOutline-icon.svg";
 import * as TagIcon from "readium-desktop/renderer/assets/icons/tag-icon.svg";
 import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
-import { readerLocalActionSetConfig } from "../redux/actions";
 import classNames from "classnames";
 // import { TextArea } from "react-aria-components";
 import { ComboBox, ComboBoxItem } from "readium-desktop/renderer/common/components/ComboBox";
@@ -43,6 +42,7 @@ import { MiniLocatorExtended } from "readium-desktop/common/redux/states/locator
 // e__slint-disable-next-line @typescript-eslint/ban-ts-comment
 // @__ts-ignore TS1479
 import {subscribe} from "@github/paste-markdown";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 // import { readiumCSSDefaults } from "@r2-navigator-js/electron/common/readium-css-settings";
 
@@ -110,7 +110,7 @@ export const AnnotationEdit: React.FC<IProps> = (props) => {
         if (flag) {
             const annotation_defaultColor = hexToRgb(colorSelected);
             const annotation_defaultDrawType = drawTypeSelected;
-            dispatch(readerLocalActionSetConfig.build({ annotation_defaultColor, annotation_defaultDrawType }));
+            dispatch(readerActions.setConfig.build({ annotation_defaultColor, annotation_defaultDrawType }));
         }
 
         previousColorSelected.current = colorSelected;

--- a/src/renderer/reader/components/BookmarkEdit.tsx
+++ b/src/renderer/reader/components/BookmarkEdit.tsx
@@ -23,7 +23,6 @@ import { noteColorCodeToColorTranslatorKeySet } from "readium-desktop/common/red
 import { hexToRgb, rgbToHex } from "readium-desktop/common/rgb";
 import { IColor } from "@r2-navigator-js/electron/common/highlight";
 import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
-import { readerLocalActionSetConfig } from "../redux/actions";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import { ComboBox, ComboBoxItem } from "readium-desktop/renderer/common/components/ComboBox";
@@ -38,6 +37,7 @@ import { ComboBox, ComboBoxItem } from "readium-desktop/renderer/common/componen
 // e__slint-disable-next-line @typescript-eslint/ban-ts-comment
 // @__ts-ignore TS1479
 import {subscribe} from "@github/paste-markdown";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 interface IProps {
     save: (name: string, color: IColor, tag: string | undefined) => void,
@@ -73,7 +73,7 @@ export const BookmarkEdit: React.FC<IProps> = (props) => {
     const saveConfig = React.useCallback(() => {
 
         if (previousColorSelected.current !== colorSelected) {
-            dispatch(readerLocalActionSetConfig.build({ annotation_defaultColor: hexToRgb(colorSelected) }));
+            dispatch(readerActions.setConfig.build({ annotation_defaultColor: hexToRgb(colorSelected) }));
         }
         previousColorSelected.current = colorSelected;
     }, [dispatch, colorSelected]);

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -85,7 +85,7 @@ import { IPdfPlayerScale, TToc } from "../pdf/common/pdfReader.type";
 import { pdfMount } from "../pdf/driver";
 import {
     readerLocalActionAnnotations,
-    readerLocalActionDivina, readerLocalActionLocatorHrefChanged, readerLocalActionSetConfig,
+    readerLocalActionDivina, readerLocalActionLocatorHrefChanged,
     readerLocalActionToggleMenu,
     readerLocalActionToggleSettings,
 } from "../redux/actions";
@@ -3349,7 +3349,7 @@ let __READING_FINISHED_CALL_COUNTER = 0;
 const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
     return {
         dispatchMarginAnnotations: (t: TDrawView, href1: string | undefined, href2: string | undefined) => {
-            dispatch(readerLocalActionSetConfig.build({ annotation_defaultDrawView: t }));
+            dispatch(readerActions.setConfig.build({ annotation_defaultDrawView: t }));
 
             if (!!href1) {
                 dispatch(readerLocalActionLocatorHrefChanged.build(href1, href1, href2, href2));
@@ -3415,7 +3415,7 @@ const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
             }
         },
         setConfig: (config: Partial<ReaderConfig>) => {
-            dispatch(readerLocalActionSetConfig.build(config));
+            dispatch(readerActions.setConfig.build(config));
 
             // session never enabled in reader but always in main/lib
             // if (!sessionEnabled) {

--- a/src/renderer/reader/components/ReaderHeader.tsx
+++ b/src/renderer/reader/components/ReaderHeader.tsx
@@ -71,7 +71,7 @@ import { ReaderSettings, ReadingAudio } from "./ReaderSettings";
 import { createOrGetPdfEventBus } from "readium-desktop/renderer/reader/pdf/driver";
 import { MySelectProps, Select } from "readium-desktop/renderer/common/components/Select";
 import { ComboBox, ComboBoxItem } from "readium-desktop/renderer/common/components/ComboBox";
-import { readerLocalActionAnnotations, readerLocalActionSetConfig, readerLocalActionToggleMenu, readerLocalActionToggleSettings } from "../redux/actions";
+import { readerLocalActionAnnotations, readerLocalActionToggleMenu, readerLocalActionToggleSettings } from "../redux/actions";
 import { AnnotationEdit } from "./AnnotationEdit";
 import { isAudiobookFn } from "readium-desktop/common/isManifestType";
 import { VoiceSelection } from "./header/voiceSelection";
@@ -96,6 +96,7 @@ import { TDrawType } from "readium-desktop/common/redux/states/renderer/note";
 import { PrintContainer } from "./Print";
 import * as PrinterIcon from "readium-desktop/renderer/assets/icons/printer-icon.svg";
 import { PublicationView } from "readium-desktop/common/views/publication";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 const debug = debug_("readium-desktop:renderer:reader:components:ReaderHeader");
 
@@ -1502,7 +1503,7 @@ const mapStateToProps = (state: IReaderRootState, _props: IBaseProps) => {
 const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
     return {
         setConfig: (state: Partial<ReaderConfig>) => {
-            dispatch(readerLocalActionSetConfig.build(state));
+            dispatch(readerActions.setConfig.build(state));
         },
         triggerAnnotationBtn: (fromKeyboard: boolean) => {
             dispatch(readerLocalActionAnnotations.trigger.build(fromKeyboard));

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -83,7 +83,7 @@ import { useTranslator } from "readium-desktop/renderer/common/hooks/useTranslat
 import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
 import { Locator } from "@r2-shared-js/models/locator";
 import { dialogActions, dockActions, readerActions } from "readium-desktop/common/redux/actions";
-import { readerLocalActionLocatorHrefChanged, readerLocalActionSetConfig } from "../redux/actions";
+import { readerLocalActionLocatorHrefChanged } from "../redux/actions";
 import { useReaderConfig, useSaveReaderConfig } from "readium-desktop/renderer/common/hooks/useReaderConfig";
 import { IReaderDialogOrDockSettingsMenuState, ReaderConfig } from "readium-desktop/common/models/reader";
 import { rgbToHex } from "readium-desktop/common/rgb";
@@ -3068,13 +3068,13 @@ export const ReaderMenu: React.FC<IBaseProps> = (props) => {
         setSerialAnnotatorMode(!serialAnnotator);
     };
     const quickAnnotationsOnChange = () => {
-        dispatch(readerLocalActionSetConfig.build({ annotation_popoverNotOpenOnNoteTaking: !readerConfig.annotation_popoverNotOpenOnNoteTaking }));
+        dispatch(readerActions.setConfig.build({ annotation_popoverNotOpenOnNoteTaking: !readerConfig.annotation_popoverNotOpenOnNoteTaking }));
     };
     const marginAnnotationsOnChange = () => {
         const annotation_defaultDrawView = readerConfig.annotation_defaultDrawView === "margin" ? "annotation" : "margin";
 
         console.log(`marginAnnotationsToggleSwitch : highlight=${annotation_defaultDrawView}`);
-        dispatch(readerLocalActionSetConfig.build({ annotation_defaultDrawView }));
+        dispatch(readerActions.setConfig.build({ annotation_defaultDrawView }));
 
         const href1 = currentLocation?.locator?.href;
         const href2 = currentLocation?.secondWebViewHref;
@@ -3084,7 +3084,7 @@ export const ReaderMenu: React.FC<IBaseProps> = (props) => {
         const annotation_defaultDrawView = readerConfig.annotation_defaultDrawView === "hide" ? "annotation" : "hide";
 
         console.log(`hideAnnotationsToggleSwitch : highlight=${annotation_defaultDrawView}`);
-        dispatch(readerLocalActionSetConfig.build({ annotation_defaultDrawView }));
+        dispatch(readerActions.setConfig.build({ annotation_defaultDrawView }));
 
         const href1 = currentLocation?.locator?.href;
         const href2 = currentLocation?.secondWebViewHref;

--- a/src/renderer/reader/createStore.ts
+++ b/src/renderer/reader/createStore.ts
@@ -12,11 +12,11 @@ import { initStore } from "readium-desktop/renderer/reader/redux/store/memory";
 
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 // import { diReaderSymbolTable } from "./diSymbolTable";
-import { readerLocalActionSetConfig } from "./redux/actions";
 import { readerConfigInitialState } from "readium-desktop/common/redux/states/reader";
 import { Store } from "redux";
 import { isDivinaFn, isPdfFn } from "readium-desktop/common/isManifestType";
 import { SagaMiddleware } from "redux-saga";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 // Create container used for dependency injection
 // const container = new Container();
@@ -127,7 +127,7 @@ export const createStoreFromDi = (preloadedState: Partial<IReaderRootState>): St
 
     if (flag) {
         console.log(`MIGRATION : There are a data need to be migrated from defaultConfig to config OLD=${JSON.stringify(store.getState().reader.config, null, 4)} NEW=${JSON.stringify(newConfig, null, 4)}`);
-        store.dispatch(readerLocalActionSetConfig.build(newConfig));
+        store.dispatch(readerActions.setConfig.build(newConfig));
         console.log(`MIGRATION : Data migrated after the dispatch so this is the new data : ${JSON.stringify(store.getState().reader.config, null, 4)}`);
     }
     return store;

--- a/src/renderer/reader/redux/actions/index.ts
+++ b/src/renderer/reader/redux/actions/index.ts
@@ -10,7 +10,6 @@ import * as readerLocalActionHighlights from "./highlights";
 import * as readerLocalActionAnnotations from "./annotations";
 import * as readerLocalActionLocatorHrefChanged from "./locatorHrefChanged";
 import * as readerLocalActionSearch from "./search";
-import * as readerLocalActionSetConfig from "./setConfig";
 import * as readerLocalActionSetTransientConfig from "./setTransientConfig";
 import * as readerLocalActionReader from "./reader";
 import * as readerLocalActionSetImageClick from "./setImgClick";
@@ -21,7 +20,6 @@ export {
     readerLocalActionToggleSettings,
     readerLocalActionToggleMenu,
     readerLocalActionAnnotations,
-    readerLocalActionSetConfig,
     readerLocalActionSetTransientConfig,
     readerLocalActionHighlights,
     readerLocalActionLocatorHrefChanged,

--- a/src/renderer/reader/redux/middleware/sync.ts
+++ b/src/renderer/reader/redux/middleware/sync.ts
@@ -72,6 +72,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     customizationActions.addHistory.ID,
 
     readerActions.setLocator.ID,
+    readerActions.setConfig.ID,
 ];
 
 export const reduxSyncMiddleware = syncFactory(SYNCHRONIZABLE_ACTIONS);

--- a/src/renderer/reader/redux/middleware/sync.ts
+++ b/src/renderer/reader/redux/middleware/sync.ts
@@ -73,6 +73,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
 
     readerActions.setLocator.ID,
     readerActions.setConfig.ID,
+    readerActions.disableRTLFlip.ID,
 ];
 
 export const reduxSyncMiddleware = syncFactory(SYNCHRONIZABLE_ACTIONS);

--- a/src/renderer/reader/redux/reducers/readerConfig.ts
+++ b/src/renderer/reader/redux/reducers/readerConfig.ts
@@ -9,15 +9,15 @@ import { type Reducer } from "redux";
 
 import { ReaderConfig } from "readium-desktop/common/models/reader";
 import { readerConfigInitialState } from "readium-desktop/common/redux/states/reader";
-import { readerLocalActionSetConfig } from "../actions";
+import { readerActions } from "readium-desktop/common/redux/actions";
 
 function readerConfigReducer_(
     state: ReaderConfig = readerConfigInitialState,
-    action: readerLocalActionSetConfig.TAction,
+    action: readerActions.setConfig.TAction,
 ): ReaderConfig {
 
     switch (action.type) {
-        case readerLocalActionSetConfig.ID:
+        case readerActions.setConfig.ID:
 
             return {
                 ...state,

--- a/src/renderer/reader/redux/sagas/note.ts
+++ b/src/renderer/reader/redux/sagas/note.ts
@@ -12,7 +12,7 @@ import debug_ from "debug";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { SagaGenerator } from "typed-redux-saga";
 import { select as selectTyped, take as takeTyped, race as raceTyped, put as putTyped, all as allTyped, call as callTyped, spawn as spawnTyped, delay as delayTyped} from "typed-redux-saga/macro";
-import { readerLocalActionAnnotations, readerLocalActionHighlights, readerLocalActionLocatorHrefChanged, readerLocalActionReader, readerLocalActionSetConfig } from "../actions";
+import { readerLocalActionAnnotations, readerLocalActionHighlights, readerLocalActionLocatorHrefChanged, readerLocalActionReader } from "../actions";
 import { spawnLeading } from "readium-desktop/common/redux/sagas/spawnLeading";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 import { winActions } from "readium-desktop/renderer/common/redux/actions";
@@ -233,7 +233,7 @@ function* noteAddUpdate(action: readerActions.note.addUpdate.TAction) {
             // ttsState === TTSStateEnum.STOPPED &&
             // mediaOverlaysState === MediaOverlaysStateEnum.STOPPED
         ) { // NOT "margin" or "annotation"
-            yield* putTyped(readerLocalActionSetConfig.build({ annotation_defaultDrawView: "annotation" }));
+            yield* putTyped(readerActions.setConfig.build({ annotation_defaultDrawView: "annotation" }));
 
             const currentLocation = yield* selectTyped((state: IReaderRootState) => state.reader.locator);
             const href1 = currentLocation?.locator?.href;
@@ -349,7 +349,7 @@ function* annotationButtonTrigger(action: readerLocalActionAnnotations.trigger.T
         // ttsState === TTSStateEnum.STOPPED &&
         // mediaOverlaysState === MediaOverlaysStateEnum.STOPPED
     ) { // NOT "margin" or "annotation"
-        yield* putTyped(readerLocalActionSetConfig.build({ annotation_defaultDrawView: "annotation" }));
+        yield* putTyped(readerActions.setConfig.build({ annotation_defaultDrawView: "annotation" }));
 
         const currentLocation = yield* selectTyped((state: IReaderRootState) => state.reader.locator);
         const href1 = currentLocation?.locator?.href;
@@ -503,7 +503,7 @@ function* readerStart() {
     debug(`${notesHighlighted.length} note(s) drawn`);
 }
 
-function* captureHightlightDrawMargin(action: readerLocalActionSetConfig.TAction) {
+function* captureHightlightDrawMargin(action: readerActions.setConfig.TAction) {
 
     const { annotation_defaultDrawView } = action.payload;
     if (!annotation_defaultDrawView) return ;
@@ -531,7 +531,7 @@ function* captureHightlightDrawMargin(action: readerLocalActionSetConfig.TAction
 export const saga = () =>
     allTyped([
         takeSpawnEvery(
-            readerLocalActionSetConfig.ID,
+            readerActions.setConfig.ID,
             captureHightlightDrawMargin,
             (e) => console.error("readerLocalActionSetConfig", e),
         ),

--- a/src/renderer/reader/redux/sagas/readerConfig.ts
+++ b/src/renderer/reader/redux/sagas/readerConfig.ts
@@ -15,7 +15,7 @@ import { MediaOverlaysStateEnum, TTSStateEnum, mediaOverlaysEnableCaptionsMode, 
     mediaOverlaysStop,
 } from "@r2-navigator-js/electron/renderer";
 
-import { readerLocalActionReader, readerLocalActionSetConfig } from "../actions";
+import { readerLocalActionReader } from "../actions";
 import { SagaGenerator } from "typed-redux-saga";
 import { all as allTyped, put as putTyped, select as selectTyped, spawn as spawnTyped, take as takeTyped } from "typed-redux-saga/macro";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
@@ -23,10 +23,10 @@ import { readerConfigInitialState, readerConfigInitialStateDefaultPublisher } fr
 import { isNotNil } from "readium-desktop/utils/nil";
 import { DialogTypeName } from "readium-desktop/common/models/dialog";
 import { DockTypeName } from "readium-desktop/common/models/dock";
-import { dialogActions, dockActions } from "readium-desktop/common/redux/actions";
+import { dialogActions, dockActions, readerActions } from "readium-desktop/common/redux/actions";
 import { IReaderDialogOrDockSettingsMenuState } from "readium-desktop/common/models/reader";
 
-function* readerConfigChanged(action: readerLocalActionSetConfig.TAction): SagaGenerator<void> {
+function* readerConfigChanged(action: readerActions.setConfig.TAction): SagaGenerator<void> {
 
     const { payload } = action;
     // payload must contain readerConfig keys that need to be updated
@@ -225,17 +225,17 @@ function* alowCustomTriggered(action: readerLocalActionReader.allowCustom.TActio
     if (checked) {
 
         const transientConfig = yield* selectTyped((state: IReaderRootState) => state.reader.transientConfig);
-        yield* putTyped(readerLocalActionSetConfig.build(transientConfig));
+        yield* putTyped(readerActions.setConfig.build(transientConfig));
 
     } else {
-        yield* putTyped(readerLocalActionSetConfig.build(readerConfigInitialStateDefaultPublisher));
+        yield* putTyped(readerActions.setConfig.build(readerConfigInitialStateDefaultPublisher));
     }
 }
 
 export function saga() {
     return allTyped([
         takeSpawnEvery(
-            readerLocalActionSetConfig.ID,
+            readerActions.setConfig.ID,
             readerConfigChanged,
         ),
         takeSpawnEvery(
@@ -245,7 +245,7 @@ export function saga() {
         spawnTyped(function* () {
             while (true) {
                 const oldEnableMathJax = yield* selectTyped((state: IReaderRootState) => state.reader.config.enableMathJax);
-                yield* takeTyped(readerLocalActionSetConfig.ID);
+                yield* takeTyped(readerActions.setConfig.ID);
                 const newEnableMathJax = yield* selectTyped((state: IReaderRootState) => state.reader.config.enableMathJax);
                 const shouldReload = oldEnableMathJax !== newEnableMathJax;
                 if (shouldReload) {

--- a/src/renderer/reader/redux/sagas/settingsOrMenu.ts
+++ b/src/renderer/reader/redux/sagas/settingsOrMenu.ts
@@ -8,10 +8,10 @@
 import debug_ from "debug";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { all, put as putTyped, SagaGenerator, select as selectTyped } from "typed-redux-saga";
-import { readerLocalActionSetConfig, readerLocalActionToggleMenu, readerLocalActionToggleSettings } from "../actions";
+import { readerLocalActionToggleMenu, readerLocalActionToggleSettings } from "../actions";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 import { DialogTypeName } from "readium-desktop/common/models/dialog";
-import { dialogActions, dockActions } from "readium-desktop/common/redux/actions";
+import { dialogActions, dockActions, readerActions } from "readium-desktop/common/redux/actions";
 import { IReaderDialogOrDockSettingsMenuState, ReaderConfig } from "readium-desktop/common/models/reader";
 import { DockTypeName } from "readium-desktop/common/models/dock";
 import { ObjectKeys } from "readium-desktop/utils/object-keys-values";
@@ -143,7 +143,7 @@ function* toggleSettingsOrMenu(action: readerLocalActionToggleMenu.TAction | rea
     }
 
     if (ObjectKeys(newReaderConfig).length) {
-        yield* putTyped(readerLocalActionSetConfig.build(newReaderConfig));
+        yield* putTyped(readerActions.setConfig.build(newReaderConfig));
     }
 
     if (readerDockingMode === "full") {


### PR DESCRIPTION


### Migration: 

win.registry[pubId]  ∪ publication.db[pubID]
- persisted to publication-data -> {config,locator,RTLFlip,bound}
- persisted to publication-storage -> {config,locator,RTLFlip}

### Runtime: 

Actions: 
- readerActions.setConfig
- readerActions.setLocator
- readerActions.disableRTLFlip
- readerActions.disableRTLFlip

are persisted to
- publication-data ->  {config,locator,RTLFlip,bound} -> WITHOUT DELAY
- publication-storage -> {config,locator,RTLFlip} -> WITH A DEBOUNCE OF 10s


publication-data is colocated with `config-data-json{-dev}` under `publication/<uuid>` folder
publication-storage is colocated with the stored publication under the default vault `%appData%/publications{-dev}/<uuid>/{config,locator,RTLFlip}` or an another directory if setting up by the user (not released yet)

- `bound.json` is not stored by publication-storage as it belongs to the appData folder

- `publication-data` handle information attached to the register publication and localized on appData
- `publication-storage` handle publication files `{book.epub,cover.png,manifest.json,locator.json,config.json,disableRTLFlip.json}` localized under a default vault which is in appData/publications{-dev}. A user vault chained with the default vault can be setting up and serve as an external publication vault in the chosen directory.  