### PR TITLE
Review: final state persistence

### DIFF
--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -25,6 +25,7 @@ import { globSync } from "glob";
 import { PublicationView } from "readium-desktop/common/views/publication";
 import { isAcceptedExtension } from "readium-desktop/common/extension";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
+import { PersistRootState } from "../redux/states";
 
 // Logger
 const debug = debug_("readium-desktop:cli:process");
@@ -93,7 +94,7 @@ const yargsInit = () =>
 
                 debug("CLI opds import", argv);
 
-                await createStoreFromDi();
+                const store = await createStoreFromDi();
                 const sagaMiddleware = diMainGet("saga-middleware");
                 __pendingCmd++;
 
@@ -122,7 +123,7 @@ const yargsInit = () =>
 
                 if (!__appStarted && __pendingCmd <= 0 && !closeProcessLock.isLock) {
 
-                    await sagaMiddleware.run(needToPersistFinalState).toPromise();
+                    await sagaMiddleware.run(needToPersistFinalState, store.getState() as Partial<PersistRootState>).toPromise();
                     app.exit(__returnCode);
                     return ;
                 }
@@ -144,7 +145,7 @@ const yargsInit = () =>
 
                 debug("CLI import publication", argv);
 
-                await createStoreFromDi();
+                const store = await createStoreFromDi();
                 const sagaMiddleware = diMainGet("saga-middleware");
                 __pendingCmd++;
 
@@ -194,7 +195,7 @@ const yargsInit = () =>
 
                 if (!__appStarted && __pendingCmd <= 0 && !closeProcessLock.isLock) {
 
-                    await sagaMiddleware.run(needToPersistFinalState).toPromise();
+                    await sagaMiddleware.run(needToPersistFinalState, store.getState() as Partial<PersistRootState>).toPromise();
                     app.exit(__returnCode);
                     return ;
                 }

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -86,12 +86,6 @@ export const stateFilePath = path.join(
     STATE_FILENAME,
 );
 
-const STATE_V340_FILENAME = "state_v340.json";
-export const state_V340_FilePath = path.join(
-    configDataFolderPath,
-    STATE_V340_FILENAME,
-);
-
 const PATCH_FILENAME = "state.patch.json";
 export const patchFilePath = path.join(
     configDataFolderPath,

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -203,19 +203,6 @@ const closeProcessLock = (() => {
 //     };
 // })();
 
-const reduxStatePersistedReference = (() => {
-    let __reduxState: Partial<RootState> | undefined;
-
-    return {
-        get reduxState() {
-            return __reduxState;
-        },
-        set reduxState(value) {
-            __reduxState = value;
-        },
-    };
-})();
-
 //
 // Depedency Injection
 //
@@ -401,7 +388,6 @@ const diMainGet: IGet = (symbol: keyof typeof diSymbolTable) => container.get<an
 
 export {
     closeProcessLock,
-    reduxStatePersistedReference,
     diMainGet,
     getLibraryWindowFromDi,
     getReaderWindowFromDi,

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -209,6 +209,19 @@ const closeProcessLock = (() => {
 //     };
 // })();
 
+const reduxStatePersistedReference = (() => {
+    let __reduxState: Partial<RootState> | undefined;
+
+    return {
+        get reduxState() {
+            return __reduxState;
+        },
+        set reduxState(value) {
+            __reduxState = value;
+        },
+    };
+})();
+
 //
 // Depedency Injection
 //
@@ -394,6 +407,7 @@ const diMainGet: IGet = (symbol: keyof typeof diSymbolTable) => container.get<an
 
 export {
     closeProcessLock,
+    reduxStatePersistedReference,
     diMainGet,
     getLibraryWindowFromDi,
     getReaderWindowFromDi,

--- a/src/main/redux/middleware/persistence.ts
+++ b/src/main/redux/middleware/persistence.ts
@@ -12,7 +12,9 @@ import { createPatch } from "rfc6902";
 import { winActions } from "../actions";
 import { patchChannel } from "../sagas/patch";
 
-import { PersistRootStatePatch, RootState } from "../states";
+import { PersistRootState, RootState } from "../states";
+import { closeProcessLock } from "readium-desktop/main/di";
+import { convertDiffableReduxState } from "../sagas/persist";
 
 // We do not persist ICommonRootState.versionUpdate ({newVersionURL, newVersion} state always starts at undefined)
 export const reduxPersistMiddleware: Middleware
@@ -26,63 +28,13 @@ export const reduxPersistMiddleware: Middleware
 
                 const nextState = store.getState();
 
-                const persistPrevState: PersistRootStatePatch = {
-                    // versionUpdate: prevState.versionUpdate,
-                    theme: prevState.theme,
-                    // win: prevState.win,
-                    reader: prevState.reader,
-                    i18n: prevState.i18n,
-                    session: prevState.session,
-                    screenReader: prevState.screenReader,
-                    publication: {
-                        db: prevState.publication.db,
-                        lastReadingQueue: prevState.publication.lastReadingQueue,
-                        readingFinishedQueue: prevState.publication.readingFinishedQueue,
-                    },
-                    opds: prevState.opds,
-                    version: prevState.version,
-                    wizard: prevState.wizard,
-                    settings: prevState.settings,
-                    creator: prevState.creator,
-                    noteExport: prevState.noteExport,
-                    customization: {
-                        provision: [],
-                        history: prevState.customization.history,
-                        activate: prevState.customization.activate,
-                        lock: undefined,
-                        welcomeScreen: undefined,
-                        manifest: undefined,
-                    },
-                };
+                if (closeProcessLock.isLock) {
+                    // do not continue to patch state when closing
+                    return returnValue;
+                }
 
-                const persistNextState: PersistRootStatePatch = {
-                    // versionUpdate: nextState.versionUpdate,
-                    theme: nextState.theme,
-                    // win: nextState.win,
-                    reader: nextState.reader,
-                    i18n: nextState.i18n,
-                    session: nextState.session,
-                    screenReader: nextState.screenReader,
-                    publication: {
-                        db: nextState.publication.db,
-                        lastReadingQueue: nextState.publication.lastReadingQueue,
-                        readingFinishedQueue: nextState.publication.readingFinishedQueue,
-                    },
-                    opds: nextState.opds,
-                    version: nextState.version,
-                    wizard: nextState.wizard,
-                    settings: nextState.settings,
-                    creator: nextState.creator,
-                    noteExport: nextState.noteExport,
-                    customization: {
-                        provision: [],
-                        history: nextState.customization.history,
-                        activate: nextState.customization.activate,
-                        lock: undefined,
-                        welcomeScreen: undefined,
-                        manifest: undefined,
-                    },
-                };
+                const persistPrevState = convertDiffableReduxState(prevState as Partial<PersistRootState>);
+                const persistNextState = convertDiffableReduxState(nextState as Partial<PersistRootState>);
 
                 // RangeError: Maximum call stack size exceeded
                 // diffAny

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -8,7 +8,7 @@
 import debug_ from "debug";
 import { app, ipcMain } from "electron";
 import { takeSpawnEveryChannel } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
-import { closeProcessLock, diMainGet, getLibraryWindowFromDi, getAllReaderWindowFromDi } from "readium-desktop/main/di";
+import { closeProcessLock, diMainGet, getLibraryWindowFromDi, getAllReaderWindowFromDi, reduxStatePersistedReference } from "readium-desktop/main/di";
 import { getOpdsNewCatalogsStringUrlChannel } from "readium-desktop/main/event";
 import {
     absorbDBToJson as absorbDBToJsonCookieJar, fetchCookieJarPersistence,
@@ -19,7 +19,7 @@ import { error } from "readium-desktop/main/tools/error";
 import { _APP_NAME } from "readium-desktop/preprocessor-directives";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { all, call, race, spawn, take } from "redux-saga/effects";
-import { delay as delayTyped, put as putTyped, race as raceTyped } from "typed-redux-saga/macro";
+import { delay as delayTyped, put as putTyped, race as raceTyped, select as selectTyped } from "typed-redux-saga/macro";
 
 // import { clearSessions } from "@r2-navigator-js/electron/main/sessions";
 import { clearSessions } from "readium-desktop/main/sessions";
@@ -32,6 +32,7 @@ import {
 import { availableLanguages } from "readium-desktop/common/services/translator";
 import { i18nActions } from "readium-desktop/common/redux/actions";
 import { URL_PROTOCOL_APP_HANDLER_OPDS, URL_PROTOCOL_APP_HANDLER_THORIUM } from "readium-desktop/common/streamerProtocol";
+import { RootState } from "../states";
 
 // Logger
 const filename_ = "readium-desktop:main:saga:app";
@@ -229,6 +230,10 @@ export function* init() {
 function* closeProcess() {
 
     closeProcessLock.lock();
+
+    const reduxStateReference = yield* selectTyped((store: RootState) => store);
+    reduxStatePersistedReference.reduxState = reduxStateReference;
+
     try {
         const [done] = yield* raceTyped([
             all([
@@ -279,7 +284,7 @@ function* closeProcess() {
                     }
                 }),
             ]),
-            delayTyped(30000), // 30 seconds timeout to force quit
+            delayTyped(60000), // 60 seconds timeout to force quit
         ]);
 
         if (!done) {

--- a/src/main/redux/sagas/app.ts
+++ b/src/main/redux/sagas/app.ts
@@ -8,7 +8,7 @@
 import debug_ from "debug";
 import { app, ipcMain } from "electron";
 import { takeSpawnEveryChannel } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
-import { closeProcessLock, diMainGet, getLibraryWindowFromDi, getAllReaderWindowFromDi, reduxStatePersistedReference } from "readium-desktop/main/di";
+import { closeProcessLock, diMainGet, getLibraryWindowFromDi, getAllReaderWindowFromDi } from "readium-desktop/main/di";
 import { getOpdsNewCatalogsStringUrlChannel } from "readium-desktop/main/event";
 import {
     absorbDBToJson as absorbDBToJsonCookieJar, fetchCookieJarPersistence,
@@ -32,7 +32,7 @@ import {
 import { availableLanguages } from "readium-desktop/common/services/translator";
 import { i18nActions } from "readium-desktop/common/redux/actions";
 import { URL_PROTOCOL_APP_HANDLER_OPDS, URL_PROTOCOL_APP_HANDLER_THORIUM } from "readium-desktop/common/streamerProtocol";
-import { RootState } from "../states";
+import { PersistRootState, RootState } from "../states";
 
 // Logger
 const filename_ = "readium-desktop:main:saga:app";
@@ -231,8 +231,7 @@ function* closeProcess() {
 
     closeProcessLock.lock();
 
-    const reduxStateReference = yield* selectTyped((store: RootState) => store);
-    reduxStatePersistedReference.reduxState = reduxStateReference;
+    const reduxState = yield* selectTyped((store: RootState) => store);
 
     try {
         const [done] = yield* raceTyped([
@@ -256,7 +255,7 @@ function* closeProcess() {
                     }
 
                     try {
-                        yield call(needToPersistFinalState);
+                        yield call(needToPersistFinalState, reduxState as Partial<PersistRootState>);
                         debug("Success to persistState");
                     } catch (e) {
                         debug("ERROR to persistState", e);

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 import * as fs from "fs";
-import { diMainGet, stateFilePath, patchFilePath, reduxStatePersistedReference, closeProcessLock } from "readium-desktop/main/di";
+import { diMainGet, stateFilePath, patchFilePath, closeProcessLock } from "readium-desktop/main/di";
 import { PersistRootState } from "readium-desktop/main/redux/states";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { call, debounce, all } from "redux-saga/effects";
@@ -218,10 +218,10 @@ export const persistStateToFs = async (nextState: Partial<PersistRootState>, fil
     debug("END persisting Redux state to disk");
 };
 
-export function* needToPersistFinalState() {
+export function* needToPersistFinalState(reduxState: Partial<PersistRootState>) {
 
     yield call(() => needToPersistPatch()); // before final state
-    yield call(() => persistStateToFs(reduxStatePersistedReference.reduxState as Partial<PersistRootState>, stateFilePath));
+    yield call(() => persistStateToFs(reduxState, stateFilePath));
 }
 
 export function* needToPersistPatch() {

--- a/src/main/redux/sagas/persist.ts
+++ b/src/main/redux/sagas/persist.ts
@@ -7,11 +7,11 @@
 
 import debug_ from "debug";
 import * as fs from "fs";
-import { diMainGet, patchFilePath, runtimeStateFilePath, state_V340_FilePath, stateFilePath } from "readium-desktop/main/di";
-import { RootState, PersistRootState } from "readium-desktop/main/redux/states";
+import { diMainGet, stateFilePath, patchFilePath, reduxStatePersistedReference, closeProcessLock } from "readium-desktop/main/di";
+import { PersistRootState } from "readium-desktop/main/redux/states";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { call, debounce, all } from "redux-saga/effects";
-import { flush as flushTyped, select as selectTyped, call as callTyped } from "typed-redux-saga/macro";
+import { flush as flushTyped, call as callTyped } from "typed-redux-saga/macro";
 import { winActions } from "../actions";
 
 import { patchChannel } from "./patch";
@@ -20,13 +20,17 @@ import { readerActions } from "readium-desktop/common/redux/actions";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
 import { ReaderConfig } from "readium-desktop/common/models/reader";
-import { IDictWinRegistryReaderState } from "../states/win/registry/reader";
+import { IDictWinRegistryReaderState, IWinRegistryReaderState } from "../states/win/registry/reader";
 import { _APP_VERSION } from "readium-desktop/preprocessor-directives";
 import { IWinSessionLibraryState } from "../states/win/session/library";
 import { JsonStringifySortedKeys } from "readium-desktop/common/utils/json";
-import { rmrf } from "readium-desktop/utils/fs";
+import crypto from "node:crypto";
+// import { rmrf } from "readium-desktop/utils/fs";
 
-const DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
+// Persist state diffs regularly now that win.registry is disabled.
+// Only publication.db and opds remain unbounded (arrays with N elements).
+const PATCH_DEBOUNCE_TIME = 1000; // 1 second before dumping to disk
+// const PATCH_DEBOUNCE_TIME = 3 * 60 * 1000; // 3 min
 
 // disabled for the 3.4 release
 // const PUBLICATION_STORAGE_DEBOUNCE_TIME = 10 * 1000; // 10 secs
@@ -36,39 +40,8 @@ const filename_ = "readium-desktop:main:saga:persist";
 const debug = debug_(filename_);
 debug("_");
 
-export const persistStateToFs = async (nextState: Partial<PersistRootState>) => {
-
-    debug("start of persist reduxState in disk");
-
-    // Part of code to reconstruct the entire state.json for 3.3 and earlier, not needed for the 3.4 and beyond
-    let reader: IDictWinRegistryReaderState | undefined = undefined;
-    if (nextState?.win?.registry?.reader) {
-        reader = {};
-        const pubData = diMainGet("publication-data");
-        const readers = await pubData.listPublication();
-
-        // TODO: need to parallelize with Promise.allSettled
-        for (const pubId of readers) {
-            // const _reader = nextState.win.registry.reader[pubId];
-            // const _readerReduxState = _reader.reduxState;
-
-            reader[pubId] = {
-                reduxState: {
-                    // "config" | "locator" | "divina" | "disableRTLFlip" | "allowCustomConfig" | "noteTotalCount" | "pdfConfig"
-                    config: await pubData.readJsonObj(pubId, "config") as any, // TODO: type object
-                    locator: await pubData.readJsonObj(pubId, "locator") as any, // TODO: type object
-                    divina: await pubData.readJsonObj(pubId, "divina") as any, // TODO: type object
-                    disableRTLFlip: await pubData.readJsonObj(pubId, "disableRTLFlip") as any, // TODO: type object
-                    allowCustomConfig: await pubData.readJsonObj(pubId, "allowCustomConfig") as any, // TODO: type object
-                    noteTotalCount: await pubData.readJsonObj(pubId, "noteTotalCount") as any, // TODO: type object
-                    pdfConfig: await pubData.readJsonObj(pubId, "pdfConfig") as any, // TODO: type object
-                },
-                windowBound: await pubData.readJsonObj(pubId, "bound") as any, // TODO: type object
-            };
-        }
-    }
-
-    const value: PersistRootState & { __t: string, __v: string } = {
+export const convertDiffableReduxState = (nextState: Partial<PersistRootState>): PersistRootState => {
+    return {
         theme: nextState.theme,
         win: {
             // disable session saving
@@ -79,7 +52,7 @@ export const persistStateToFs = async (nextState: Partial<PersistRootState>) => 
                 reader: undefined,
             },
             registry: {
-                reader,
+                reader: undefined,
             },
         },
         publication: nextState.publication,
@@ -103,83 +76,159 @@ export const persistStateToFs = async (nextState: Partial<PersistRootState>) => 
             welcomeScreen: undefined,
             manifest: undefined,
         },
-        __t: (new Date()).toUTCString(),
-        __v: _APP_VERSION,
     };
+};
 
-    const oldStateDataStringified = JsonStringifySortedKeys(value);
+export const convertPersistedReduxState = (nextState: Partial<PersistRootState>): PersistRootState & { __t: number, __v: string, __state_version: 340 } => {
 
-    // remove the registry.reader key
-    // in case of crash, the N-1 state_v340.json will not contain any publication reader data, hydration will come from publication-data json chunk file.
-    // This is part of the migration from an unique central json state with WAL as diff patch TO multiple chunks of json data on filesystem colocalised to the publication itself
-    delete value.win.registry;
-    const newStateDataV340Stringified = JsonStringifySortedKeys(value);
-    let stateDataWriteCrashNOTWRITTEN = false;
-    try {
-        await fs.promises.writeFile(state_V340_FilePath, newStateDataV340Stringified, {encoding: "utf8"});
-    } catch (e) {
-        stateDataWriteCrashNOTWRITTEN = true;
-        debug("ERROR to write state_v340.json to disk !!!", `${e}`);
-    }
+    return {
+        ...convertDiffableReduxState(nextState),
+        __t: (new Date()).getTime(),
+        __v: _APP_VERSION,
+        __state_version: 340,
+    };
+};
 
-    // let's write state.json after state_v340.json in case of disk full error
-    try {
-        await fs.promises.writeFile(stateFilePath, oldStateDataStringified, {encoding: "utf8"});
-    } catch (e) {
-        stateDataWriteCrashNOTWRITTEN = true;
-        debug("ERROR to write state.json to disk !!!", e);
-    }
 
-    if (stateDataWriteCrashNOTWRITTEN) {
-        debug("data not saved due to CRASH so do not remove state.runtime.json and state.patch.json, just exit and try to recover on the next start");
-    } else {
-        const oldStateDataRead = await fs.promises.readFile(stateFilePath, { encoding: "utf-8" });
-        const oldDataWriteIsOldDataRead = oldStateDataRead === oldStateDataStringified;
-        const newStateDataRead = await fs.promises.readFile(state_V340_FilePath, { encoding: "utf-8" });
-        const newDataWriteIsNewDataRead = newStateDataRead === newStateDataV340Stringified;
-        if (oldDataWriteIsOldDataRead && newDataWriteIsNewDataRead) {
-            debug("state.json and state_v340.json successfuly written to disk");
+export const convertPublicationToRegistryReaderState = async (pubIds: string[]): Promise<IDictWinRegistryReaderState> => {
+    const publicationData = diMainGet("publication-data");
 
-            // temporary hack for the 3.4.0 backward compatibility before removing diff patch
+    const readerRegistry: IDictWinRegistryReaderState | undefined = {};
+    for (const pubId of pubIds) {
 
-            // remove state.json (replace by state_v340.json)
-            // remove every state.runtime.json
-            // remove state.patch.json
-            try {
-                debug("remove state.patch.json");
-                await rmrf(patchFilePath);
-            } catch (e) {
-                debug("cannot remove state.patch.json", e);
+        const keys = [
+            "config",
+            "locator",
+            "divina",
+            "disableRTLFlip",
+            "allowCustomConfig",
+            "noteTotalCount",
+            "pdfConfig",
+            "bound",
+        ] as const;
+
+        const results = await Promise.allSettled(keys.map(key => publicationData.readJsonObj(pubId, key)));
+        await publicationData.close(pubId);
+
+        const readerState: IWinRegistryReaderState = {
+            reduxState: {},
+            windowBound: undefined,
+        };
+
+        results.forEach((result, index) => {
+            const key = keys[index];
+            if (result.status === "fulfilled") {
+                if (key === "bound") {
+                    readerState.windowBound = result.value as any; // TODO: object;
+                } else {
+                    readerState.reduxState[key] = result.value as any; // TODO: object
+                }
+            } else {
+                debug(`Failed to load ${key}:`, result.reason);
             }
-            try {
-                debug("remove state.runtime.json");
-                await rmrf(runtimeStateFilePath);
-            } catch (e) {
-                debug("cannot remove state.runtime.json", e);
-            }
+        });
 
-        } else {
-            debug("oldDataWriteIsOldDataRead", oldDataWriteIsOldDataRead);
-            debug("newDataWriteIsNewDataRead", newDataWriteIsNewDataRead);
-            debug("ERROR to write state.json and/or state_v340.json to disk, \"data write is date read\" not true, so this is probably a file corruption !!!");
-            debug("state.patch.json and state.runtime.json are not removed, so let's recover the state in the next start");
+        const hasData =
+            Object.values(readerState.reduxState).some(v => v !== undefined) ||
+            readerState.windowBound !== undefined;
+        if (hasData) {
+            readerRegistry[pubId] = readerState;
+
+            debug(`SAVED reader[${pubId}]: ${JSON.stringify({
+                reduxState: {
+                    config: typeof readerRegistry[pubId]?.reduxState.config,
+                    locator: typeof readerRegistry[pubId]?.reduxState.locator,
+                    divina: typeof readerRegistry[pubId]?.reduxState.divina,
+                    disableRTLFlip: typeof readerRegistry[pubId]?.reduxState.disableRTLFlip,
+                    allowCustomConfig: typeof readerRegistry[pubId]?.reduxState.allowCustomConfig,
+                    noteTotalCount: typeof readerRegistry[pubId]?.reduxState.noteTotalCount,
+                    pdfConfig: typeof readerRegistry[pubId]?.reduxState.pdfConfig,
+                },
+                windowBound: typeof readerRegistry[pubId]?.windowBound,
+            }, null, 4)}`);
+        }
+
+    }
+    return readerRegistry;
+};
+
+const persistReaderRegistry = async (nextState: Partial<PersistRootState>): Promise<IDictWinRegistryReaderState> => {
+
+    debug("START persisting win.registry.reader state from visited publications on disk");
+    const publicationData = diMainGet("publication-data");
+    const publicationIdentifierFromPublicationDataBase = Object.keys(nextState?.publication?.db || {});
+
+    // Separate publication IDs into visited and not visited
+    const pubIdVisistedSet = publicationIdentifierFromPublicationDataBase.filter((pubId) => publicationData.visited.has(pubId));
+    const pubIdNotVisitedSet = publicationIdentifierFromPublicationDataBase.filter((pubId) => !publicationData.visited.has(pubId));
+    const registryReaderState = await convertPublicationToRegistryReaderState(pubIdVisistedSet);
+
+    // Preserve registry reader state for not-visited publications (backward compatibility)
+    for (const pubId of pubIdNotVisitedSet) {
+        if (nextState?.win?.registry?.reader[pubId]) {
+            registryReaderState[pubId] = nextState.win.registry.reader[pubId];
         }
     }
+    debug("END persisting registry reader state (backward compatibility applied)");
+    return registryReaderState;
+};
 
-    debug("end of persist reduxState in disk");
+export const persistStateToFs = async (nextState: Partial<PersistRootState>, filePath: string): Promise<void> => {
+    debug("START persisting Redux state to", filePath);
+
+    const persistedReduxState = convertPersistedReduxState(nextState);
+
+    let stateDataStringified = JsonStringifySortedKeys(persistedReduxState);
+    const checksum = crypto.createHash("sha1").update(stateDataStringified).digest("hex");
+
+    if (filePath === stateFilePath) {
+        // Add registry.reader for backward compatibility with older state.json versions 330
+        persistedReduxState.win.registry.reader = await persistReaderRegistry(nextState);
+        stateDataStringified = JsonStringifySortedKeys(persistedReduxState);
+    }
+
+    // Prepend checksum at the beginning of the JSON
+    stateDataStringified = stateDataStringified.replace(/^{/, `\{\"__checksum\": \"${checksum}\"\,`); // add checksum on the beginning of the file
+    debug("Checksum inserted at the beginning of the JSON file (preview):", stateDataStringified.slice(0, 60), "...");
+
+
+    try {
+        debug(`Persist the ${filePath} to disk`);
+        await fs.promises.writeFile(filePath, stateDataStringified, { encoding: "utf-8" });
+    } catch (e) {
+        debug("ERROR writing state.json to disk!", e);
+    }
+
+    try {
+        const data = await fs.promises.readFile(filePath, { encoding: "utf-8"});
+        const reduxState = JSON.parse(data);
+        delete (reduxState as any).__checksum;
+        delete reduxState.win.registry.reader;
+        const reduxStateChecksum = JsonStringifySortedKeys(reduxState);
+        const checksumGenerated = crypto.createHash("sha1").update(reduxStateChecksum).digest("hex");
+        if (checksumGenerated === checksum) {
+            debug("Checksum verified and valid after the final state was written");
+        } else {
+            debug("Checksum mismatch detected!");
+        }
+    } catch (e) {
+        debug(`CRITICAL ERROR: ${filePath} not verified and valid; ${e}`);
+    }
+
+    debug("END persisting Redux state to disk");
 };
 
 export function* needToPersistFinalState() {
 
-    const nextState = yield* selectTyped((store: RootState) => store);
-    yield call(() => needToPersistPatch());
-
-    // final step because the patch and runtime state is remove if the final state.json is successfuly written to disk
-    // Just a temporary hack for the 3.4.0 release, before removing diff patch
-    yield call(() => persistStateToFs(nextState as Partial<PersistRootState>));
+    yield call(() => needToPersistPatch()); // before final state
+    yield call(() => persistStateToFs(reduxStatePersistedReference.reduxState as Partial<PersistRootState>, stateFilePath));
 }
 
 export function* needToPersistPatch() {
+
+    if (closeProcessLock.isLock) {
+        return ;
+    }
 
     try {
 
@@ -209,7 +258,7 @@ export function* needToPersistPatch() {
 export function saga() {
     return all([
         debounce(
-            DEBOUNCE_TIME,
+            PATCH_DEBOUNCE_TIME,
             winActions.persistRequest.ID,
             needToPersistPatch,
         ),

--- a/src/main/redux/sagas/win/session/library.ts
+++ b/src/main/redux/sagas/win/session/library.ts
@@ -12,6 +12,7 @@ import { winActions } from "readium-desktop/main/redux/actions";
 import { eventChannel, Task, buffers } from "redux-saga";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { cancel, debounce, fork, put, take } from "redux-saga/effects";
+import { closeProcessLock } from "readium-desktop/main/di";
 
 // Logger
 const filename_ = "readium-desktop:main:redux:sagas:win:session:library";
@@ -73,6 +74,11 @@ function* libraryMoveOrResizeObserver(action: winActions.session.registerLibrary
     );
 
     yield debounce(DEBOUNCE_TIME, channel, function*() {
+
+        if (closeProcessLock.isLock) {
+            debug("CLOSE process library bound not persisted");
+            return ;
+        }
 
         try {
             const winBound = library.getBounds(); // current bounds of the window maximized/fullscreen/minimized (not on windows11, specific events)

--- a/src/main/redux/sagas/win/session/reader.ts
+++ b/src/main/redux/sagas/win/session/reader.ts
@@ -14,6 +14,7 @@ import { eventChannel, Task, buffers } from "redux-saga";
 import { cancel, debounce, fork, put, take, call  } from "redux-saga/effects";
 import { diMainGet } from "readium-desktop/main/di";
 import { winClose } from "../reader";
+import { closeProcessLock } from "readium-desktop/main/di";
 
 // Logger
 const filename_ = "readium-desktop:main:redux:sagas:win:session:reader";
@@ -74,6 +75,11 @@ function* readerMoveOrResizeObserver(action: winActions.session.registerReader.T
     );
 
     yield debounce(DEBOUNCE_TIME, channel, function*() {
+
+        if (closeProcessLock.isLock) {
+            debug("CLOSE process reader bound not persisted");
+            return ;
+        }
 
         try {
             const winBound = reader.getBounds();

--- a/src/main/redux/states/index.ts
+++ b/src/main/redux/states/index.ts
@@ -63,4 +63,14 @@ export type PersistRootState = Omit<PersistRootState_, "win"> & {
         },
     };
 }
-export type PersistRootStatePatch = Pick<RootState, "publication" | "reader" | "session" | "screenReader" | "i18n" | "opds" | "version" | "theme" | "wizard" | "settings" | "creator" | "noteExport" | "customization">;
+// export type PersistRootStatePatch = Pick<RootState, "publication" | "reader" | "session" | "screenReader" | "i18n" | "opds" | "version" | "theme" | "wizard" | "settings" | "creator" | "noteExport" | "customization"> & {
+//     win: {
+//         session: {
+//             library: IWinSessionLibraryState,
+//             // reader: IDictWinSessionReaderState,
+//         },
+//         registry: {
+//             // reader: // IDictWinRegistryReaderState,
+//         },
+//     };
+// }

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -9,7 +9,7 @@ import debug_ from "debug";
 import * as fs from "fs";
 import { deepStrictEqual, ok } from "readium-desktop/common/utils/assert";
 import {
-    diMainGet, memoryLoggerFilename, patchFilePath, runtimeStateFilePath, state_V340_FilePath, stateFilePath,
+    diMainGet, memoryLoggerFilename, patchFilePath, runtimeStateFilePath, stateFilePath,
 } from "readium-desktop/main/di";
 import { reduxSyncMiddleware } from "readium-desktop/main/redux/middleware/sync";
 import { rootReducer } from "readium-desktop/main/redux/reducers";

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -119,34 +119,35 @@ export async function initStore()
 
     try {
 
-        let jsonStr = "";
-        let getNewStateFromV340 = false;
-        try {
-            jsonStr = await fs.promises.readFile(stateFilePath, { encoding: "utf8" });
-            const json = JSON.parse(jsonStr);
-            if (json.__t && json.__v) {
-                debug("The old one: \"state.json\" was written with the v3.4.0 last release and not from an old one (like v3.3.0), so let's recover the json redux state from \"state_v340.json\"");
-                getNewStateFromV340 = true;
-            } else {
-                // the old state.json has been updated from an older thorium version (3.3.0?) so let's migrate from it.
-                debug("If there is a crash from v330 and a forward migration to v340, publications data will not be imported, state.json will not be updated with new publications state");
-                getNewStateFromV340 = false;
-            }
-        } catch (e) {
-            debug("read/parse old state crash so let's read new state v340", `${e}`);
-            getNewStateFromV340 = true;
-        }
+        // let jsonStr = "";
+        // let getNewStateFromV340 = false;
+        // try {
+        //     jsonStr = await fs.promises.readFile(stateFilePath, { encoding: "utf8" });
+        //     const json = JSON.parse(jsonStr);
+        //     if (json.__t && json.__v) {
+        //         debug("The old one: \"state.json\" was written with the v3.4.0 last release and not from an old one (like v3.3.0), so let's recover the json redux state from \"state_v340.json\"");
+        //         getNewStateFromV340 = true;
+        //     } else {
+        //         // the old state.json has been updated from an older thorium version (3.3.0?) so let's migrate from it.
+        //         debug("If there is a crash from v330 and a forward migration to v340, publications data will not be imported, state.json will not be updated with new publications state");
+        //         getNewStateFromV340 = false;
+        //     }
+        // } catch (e) {
+        //     debug("read/parse old state crash so let's read new state v340", `${e}`);
+        //     getNewStateFromV340 = true;
+        // }
 
-        if (getNewStateFromV340) {
-            try {
-                jsonStr = await fs.promises.readFile(state_V340_FilePath, { encoding: "utf8" });
-            } catch (e) {
-                debug("NEW state_v340.json not created so fallback on state.json", `${e}`);
-            }
-        } else {
-            debug("state is loaded from \"state.json\" and not \"state_v340.json\"");
-        }
+        // if (getNewStateFromV340) {
+        //     try {
+        //         jsonStr = await fs.promises.readFile(state_V340_FilePath, { encoding: "utf8" });
+        //     } catch (e) {
+        //         debug("NEW state_v340.json not created so fallback on state.json", `${e}`);
+        //     }
+        // } else {
+        //     debug("state is loaded from \"state.json\" and not \"state_v340.json\"");
+        // }
 
+        const jsonStr = await fs.promises.readFile(stateFilePath, { encoding: "utf8" });
         const json = JSON.parse(jsonStr);
         if (test(json))
             reduxState = json;
@@ -656,11 +657,10 @@ export async function initStore()
         }
 
         try {
-            await persistStateToFs(preloadedState);
-            debug("state.json and state_v340.json written with the new migration final state");
+            await persistStateToFs(preloadedState, stateFilePath);
         } catch (e) {
             debug(e);
-            debug("ERROR to write state.json and state_v340.json on disk after migration !!!");
+            debug("ERROR to write state.json on disk after migration !!!");
         }
 
         debug("END reader registry migration, let's create the redux store");


### PR DESCRIPTION


**Be careful: This PR did not use anymore the previous `state_v340.json` (unreleased, only on nightly build). Instead, it uses `state.json` to maintain backward compatibility. No transitive final state is generated.**

Extracted from this [PR](https://github.com/edrlab/thorium-reader/pull/3471)

Changes list:
- File storage persistence is now parallelized for publications from version 330 → 340.
- Reading persistence of publications is parallelized when reconstructing the final backward-compatible 330 `state.json` with the reader registry object.
- Added a visitedPublicationIds array set on each publication-data structure to track changes per publication.
- Avoids looping through the entire publication registry on disk when persisting the final backward-compatible 330 `state.json`.
 - Ensures the immutable redux state copy shares a common final reference in both the diff patch and the persisted final state.
 - Added control metadata on the final state
    - __t: timestamp
    -  __v: version,
    - __state_version: 330 | 340 (legacy vs current)
    - __checksum: SHA-1 checksum of the entire stringified JSON, including all __ keys
- Prevents any saga debounce and the diff patching process from continuing and potentially mutating the Redux state during the persistence process via a global closeProcess lock.
