### PR TITLE
fix: window bounds rectangle issues 

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -15,6 +15,9 @@ export const ABOUT_BOOK_TITLE_PREFIX = "EDRLAB.ThoriumReader-";
 export const WINDOW_MIN_WIDTH = 700;
 export const WINDOW_MIN_HEIGHT = 600;
 
+export const WINDOW_DEFAULT_WIDTH = 1024;
+export const WINDOW_DEFAULT_HEIGHT = 768;
+
 export const FORCE_PROD_DB_IN_DEV = false;
 
 export const USER_DATA_FOLDER = app.getPath("userData");

--- a/src/common/rectangle/window.ts
+++ b/src/common/rectangle/window.ts
@@ -5,8 +5,8 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { /*BrowserWindow,*/ Rectangle, screen } from "electron";
-import { WINDOW_DEFAULT_HEIGHT, WINDOW_DEFAULT_WIDTH } from "../constant";
+import { /*BrowserWindow,*/ Rectangle, screen, Display } from "electron";
+import { WINDOW_DEFAULT_HEIGHT, WINDOW_DEFAULT_WIDTH, WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH } from "../constant";
 
 // import debug_ from "debug";
 // // Logger
@@ -15,61 +15,179 @@ import { WINDOW_DEFAULT_HEIGHT, WINDOW_DEFAULT_WIDTH } from "../constant";
 export const compareWindowBound = (a: Rectangle, b: Rectangle): boolean =>
     a.x === b.x && a.y === b.y && a.height === b.height && a.width === b.width;
 
-export const defaultRectangle = (): Rectangle => {
-    const screenHeight = screen.getPrimaryDisplay().workAreaSize.height;
-    const screenWidth = screen.getPrimaryDisplay().workAreaSize.width;
-    const windowHeight = Math.min(WINDOW_DEFAULT_HEIGHT, screenHeight);
-    const windowWidth = Math.min(WINDOW_DEFAULT_WIDTH, screenWidth);
-    
+
+function getDefaultDisplay(): Display {
+
+    // https://github.com/microsoft/vscode/blob/509690479065730f9cdd62984046e39093ffcf76/src/vs/platform/windows/electron-main/windowsStateHandler.ts#L343
+    let displayToUse: Display | undefined;
+    const displays = screen.getAllDisplays();
+
+    // Single Display
+    if (displays.length === 1) {
+        displayToUse = displays[0];
+    }
+
+    // Multi Display
+    else {
+
+        // on mac there is 1 menu per window so we need to use the monitor where the cursor currently is
+        if (process.platform === "darwin") {
+            const cursorPoint = screen.getCursorScreenPoint();
+            displayToUse = screen.getDisplayNearestPoint(cursorPoint);
+        }
+        // fallback to primary display or first display
+        if (!displayToUse) {
+            displayToUse = screen.getPrimaryDisplay() || displays[0];
+        }
+    }
+
+    return displayToUse;
+}
+
+export const defaultWinBoundRectangle = (display?: Display, winBound: Rectangle = { x: 0, y: 0, height: WINDOW_DEFAULT_HEIGHT, width: WINDOW_DEFAULT_WIDTH }): Rectangle => {
+    let workArea: Rectangle;
+    if (display) {
+        workArea = getWorkingArea(display);
+    } else {
+        try {
+            const display = getDefaultDisplay();
+            workArea = getWorkingArea(display);
+        } catch { 
+            workArea = winBound;
+        }
+    }
+    const height = Math.min(winBound.height, workArea.height);
+    const width = Math.min(winBound.width, workArea.width);
+
+    const x = Math.round(Math.max(workArea.x, workArea.x + (workArea.width / 2) - (width / 2)));
+    const y = Math.round(Math.max(workArea.y, workArea.y + (workArea.height / 2) - (height / 2)));
+
     return {
-        height: windowHeight,
-        width: windowWidth,
-        y: Math.max(0, Math.round(screenHeight / 2 - windowHeight / 2)),
-        x: Math.max(0, Math.round(screenWidth / 2 - windowWidth / 2)),
+        width,
+        height,
+        x,
+        y,
     };
 };
 
-export const windowIsFullyVisible = (winBound: Rectangle): boolean => {
-    const windowWithinBounds = (containerBound: Rectangle, windowBound: Rectangle): boolean => {
-        return !!containerBound && !!windowBound && (
-            windowBound.x >= containerBound.x &&
-            windowBound.y >= containerBound.y &&
-            windowBound.x + windowBound.width <= containerBound.x + containerBound.width &&
-            windowBound.y + windowBound.height <= containerBound.y + containerBound.height
-        );
-    };
+// https://github.com/microsoft/vscode/blob/509690479065730f9cdd62984046e39093ffcf76/src/vs/platform/windows/electron-main/windows.ts#L405
+function getWorkingArea(display: Display): Rectangle | undefined {
 
-    const isVisible = screen.getAllDisplays().some((display) => {
-        return windowWithinBounds(display.workArea, winBound);
-    });
+    // Prefer the working area of the display to account for taskbars on the
+    // desktop being positioned somewhere (https://github.com/microsoft/vscode/issues/50830).
+    //
+    // Linux X11 sessions sometimes report wrong display bounds, so we validate
+    // the reported sizes are positive.
+    if (display.workArea.width > 0 && display.workArea.height > 0) {
+        return display.workArea;
+    }
 
-    return isVisible;
+    if (display.bounds.width > 0 && display.bounds.height > 0) {
+        return display.bounds;
+    }
+
+    return undefined;
+}
+
+// https://github.com/microsoft/vscode/blob/509690479065730f9cdd62984046e39093ffcf76/src/vs/platform/windows/electron-main/windows.ts#L384
+export const validateWindowBoundOnDisplay = (winBound: Rectangle, displayWorkingArea: Rectangle): winBound is Rectangle => {
+
+    return Boolean(
+        displayWorkingArea &&											            // we have valid working area bounds
+        winBound.x + winBound.width > displayWorkingArea.x &&					    // prevent window from falling out of the screen to the left
+        winBound.y + winBound.height > displayWorkingArea.y &&				        // prevent window from falling out of the screen to the top
+        winBound.x < displayWorkingArea.x + displayWorkingArea.width &&	            // prevent window from falling out of the screen to the right
+        winBound.y < displayWorkingArea.y + displayWorkingArea.height,		        // prevent window from falling out of the screen to the bottom
+    );
+};
+
+// export const winBoundIsFullyVisible = (winBound: Rectangle): boolean => {
+//     const windowWithinBounds = (displayWorkingArea: Rectangle, windowBound: Rectangle): boolean => {
+//         return !!displayWorkingArea && !!windowBound && (
+//             windowBound.x >= displayWorkingArea.x &&
+//             windowBound.y >= displayWorkingArea.y &&
+//             windowBound.x + windowBound.width <= displayWorkingArea.x + displayWorkingArea.width &&
+//             windowBound.y + windowBound.height <= displayWorkingArea.y + displayWorkingArea.height
+//         );
+//     };
+
+//     const isVisible = screen.getAllDisplays().some((display) => {
+//         const displayWorkingArea = getWorkingArea(display);
+//         return windowWithinBounds(displayWorkingArea, winBound);
+//     });
+
+//     return isVisible;
+// }
+
+
+export const ensureWinBoundCanBeSeenInDisplayWorkingArea = (winBound: Rectangle, displayWorkingArea: Rectangle) => {
+
+    // https://github.com/microsoft/vscode/blob/509690479065730f9cdd62984046e39093ffcf76/src/vs/platform/windows/electron-main/windows.ts#L283-L288
+    // Single Monitor: be strict about x/y positioning
+    // macOS & Linux: these OS seem to be pretty good in ensuring that a window is never outside of it's bounds.
+    // Windows: it is possible to have a window with a size that makes it fall out of the window. our strategy
+    //          is to try as much as possible to keep the window in the monitor bounds. we are not as strict as
+    //          macOS and Linux and allow the window to exceed the monitor bounds as long as the window is still
+    //          some pixels (128) visible on the screen for the user to drag it back.
+
+
+    // prevent window from falling out of the screen to the right with
+    // 128px margin by positioning the window to the far right edge of the screen
+    winBound.x = Math.max(displayWorkingArea.x, Math.min(winBound.x, displayWorkingArea.x + displayWorkingArea.width - 128));
+
+    // prevent window from falling out of the screen to the bottom with
+    // 128px margin by positioning the window to the far right edge of the screen
+    winBound.y = Math.max(displayWorkingArea.y, Math.min(winBound.y, displayWorkingArea.y + displayWorkingArea.height - 128));
+
+    winBound.width = Math.min(winBound.width, displayWorkingArea.width);
+    winBound.height = Math.min(winBound.height, displayWorkingArea.height);
 };
 
 export const normalizeWinBoundRectangle = (winBound: Rectangle): Rectangle => {
 
     if (!winBound) {
-        return defaultRectangle();
+        return defaultWinBoundRectangle();
     }
 
     const winBoundCopy = {...winBound};
 
-    if (!winBound.x) {// NaN, undefined, null, zero (positive and negative numbers are truthy)
+    if (!winBound.x || typeof winBound.x !== "number") {// NaN, undefined, null, zero (positive and negative numbers are truthy)
         winBoundCopy.x = 0;
     }
-    if (!winBound.y) {
+    if (!winBound.y || typeof winBound.y !== "number") {
         winBoundCopy.y = 0;
     }
-    if (!winBound.height) {
-        winBoundCopy.height = defaultRectangle().height;
+    if (!winBound.height || typeof winBound.height !== "number" || winBound.height < WINDOW_MIN_HEIGHT) {
+        winBoundCopy.height = WINDOW_MIN_HEIGHT;
     }
-    if (!winBound.width) {
-        winBoundCopy.width = defaultRectangle().width;
-    }
-
-    if (windowIsFullyVisible(winBoundCopy)) {
-        return winBoundCopy;
+    if (!winBound.width || typeof winBound.width !== "number" || winBound.width < WINDOW_MIN_WIDTH) {
+        winBoundCopy.width = WINDOW_MIN_WIDTH;
     }
 
-    return defaultRectangle();
+    try {
+        const displays = screen.getAllDisplays();
+
+        // Single Display
+        if (displays.length === 1) {
+            const displayWorkingArea = getWorkingArea(displays[0]);
+            ensureWinBoundCanBeSeenInDisplayWorkingArea(winBoundCopy, displayWorkingArea);
+        } else {
+
+            const display = screen.getDisplayMatching(winBoundCopy);
+            const displayWorkingArea = getWorkingArea(display);
+            if (!validateWindowBoundOnDisplay(winBoundCopy, displayWorkingArea)) {
+                return defaultWinBoundRectangle(display, winBound);
+            } else {
+                ensureWinBoundCanBeSeenInDisplayWorkingArea(winBoundCopy, displayWorkingArea);
+            }
+        }
+    } catch {
+        // https://github.com/microsoft/vscode/blob/509690479065730f9cdd62984046e39093ffcf76/src/vs/platform/windows/electron-main/windows.ts#L369-L371
+        // Electron has weird conditions under which it throws errors
+        // e.g. https://github.com/microsoft/vscode/issues/100334 when
+        // large numbers are passed in
+        return defaultWinBoundRectangle(undefined, winBound);
+    }
+
+    return winBoundCopy;
 };

--- a/src/common/rectangle/window.ts
+++ b/src/common/rectangle/window.ts
@@ -13,18 +13,16 @@ import { /*BrowserWindow,*/ Rectangle, screen } from "electron";
 
 export const defaultRectangle = (): Rectangle => (
     {
-        height: 600,
-        width: 800,
-        x: Math.round(screen.getPrimaryDisplay().workAreaSize.width / 3),
-        y: Math.round(screen.getPrimaryDisplay().workAreaSize.height / 3),
+        height: 768,
+        width: 1024,
+        x: Math.max(0, Math.round(screen.getPrimaryDisplay().workAreaSize.width / 2 - 1024 / 2)),
+        y: Math.max(0, Math.round(screen.getPrimaryDisplay().workAreaSize.height / 2 - 768 / 2)),
     });
 
-export const normalizeRectangle = (winBound: Rectangle): Rectangle | undefined => {
+export const normalizeRectangle = (winBound: Rectangle): Rectangle => {
 
-    // TS strictNullChecks would flag this incoherent check ...
-    // ... but the "window bounds" code has been brittle so let's err on the side of caution
     if (!winBound) {
-        return undefined;
+        return defaultRectangle();
     }
 
     const normalizeBound = { ...winBound };

--- a/src/common/rectangle/window.ts
+++ b/src/common/rectangle/window.ts
@@ -6,42 +6,70 @@
 // ==LICENSE-END==
 
 import { /*BrowserWindow,*/ Rectangle, screen } from "electron";
+import { WINDOW_DEFAULT_HEIGHT, WINDOW_DEFAULT_WIDTH } from "../constant";
 
 // import debug_ from "debug";
 // // Logger
 // const debug = debug_("readium-desktop:common:rectangle:window");
 
-export const defaultRectangle = (): Rectangle => (
-    {
-        height: 768,
-        width: 1024,
-        x: Math.max(0, Math.round(screen.getPrimaryDisplay().workAreaSize.width / 2 - 1024 / 2)),
-        y: Math.max(0, Math.round(screen.getPrimaryDisplay().workAreaSize.height / 2 - 768 / 2)),
+export const compareWindowBound = (a: Rectangle, b: Rectangle): boolean =>
+    a.x === b.x && a.y === b.y && a.height === b.height && a.width === b.width;
+
+export const defaultRectangle = (): Rectangle => {
+    const screenHeight = screen.getPrimaryDisplay().workAreaSize.height;
+    const screenWidth = screen.getPrimaryDisplay().workAreaSize.width;
+    const windowHeight = Math.min(WINDOW_DEFAULT_HEIGHT, screenHeight);
+    const windowWidth = Math.min(WINDOW_DEFAULT_WIDTH, screenWidth);
+    
+    return {
+        height: windowHeight,
+        width: windowWidth,
+        y: Math.max(0, Math.round(screenHeight / 2 - windowHeight / 2)),
+        x: Math.max(0, Math.round(screenWidth / 2 - windowWidth / 2)),
+    };
+};
+
+export const windowIsFullyVisible = (winBound: Rectangle): boolean => {
+    const windowWithinBounds = (containerBound: Rectangle, windowBound: Rectangle): boolean => {
+        return !!containerBound && !!windowBound && (
+            windowBound.x >= containerBound.x &&
+            windowBound.y >= containerBound.y &&
+            windowBound.x + windowBound.width <= containerBound.x + containerBound.width &&
+            windowBound.y + windowBound.height <= containerBound.y + containerBound.height
+        );
+    };
+
+    const isVisible = screen.getAllDisplays().some((display) => {
+        return windowWithinBounds(display.workArea, winBound);
     });
 
-export const normalizeRectangle = (winBound: Rectangle): Rectangle => {
+    return isVisible;
+};
+
+export const normalizeWinBoundRectangle = (winBound: Rectangle): Rectangle => {
 
     if (!winBound) {
         return defaultRectangle();
     }
 
-    const normalizeBound = { ...winBound };
+    const winBoundCopy = {...winBound};
 
-    const windowWithinBounds = (bounds: Rectangle, state: Rectangle): boolean => {
-        return !!bounds && !!state && (
-            state.x >= bounds.x &&
-            state.y >= bounds.y &&
-            state.x + state.width <= bounds.x + bounds.width &&
-            state.y + state.height <= bounds.y + bounds.height
-        );
-    };
-
-    const visible = screen.getAllDisplays().some((display) => {
-        return windowWithinBounds(display.workArea, normalizeBound);
-    });
-
-    if (visible) {
-        return normalizeBound;
+    if (!winBound.x) {// NaN, undefined, null, zero (positive and negative numbers are truthy)
+        winBoundCopy.x = 0;
     }
+    if (!winBound.y) {
+        winBoundCopy.y = 0;
+    }
+    if (!winBound.height) {
+        winBoundCopy.height = defaultRectangle().height;
+    }
+    if (!winBound.width) {
+        winBoundCopy.width = defaultRectangle().width;
+    }
+
+    if (windowIsFullyVisible(winBoundCopy)) {
+        return winBoundCopy;
+    }
+
     return defaultRectangle();
 };

--- a/src/main/redux/actions/win/session/setBound.ts
+++ b/src/main/redux/actions/win/session/setBound.ts
@@ -11,18 +11,18 @@ import { Action } from "readium-desktop/common/models/redux";
 export const ID = "WIN_SESSION_SET_BOUND";
 
 export interface Payload {
-    identifier: string;
-    bound: Rectangle;
+    windowIdentifier: string;
+    winBound: Rectangle;
 }
 
-export function build(id: string, bound: Rectangle):
+export function build(windowIdentifier: string, winBound: Rectangle):
     Action<typeof ID, Payload> {
 
     return {
         type: ID,
         payload: {
-            identifier: id,
-            bound,
+            windowIdentifier: windowIdentifier,
+            winBound,
         },
     };
 }

--- a/src/main/redux/actions/win/session/setBound.ts
+++ b/src/main/redux/actions/win/session/setBound.ts
@@ -21,7 +21,7 @@ export function build(windowIdentifier: string, winBound: Rectangle):
     return {
         type: ID,
         payload: {
-            windowIdentifier: windowIdentifier,
+            windowIdentifier,
             winBound,
         },
     };

--- a/src/main/redux/reducers/win/session/library.ts
+++ b/src/main/redux/reducers/win/session/library.ts
@@ -30,7 +30,7 @@ function winSessionLibraryReducer_(
                 ...{
                     browserWindowId: action.payload.win.id,
                     identifier: action.payload.identifier,
-                    windowBound: action.payload.winBound,
+                    windowBound: {...action.payload.winBound},
                 },
             };
 
@@ -44,11 +44,11 @@ function winSessionLibraryReducer_(
             };
 
         case winActions.session.setBound.ID:
-            if (state.identifier === action.payload.identifier) {
+            if (state.identifier === action.payload.windowIdentifier) {
                 return {
                     ...state,
                     ...{
-                        windowBound: action.payload.bound,
+                        windowBound: {...action.payload.winBound},
                     },
                 };
             }

--- a/src/main/redux/reducers/win/session/reader.ts
+++ b/src/main/redux/reducers/win/session/reader.ts
@@ -30,7 +30,7 @@ function winSessionReaderReducer_(
                 ...{
                     [id]: {
                         ...{
-                            windowBound: action.payload.winBound,
+                            windowBound: {...action.payload.winBound},
                             reduxState: action.payload.reduxStateReader,
                         },
                         ...state[id],
@@ -62,7 +62,7 @@ function winSessionReaderReducer_(
 
         case winActions.session.setBound.ID: {
 
-            const id = action.payload.identifier;
+            const id = action.payload.windowIdentifier;
 
             if (state[id]) {
                 return {
@@ -71,7 +71,7 @@ function winSessionReaderReducer_(
                         [id]: {
                             ...state[id],
                             ...{
-                                windowBound: action.payload.bound,
+                                windowBound: {...action.payload.winBound},
                             },
                         },
                     },

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -215,8 +215,8 @@ export function saga() {
             winActions.session.setBound.ID,
             function* (action: winActions.session.setBound.TAction) {
                 const payload = action.payload;
-                const identifier = payload.identifier;
-                const boundJsonObj = payload.bound;
+                const identifier = payload.windowIdentifier;
+                const boundJsonObj = payload.winBound;
 
                 const reader = yield* selectTyped((state: RootState) => state.win.session.reader[identifier]);
                 if (!reader) {

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -211,24 +211,35 @@ export function saga() {
             winActions.persistRequest.ID,
             needToPersistPatch,
         ),
-        takeSpawnLeading(
-            winActions.session.setBound.ID,
-            function* (action: winActions.session.setBound.TAction) {
-                const payload = action.payload;
-                const identifier = payload.windowIdentifier;
-                const boundJsonObj = payload.winBound;
+        // takeSpawnLeading(
+        //     winActions.session.registerReader.ID,
+        //     function* (action: winActions.session.registerReader.TAction) {
+        //         const payload = action.payload;
+        //         const boundJsonObj = payload.winBound;
+        //         const pubId = action.payload.publicationIdentifier;
 
-                const reader = yield* selectTyped((state: RootState) => state.win.session.reader[identifier]);
-                if (!reader) {
-                    debug("ERROR!!! no reader sender found in session !!!");
-                    return;
-                }
-                const pubId = reader.publicationIdentifier;
+        //         yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", boundJsonObj));
+        //     },
+        //     (e) => debug(e),
+        // ),
+        // takeSpawnLeading(
+        //     winActions.session.setBound.ID,
+        //     function* (action: winActions.session.setBound.TAction) {
+        //         const payload = action.payload;
+        //         const identifier = payload.windowIdentifier;
+        //         const boundJsonObj = payload.winBound;
 
-                yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", boundJsonObj));
-            },
-            (e) => debug(e),
-        ),
+        //         const reader = yield* selectTyped((state: RootState) => state.win.session.reader[identifier]);
+        //         if (!reader) {
+        //             debug("ERROR!!! no reader sender found in session !!!");
+        //             return;
+        //         }
+        //         const pubId = reader.publicationIdentifier;
+
+        //         yield* callTyped(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", boundJsonObj));
+        //     },
+        //     (e) => debug(e),
+        // ),
         takeSpawnLeading(
             readerActions.pdfConfig.ID,
             function* (action: readerActions.pdfConfig.TAction) {

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -6,12 +6,12 @@
 // ==LICENSE-END==
 
 import debug_ from "debug";
-import { clipboard, screen } from "electron";
+import { clipboard } from "electron";
 import { ReaderMode } from "readium-desktop/common/models/reader";
 import { Action } from "readium-desktop/common/models/redux";
 import { ActionWithDestination, ActionWithSender, SenderType } from "readium-desktop/common/models/sync";
 import { ToastType } from "readium-desktop/common/models/toast";
-import { compareWindowBound, defaultRectangle, normalizeWinBoundRectangle, windowIsFullyVisible } from "readium-desktop/common/rectangle/window";
+import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { readerActions, toastActions } from "readium-desktop/common/redux/actions";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLeading";
@@ -103,64 +103,28 @@ function* readerDetachRequest(action: readerActions.detachModeRequest.TAction) {
 export function* readerNewWindowBound(publicationIdentifier: string | undefined): SagaGenerator<Electron.Rectangle> {
 
     const libraryBrowserWindows = getLibraryWindowFromDi();
-    const browserWindowBoundList: Electron.Rectangle[] = [];
+    const existingWindowBounds: Electron.Rectangle[] = [];
     if (libraryBrowserWindows && !libraryBrowserWindows.isDestroyed()) {
-        const winBound = libraryBrowserWindows.getNormalBounds(); // get normal state not fullscreen/maximized/minimized window’s before it was maximized or fullscreened
-        if (windowIsFullyVisible(winBound)) {
-            browserWindowBoundList.push(winBound);
-        }
+        existingWindowBounds.push(getLibraryWindowFromDi().getBounds());
     }
 
     const savedWindowBound = (yield* callTyped(() => diMainGet("publication-data").readJsonObj(publicationIdentifier, "bound"))) as any; // TODO: type object
-    let windowBound: Electron.Rectangle = savedWindowBound;
+    const windowBound = normalizeWinBoundRectangle(savedWindowBound || existingWindowBounds[0]);
     if (savedWindowBound) {
-        try {
-            windowBound = normalizeWinBoundRectangle(windowBound);
-        } catch (e) {
-            debug(`${e}`);
-            windowBound = defaultRectangle();
-        }
 
         const readerBrowserWindows = getAllReaderWindowFromDi();
-        for (const reader of readerBrowserWindows) {
-            if (reader && !reader.isDestroyed()) {
-                const winBound = reader.getNormalBounds(); // get normal state not fullscreen/maximized/minimized window’s before it was maximized or fullscreened
-                if (windowIsFullyVisible(winBound)) {
-                    browserWindowBoundList.push(winBound);
-                }
+        for (const readerBrowserWindow of readerBrowserWindows) {
+            if (readerBrowserWindow && !readerBrowserWindow.isDestroyed()) {
+                existingWindowBounds.push(readerBrowserWindow.getBounds());
             }
         }
-    } else {
-        windowBound = browserWindowBoundList[0] || defaultRectangle(); // track library window
     }
-    debug(`pubId=${publicationIdentifier} winBound=${JSON.stringify(windowBound, null, 4)}`);
 
-    const displayArea = screen.getPrimaryDisplay().workAreaSize;
-    const windowBoundCopy = { ...windowBound };
-    let numberOfBrowserWindows = browserWindowBoundList.length;
-    do {
-        const windowBoundHided = browserWindowBoundList.some((browserWindowBound) => compareWindowBound(windowBoundCopy, browserWindowBound));
-        if (!windowBoundHided) {
-            if (windowIsFullyVisible(windowBoundCopy)) {
-                windowBound = windowBoundCopy;
-                break;
-            }
-        }
-        windowBoundCopy.x += 20;
-        const wDiff = Math.abs(displayArea.width - windowBoundCopy.width);
-        if (wDiff) {
-            windowBoundCopy.x %= wDiff;
-        }
-        windowBoundCopy.y += 20;
-        const hDiff = Math.abs(displayArea.height - windowBoundCopy.height);
-        if (hDiff) {
-            windowBoundCopy.y %= hDiff;
-        }
-        numberOfBrowserWindows--;
-    } while (numberOfBrowserWindows >= 0);
+    while (existingWindowBounds.some((existingBounds) => existingBounds.x === windowBound.x && existingBounds.y === existingBounds.y)) {
+        windowBound.x += 30;
+        windowBound.y += 30;
+    }
 
-
-    windowBound = normalizeWinBoundRectangle(windowBound);
     debug(`pubId=${publicationIdentifier} winBound=${JSON.stringify(windowBound, null, 4)}`);
     return windowBound;
 }

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -105,6 +105,9 @@ function* readerDetachRequest(action: readerActions.detachModeRequest.TAction) {
 export function* getWinBound(publicationIdentifier: string | undefined): SagaGenerator<Electron.Rectangle> {
 
     const readers = yield* selectTyped((state: RootState) => state.win.session.reader);
+
+    debug("LIST OF READERS: ", JSON.stringify(readers, null, 4));
+
     const library = yield* selectTyped((state: RootState) => state.win.session.library);
     const readerArray = ObjectValues(readers);
 
@@ -126,52 +129,49 @@ export function* getWinBound(publicationIdentifier: string | undefined): SagaGen
     }
     debug(`reader[${publicationIdentifier}]?.winBound}`, winBound);
 
-    const winBoundArray = readerArray.map((reader) => reader.windowBound);
-    winBoundArray.push(library.windowBound);
+    const winBoundArray = readerArray.map((reader) => reader.windowBound ? normalizeRectangle(reader.windowBound) : undefined).filter((v) => !!v);
+
+    debug("WIN BOUND ARRAY:", JSON.stringify(winBoundArray, null, 4));
+    if (library.windowBound) {
+        winBoundArray.push(normalizeRectangle(library.windowBound));
+    }
     const winBoundAlreadyTaken = !winBound || !!winBoundArray.find((bound) => ramda.equals(winBound, bound));
 
-    if (
-        !winBound
-        || winBoundAlreadyTaken
-    ) {
-        // if (readerArray.length) {
+    if (winBoundAlreadyTaken) {
+        const displayArea = yield* callTyped(() => screen.getPrimaryDisplay().workAreaSize);
+        debug("displayArea", displayArea);
 
-            const displayArea = yield* callTyped(() => screen.getPrimaryDisplay().workAreaSize);
-            debug("displayArea", displayArea);
+        const winBoundWithOffset = winBoundArray.map(
+            (rect) => {
+                if (!rect.x) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
+                    rect.x = 0;
+                }
+                rect.x += 20;
+                const wDiff = Math.abs(displayArea.width - rect.width);
+                if (wDiff) {
+                    rect.x %= wDiff;
+                }
 
-            const winBoundWithOffset = winBoundArray.map(
-                (rect) => {
-                    if (!rect.x) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
-                        rect.x = 0;
-                    }
-                    rect.x += 20;
-                    const wDiff = Math.abs(displayArea.width - rect.width);
-                    if (wDiff) {
-                        rect.x %= wDiff;
-                    }
+                if (!rect.y) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
+                    rect.y = 0;
+                }
+                rect.y += 20;
+                const hDiff = Math.abs(displayArea.height - rect.height);
+                if (hDiff) {
+                    rect.y %= hDiff;
+                }
 
-                    if (!rect.y) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
-                        rect.y = 0;
-                    }
-                    rect.y += 20;
-                    const hDiff = Math.abs(displayArea.height - rect.height);
-                    if (hDiff) {
-                        rect.y %= hDiff;
-                    }
+                debug("rect", rect);
+                return rect;
+            },
+        );
+        debug("winBoundWithOffset", winBoundWithOffset);
 
-                    debug("rect", rect);
-                    return rect;
-                },
-            );
-            debug("winBoundWithOffset", winBoundWithOffset);
+        [winBound] = ramda.uniq(winBoundWithOffset);
+        debug("winBound", winBound);
+        winBound = normalizeRectangle(winBound);
 
-            [winBound] = ramda.uniq(winBoundWithOffset);
-            debug("winBound", winBound);
-            winBound = normalizeRectangle(winBound);
 
-        // } else {
-        //     winBound = normalizeRectangle(library.windowBound);
-        // }
     }
 
     return winBound;

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -7,20 +7,18 @@
 
 import debug_ from "debug";
 import { clipboard, screen } from "electron";
-import * as ramda from "ramda";
 import { ReaderMode } from "readium-desktop/common/models/reader";
 import { Action } from "readium-desktop/common/models/redux";
 import { ActionWithDestination, ActionWithSender, SenderType } from "readium-desktop/common/models/sync";
 import { ToastType } from "readium-desktop/common/models/toast";
-import { defaultRectangle, normalizeRectangle } from "readium-desktop/common/rectangle/window";
+import { compareWindowBound, defaultRectangle, normalizeWinBoundRectangle, windowIsFullyVisible } from "readium-desktop/common/rectangle/window";
 import { readerActions, toastActions } from "readium-desktop/common/redux/actions";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLeading";
-import { diMainGet, getLibraryWindowFromDi, getReaderWindowFromDi } from "readium-desktop/main/di";
+import { diMainGet, getAllReaderWindowFromDi, getLibraryWindowFromDi, getReaderWindowFromDi } from "readium-desktop/main/di";
 import { error } from "readium-desktop/main/tools/error";
 import { streamerActions } from "readium-desktop/main/redux/actions";
 import { RootState } from "readium-desktop/main/redux/states";
-import { ObjectValues } from "readium-desktop/utils/object-keys-values";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { all, call, put, take } from "redux-saga/effects";
 import { call as callTyped, select as selectTyped, put as putTyped, SagaGenerator } from "typed-redux-saga/macro";
@@ -69,7 +67,7 @@ function* readerDetachRequest(action: readerActions.detachModeRequest.TAction) {
         let libBound: Electron.Rectangle;
         try {
             // get an bound with offset
-            libBound = yield* callTyped(getWinBound, undefined);
+            libBound = yield* callTyped(readerNewWindowBound, undefined);
             debug("getWinBound(undefined)", libBound);
             if (libBound) {
                 libWin.setBounds(libBound);
@@ -102,79 +100,69 @@ function* readerDetachRequest(action: readerActions.detachModeRequest.TAction) {
     yield put(readerActions.detachModeSuccess.build());
 }
 
-export function* getWinBound(publicationIdentifier: string | undefined): SagaGenerator<Electron.Rectangle> {
+export function* readerNewWindowBound(publicationIdentifier: string | undefined): SagaGenerator<Electron.Rectangle> {
 
-    const readers = yield* selectTyped((state: RootState) => state.win.session.reader);
-
-    debug("LIST OF READERS: ", JSON.stringify(readers, null, 4));
-
-    const library = yield* selectTyped((state: RootState) => state.win.session.library);
-    const readerArray = ObjectValues(readers);
-
-    debug("library.windowBound", library.windowBound);
-    // normalizeRectangle(library.windowBound);
-
-    // if (readerArray.length === 0) {
-    //     return library.windowBound;
-    // }
-
-    // let winBound = (yield* selectTyped(
-    //     (state: RootState) => state.win.registry.reader[publicationIdentifier]?.windowBound,
-    // )) as Electron.Rectangle | undefined;
-    let winBound: Electron.Rectangle | undefined = yield* callTyped(() => diMainGet("publication-data").readJsonObj(publicationIdentifier, "bound")) as any; // TODO: type object
-    try {
-        winBound = normalizeRectangle(winBound);
-    } catch {
-        winBound = defaultRectangle();
-    }
-    debug(`reader[${publicationIdentifier}]?.winBound}`, winBound);
-
-    const winBoundArray = readerArray.map((reader) => reader.windowBound ? normalizeRectangle(reader.windowBound) : undefined).filter((v) => !!v);
-
-    debug("WIN BOUND ARRAY:", JSON.stringify(winBoundArray, null, 4));
-    if (library.windowBound) {
-        winBoundArray.push(normalizeRectangle(library.windowBound));
-    }
-    const winBoundAlreadyTaken = !winBound || !!winBoundArray.find((bound) => ramda.equals(winBound, bound));
-
-    if (winBoundAlreadyTaken) {
-        const displayArea = yield* callTyped(() => screen.getPrimaryDisplay().workAreaSize);
-        debug("displayArea", displayArea);
-
-        const winBoundWithOffset = winBoundArray.map(
-            (rect) => {
-                if (!rect.x) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
-                    rect.x = 0;
-                }
-                rect.x += 20;
-                const wDiff = Math.abs(displayArea.width - rect.width);
-                if (wDiff) {
-                    rect.x %= wDiff;
-                }
-
-                if (!rect.y) { // NaN, undefined, null, zero (positive and negative numbers are truthy)
-                    rect.y = 0;
-                }
-                rect.y += 20;
-                const hDiff = Math.abs(displayArea.height - rect.height);
-                if (hDiff) {
-                    rect.y %= hDiff;
-                }
-
-                debug("rect", rect);
-                return rect;
-            },
-        );
-        debug("winBoundWithOffset", winBoundWithOffset);
-
-        [winBound] = ramda.uniq(winBoundWithOffset);
-        debug("winBound", winBound);
-        winBound = normalizeRectangle(winBound);
-
-
+    const libraryBrowserWindows = getLibraryWindowFromDi();
+    const browserWindowBoundList: Electron.Rectangle[] = [];
+    if (libraryBrowserWindows && !libraryBrowserWindows.isDestroyed()) {
+        const winBound = libraryBrowserWindows.getNormalBounds(); // get normal state not fullscreen/maximized/minimized
+        if (windowIsFullyVisible(winBound)) {
+            browserWindowBoundList.push(winBound);
+        }
     }
 
-    return winBound;
+    const savedWindowBound = (yield* callTyped(() => diMainGet("publication-data").readJsonObj(publicationIdentifier, "bound"))) as any; // TODO: type object
+    let windowBound: Electron.Rectangle = savedWindowBound;
+    if (savedWindowBound) {
+        try {
+            windowBound = normalizeWinBoundRectangle(windowBound);
+        } catch (e) {
+            debug(`${e}`);
+            windowBound = defaultRectangle();
+        }
+
+        const readerBrowserWindows = getAllReaderWindowFromDi();
+        for (const reader of readerBrowserWindows) {
+            if (reader && !reader.isDestroyed()) {
+                const winBound = reader.getNormalBounds(); // get normal state not fullscreen/maximized/minimized
+                if (windowIsFullyVisible(winBound)) {
+                    browserWindowBoundList.push(winBound);
+                }
+            }
+        }
+    } else {
+        windowBound = browserWindowBoundList[0] || defaultRectangle(); // track library window
+    }
+    debug(`pubId=${publicationIdentifier} winBound=${JSON.stringify(windowBound, null, 4)}`);
+
+    const displayArea = screen.getPrimaryDisplay().workAreaSize;
+    const windowBoundCopy = { ...windowBound };
+    let numberOfBrowserWindows = browserWindowBoundList.length;
+    do {
+        const windowBoundHided = browserWindowBoundList.some((browserWindowBound) => compareWindowBound(windowBoundCopy, browserWindowBound));
+        if (!windowBoundHided) {
+            if (windowIsFullyVisible(windowBoundCopy)) {
+                windowBound = windowBoundCopy;
+                break;
+            }
+        }
+        windowBoundCopy.x += 20;
+        const wDiff = Math.abs(displayArea.width - windowBoundCopy.width);
+        if (wDiff) {
+            windowBoundCopy.x %= wDiff;
+        }
+        windowBoundCopy.y += 20;
+        const hDiff = Math.abs(displayArea.height - windowBoundCopy.height);
+        if (hDiff) {
+            windowBoundCopy.y %= hDiff;
+        }
+        numberOfBrowserWindows--;
+    } while (numberOfBrowserWindows >= 0);
+
+
+    windowBound = normalizeWinBoundRectangle(windowBound);
+    debug(`pubId=${publicationIdentifier} winBound=${JSON.stringify(windowBound, null, 4)}`);
+    return windowBound;
 }
 
 function* readerOpenRequest(action: readerActions.openRequest.TAction) {

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -105,7 +105,7 @@ export function* readerNewWindowBound(publicationIdentifier: string | undefined)
     const libraryBrowserWindows = getLibraryWindowFromDi();
     const browserWindowBoundList: Electron.Rectangle[] = [];
     if (libraryBrowserWindows && !libraryBrowserWindows.isDestroyed()) {
-        const winBound = libraryBrowserWindows.getNormalBounds(); // get normal state not fullscreen/maximized/minimized
+        const winBound = libraryBrowserWindows.getNormalBounds(); // get normal state not fullscreen/maximized/minimized window’s before it was maximized or fullscreened
         if (windowIsFullyVisible(winBound)) {
             browserWindowBoundList.push(winBound);
         }
@@ -124,7 +124,7 @@ export function* readerNewWindowBound(publicationIdentifier: string | undefined)
         const readerBrowserWindows = getAllReaderWindowFromDi();
         for (const reader of readerBrowserWindows) {
             if (reader && !reader.isDestroyed()) {
-                const winBound = reader.getNormalBounds(); // get normal state not fullscreen/maximized/minimized
+                const winBound = reader.getNormalBounds(); // get normal state not fullscreen/maximized/minimized window’s before it was maximized or fullscreened
                 if (windowIsFullyVisible(winBound)) {
                     browserWindowBoundList.push(winBound);
                 }

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -9,7 +9,7 @@ import debug_ from "debug";
 import { encodeURIComponent_RFC3986 } from "@r2-utils-js/_utils/http/UrlUtils";
 import { BrowserWindow, Event as ElectronEvent, HandlerDetails, shell, WebContentsWillNavigateEventParams } from "electron";
 import * as path from "path";
-import { defaultRectangle, normalizeRectangle } from "readium-desktop/common/rectangle/window";
+import { defaultRectangle, normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
 import { setMenu } from "readium-desktop/main/menu";
 import { winActions } from "readium-desktop/main/redux/actions";
@@ -41,7 +41,7 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
     // initial state apply in reducers
     let windowBound = yield* selectTyped(
         (state: RootState) => state.win.session.library.windowBound);
-    windowBound = normalizeRectangle(windowBound);
+    windowBound = normalizeWinBoundRectangle(windowBound);
     if (!windowBound) {
         windowBound = defaultRectangle();
     }

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -9,7 +9,7 @@ import debug_ from "debug";
 import { encodeURIComponent_RFC3986 } from "@r2-utils-js/_utils/http/UrlUtils";
 import { BrowserWindow, Event as ElectronEvent, HandlerDetails, shell, WebContentsWillNavigateEventParams } from "electron";
 import * as path from "path";
-import { defaultRectangle, normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
+import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
 import { setMenu } from "readium-desktop/main/menu";
 import { winActions } from "readium-desktop/main/redux/actions";
@@ -42,9 +42,6 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
     let windowBound = yield* selectTyped(
         (state: RootState) => state.win.session.library.windowBound);
     windowBound = normalizeWinBoundRectangle(windowBound);
-    if (!windowBound) {
-        windowBound = defaultRectangle();
-    }
 
     libWindow = new BrowserWindow({
         ...windowBound,

--- a/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
@@ -25,7 +25,7 @@ import {
 import { getPublication } from "../../api/publication/getPublication";
 import { TIMEOUT_BROWSER_WINDOW_INITIALISATION, WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH } from "readium-desktop/common/constant";
 import { URL_PROTOCOL_FILEX, URL_HOST_COMMON } from "readium-desktop/common/streamerProtocol";
-import { getWinBound } from "../../reader";
+import { readerNewWindowBound } from "../../reader";
 import { winCommonActions } from "readium-desktop/common/redux/actions";
 
 // Logger
@@ -45,7 +45,7 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
     assertUUIDv4(windowIdentifier);
     assertUUIDv4(publicationIdentifier);
     
-    const winBound = yield* callTyped(getWinBound, publicationIdentifier);
+    const winBound = yield* callTyped(readerNewWindowBound, publicationIdentifier);
     const readerWindow = new BrowserWindow({
         ...winBound,
         minWidth: WINDOW_MIN_WIDTH,

--- a/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
@@ -9,9 +9,9 @@ import { encodeURIComponent_RFC3986 } from "@r2-utils-js/_utils/http/UrlUtils";
 import debug_ from "debug";
 import { BrowserWindow, Event as ElectronEvent, HandlerDetails, shell, WebContentsWillNavigateEventParams } from "electron";
 import * as path from "path";
-import { call as callTyped, put as putTyped, race as raceTyped, take as takeTyped, delay as delayTyped, spawn as spawnTyped, SagaGenerator } from "typed-redux-saga/macro";
+import { call as callTyped, put as putTyped, race as raceTyped, take as takeTyped, delay as delayTyped, spawn as spawnTyped, fork as forkTyped, SagaGenerator } from "typed-redux-saga/macro";
 import { buffers, END, eventChannel } from "redux-saga";
-import { saveReaderWindowInDi } from "readium-desktop/main/di";
+import { diMainGet, saveReaderWindowInDi } from "readium-desktop/main/di";
 import { setMenu } from "readium-desktop/main/menu";
 import { winActions } from "readium-desktop/main/redux/actions";
 import {
@@ -91,6 +91,7 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
         // reduxState,
         windowIdentifier,
     ));
+    yield* forkTyped(() => diMainGet("publication-data").writeJsonObj(publicationIdentifier, "bound", winBound));
 
     saveReaderWindowInDi(readerWindow, windowIdentifier);
 

--- a/src/main/redux/sagas/win/reader.ts
+++ b/src/main/redux/sagas/win/reader.ts
@@ -8,7 +8,7 @@
 import debug_ from "debug";
 import { readerIpc } from "readium-desktop/common/ipc";
 import { ReaderInfo, ReaderMode } from "readium-desktop/common/models/reader";
-import { normalizeRectangle } from "readium-desktop/common/rectangle/window";
+import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { deleteReaderWindowInDi, diMainGet, getLibraryWindowFromDi, getReaderWindowFromDi } from "readium-desktop/main/di";
 import { error } from "readium-desktop/main/tools/error";
@@ -233,7 +233,7 @@ export function* winClose(windowIdentifier: string, publicationIdentifier: strin
                         try {
                             let winBound = readerWin.getBounds();
                             debug("_______3 readerWin.getBounds()", winBound);
-                            winBound = normalizeRectangle(winBound);
+                            winBound = normalizeWinBoundRectangle(winBound);
 
                             if (libraryWin && !libraryWin.isDestroyed() && !libraryWin.webContents.isDestroyed()) {
                                 libraryWin.setBounds(winBound);

--- a/src/main/redux/sagas/win/reader.ts
+++ b/src/main/redux/sagas/win/reader.ts
@@ -231,9 +231,9 @@ export function* winClose(windowIdentifier: string, publicationIdentifier: strin
                     const readerWin = yield* callTyped(() => getReaderWindowFromDi(windowIdentifier));
                     if (readerWin && !readerWin.isDestroyed() && !readerWin.webContents.isDestroyed()) {
                         try {
-                            const winBound = readerWin.getBounds();
+                            let winBound = readerWin.getBounds();
                             debug("_______3 readerWin.getBounds()", winBound);
-                            normalizeRectangle(winBound);
+                            winBound = normalizeRectangle(winBound);
 
                             if (libraryWin && !libraryWin.isDestroyed() && !libraryWin.webContents.isDestroyed()) {
                                 libraryWin.setBounds(winBound);

--- a/src/main/redux/sagas/win/session/library.ts
+++ b/src/main/redux/sagas/win/session/library.ts
@@ -76,7 +76,7 @@ function* libraryMoveOrResizeObserver(action: winActions.session.registerLibrary
     yield debounce(DEBOUNCE_TIME, channel, function*() {
 
         try {
-            let winBound = library.getBounds();
+            let winBound = library.getBounds(); // current bounds of the window maximized/fullscreen/minimized (not on windows11, specific events)
             debug("_______2 library.getBounds()", winBound);
             winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));

--- a/src/main/redux/sagas/win/session/library.ts
+++ b/src/main/redux/sagas/win/session/library.ts
@@ -78,7 +78,7 @@ function* libraryMoveOrResizeObserver(action: winActions.session.registerLibrary
         try {
             let winBound = library.getBounds(); // current bounds of the window maximized/fullscreen/minimized (not on windows11, specific events)
             debug("_______2 library.getBounds()", winBound);
-            winBound = normalizeWinBoundRectangle(winBound);
+            // winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
         } catch (e) {
             debug("set library bound error", e);

--- a/src/main/redux/sagas/win/session/library.ts
+++ b/src/main/redux/sagas/win/session/library.ts
@@ -76,9 +76,9 @@ function* libraryMoveOrResizeObserver(action: winActions.session.registerLibrary
     yield debounce(DEBOUNCE_TIME, channel, function*() {
 
         try {
-            const winBound = library.getBounds();
+            let winBound = library.getBounds();
             debug("_______2 library.getBounds()", winBound);
-            normalizeRectangle(winBound);
+            winBound = normalizeRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
         } catch (e) {
             debug("set library bound error", e);

--- a/src/main/redux/sagas/win/session/library.ts
+++ b/src/main/redux/sagas/win/session/library.ts
@@ -6,7 +6,7 @@
 // ==LICENSE-END==
 
 import debug_ from "debug";
-import { normalizeRectangle } from "readium-desktop/common/rectangle/window";
+import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLeading";
 import { error } from "readium-desktop/main/tools/error";
 import { winActions } from "readium-desktop/main/redux/actions";
@@ -78,7 +78,7 @@ function* libraryMoveOrResizeObserver(action: winActions.session.registerLibrary
         try {
             let winBound = library.getBounds();
             debug("_______2 library.getBounds()", winBound);
-            winBound = normalizeRectangle(winBound);
+            winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
         } catch (e) {
             debug("set library bound error", e);

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -12,7 +12,7 @@ import { error } from "readium-desktop/main/tools/error";
 import { winActions } from "readium-desktop/main/redux/actions";
 import { eventChannel, Task, buffers } from "redux-saga";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
-import { cancel, debounce, fork, put, take, call } from "redux-saga/effects";
+import { cancel, debounce, fork, put, take, call  } from "redux-saga/effects";
 import { diMainGet } from "readium-desktop/main/di";
 import { winClose } from "../reader";
 
@@ -77,15 +77,15 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
     yield debounce(DEBOUNCE_TIME, channel, function*() {
 
         try {
-            const winBound = reader.getBounds();
+            let winBound = reader.getBounds();
             debug("_______1 reader.getBounds()", winBound);
-            normalizeRectangle(winBound);
+            winBound = normalizeRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
             yield call(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", winBound));
         } catch (e) {
             debug("set reader bound error", id, e);
         }
-    });
+    }); 
 }
 
 export function saga() {

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -77,7 +77,7 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
     yield debounce(DEBOUNCE_TIME, channel, function*() {
 
         try {
-            let winBound = reader.getBounds(); // current bounds of the window maximized/fullscreen/minimized (not on windows11, specific events)
+            let winBound = reader.getBounds();
             debug("_______1 reader.getBounds()", winBound);
             winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -77,7 +77,7 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
     yield debounce(DEBOUNCE_TIME, channel, function*() {
 
         try {
-            let winBound = reader.getBounds();
+            let winBound = reader.getBounds(); // current bounds of the window maximized/fullscreen/minimized (not on windows11, specific events)
             debug("_______1 reader.getBounds()", winBound);
             winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -6,7 +6,7 @@
 // ==LICENSE-END==
 
 import debug_ from "debug";
-import { normalizeRectangle } from "readium-desktop/common/rectangle/window";
+import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { error } from "readium-desktop/main/tools/error";
 import { winActions } from "readium-desktop/main/redux/actions";
@@ -79,7 +79,7 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
         try {
             let winBound = reader.getBounds();
             debug("_______1 reader.getBounds()", winBound);
-            winBound = normalizeRectangle(winBound);
+            winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
             yield call(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", winBound));
         } catch (e) {

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -79,7 +79,7 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
         try {
             let winBound = reader.getBounds();
             debug("_______1 reader.getBounds()", winBound);
-            winBound = normalizeWinBoundRectangle(winBound);
+            // winBound = normalizeWinBoundRectangle(winBound);
             yield put(winActions.session.setBound.build(id, winBound));
             yield call(() => diMainGet("publication-data").writeJsonObj(pubId, "bound", winBound));
         } catch (e) {


### PR DESCRIPTION
Fixes #3466 


**Change list:**

* set default window size to 1024×768, centered on the primary display (previously 800×600 positioned at one-third of the primary screen)
* ensure immutability by creating a copy of the window bounds object before modifying and saving it (fixes session reducer issue)
* Electron window bounds handling:

  * `getBounds()`: used to persist window size and position
* refactor `readerNewWindowBound` (`getWinBound`)

  * use Electron BrowserWindow instance bounds rectangle instead of the global Redux session state
  * on first publication open, initialize reader window position based on the library window position to target the active screen, with a position shift of 30px if possible
  * loop on the window bounds rectangle position until a free position is found with an offset of 30px
* use VS Code logic to normalize window bounds rectangle and to get the default display
* use VS Code logic to get the default display on single or multiple screens to compute the default rectangle

  * on macOS, new windows will be centered on the display with the current cursor

---

**Browser window bounds rectangle logic:**

**First start of Thorium:**

* window centred on the default display (active cursor position on macOS)
* window default size is 1024 x 768 if the display size allows it (on macOS, the display size excludes the top bar and dock, only the active display screen)
* window minimal resolution is 700 x 600 to target the minimal supported resolution of 800x600

**First opening of a publication:**

* will have the same size and position as the library window, before persistence of the bounds rectangle

**Multiple reader windows opened:**

* new reader window with the same position as current windows, will be shifted x/y of 20px until a free position is found
* macOS & Linux: these OSes seem to be pretty good at ensuring that a window is never outside of its bounds
* on MS Windows: it is possible to have a window with a size that makes it fall outside of the screen. The strategy is to try as much as possible to keep the window within the monitor bounds. We are not as strict as macOS and Linux and allow the window to exceed the monitor bounds as long as some pixels (128) of the window remain visible on the screen for the user to drag it back

**Single display:**

* strict x/y positioning, window bounds rectangle saved will be applied on the next start window, even if the window exceeds the monitor bounds (see above). On Linux and macOS, windows will not be truncated; only Windows allows it. No normalization is done when saving, only when the bounds are applied to a new BrowserWindow

**Multiple display:**

* window bounds rectangle normalization will try to restore the window position on the original display screen. If the restoration fails and the display is not available, the window position will either be on the intended display with the desired width/height if possible, or, as a fallback, on the default screen with the default size
* macOS: maximum width/height of the second display resolution is capped to the default display size. Fullscreen windows on the external display will be saved but restored to the default maximum size of the first display and positioned in the top-left corner
* Linux Wayland: x/y positioning is not possible
* MS Windows: window composition works; fullscreen or maximized/minimized state is not saved or applied on next start, only the window bounds rectangle is saved
* macOS: same applies to the fullscreen desktop state/mode
