### PR TITLE
feat(publication-storage): add a configurable external publication storage in Library Settings

### DIFF
--- a/src/common/api/interface/publicationApi.interface.ts
+++ b/src/common/api/interface/publicationApi.interface.ts
@@ -19,9 +19,6 @@ export interface IPublicationApi {
         identifier: string,
         preservePublicationOnFileSystem?: string,
     ) => SagaGenerator<void>;
-    openFolder: (
-        Identifier?: string,
-    ) => SagaGenerator<void>;
     findAll: (
     ) => SagaGenerator<PublicationView[]>;
     findByTag: (
@@ -61,7 +58,6 @@ export interface IPublicationApi {
 export interface IPublicationModuleApi {
     "publication/get": IPublicationApi["get"];
     "publication/delete": IPublicationApi["delete"];
-    "publication/openFolder": IPublicationApi["openFolder"];
     "publication/findAll": IPublicationApi["findAll"];
     "publication/findByTag": IPublicationApi["findByTag"];
     "publication/updateTags": IPublicationApi["updateTags"];

--- a/src/common/redux/actions/catalog/index.ts
+++ b/src/common/redux/actions/catalog/index.ts
@@ -6,11 +6,17 @@
 // ==LICENSE-END==
 
 import * as getCatalog from "./getCatalog";
+import * as openDefaultDirectory from "./openDefaultDirectory";
+import * as openUserDirectory from "./openUserDirectory";
 import * as setCatalog from "./setCatalogView";
 import * as setTagView from "./setTagView";
+import * as setUserDirectory from "./setDirectory";
 
 export {
     getCatalog,
+    openDefaultDirectory,
+    openUserDirectory,
     setCatalog,
     setTagView,
+    setUserDirectory,
 };

--- a/src/common/redux/actions/catalog/openDefaultDirectory.ts
+++ b/src/common/redux/actions/catalog/openDefaultDirectory.ts
@@ -1,0 +1,25 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+
+export const ID = "CATALOG_OPEN_DEFAULT_DIRECTORY";
+
+export interface Payload {
+}
+
+export function build():
+    Action<typeof ID, Payload> {
+
+    return {
+        type: ID,
+        payload: {
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/common/redux/actions/catalog/openUserDirectory.ts
+++ b/src/common/redux/actions/catalog/openUserDirectory.ts
@@ -1,0 +1,25 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+
+export const ID = "CATALOG_OPEN_USER_DIRECTORY";
+
+export interface Payload {
+}
+
+export function build():
+    Action<typeof ID, Payload> {
+
+    return {
+        type: ID,
+        payload: {
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/common/redux/actions/catalog/setDirectory.ts
+++ b/src/common/redux/actions/catalog/setDirectory.ts
@@ -1,0 +1,27 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+
+export const ID = "CATALOG_SET_PUBLICATION_USER_DIRECTORY";
+
+export interface Payload {
+    userDirectory: string;
+}
+
+export function build(dir: string):
+    Action<typeof ID, Payload> {
+
+    return {
+        type: ID,
+        payload: {
+            userDirectory: dir,
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/common/redux/actions/publication/index.ts
+++ b/src/common/redux/actions/publication/index.ts
@@ -7,8 +7,10 @@
 
 import * as readingFinished from "./readingFinished";
 import * as checker from "./checker";
+import * as openFolder from "./openFolder";
 
 export {
     readingFinished,
     checker,
+    openFolder,
 };

--- a/src/common/redux/actions/publication/openFolder.ts
+++ b/src/common/redux/actions/publication/openFolder.ts
@@ -1,0 +1,27 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+
+export const ID = "PUBLICATION_OPEN_FOLDER";
+
+export interface Payload {
+    identifier?: string;
+}
+
+export function build(identifier?: string):
+    Action<typeof ID, Payload> {
+
+    return {
+        type: ID,
+        payload: {
+            identifier,
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/common/redux/reducers/directory.ts
+++ b/src/common/redux/reducers/directory.ts
@@ -1,0 +1,35 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { type Reducer } from "redux";
+
+import { catalogActions } from "readium-desktop/common/redux/actions";
+
+const initialState: {
+    defaultDirectory?: string;
+    userDirectory?: string;
+} = {};
+
+function directoryReducer_(
+    state = initialState,
+    action: catalogActions.setUserDirectory.TAction,
+): typeof initialState {
+    switch (action.type) {
+        case catalogActions.setUserDirectory.ID:
+            const {userDirectory} = action.payload;
+            return {
+                defaultDirectory: state.defaultDirectory,
+                userDirectory,
+            };
+
+        default:
+            return state;
+
+    }
+}
+
+export const directoryReducer = directoryReducer_ as Reducer<ReturnType<typeof directoryReducer_>>;

--- a/src/common/redux/states/renderer/libraryRootState.ts
+++ b/src/common/redux/states/renderer/libraryRootState.ts
@@ -33,7 +33,11 @@ export interface ILibraryRootState extends IRendererCommonRootState {
     publication: {
         catalog: CatalogView,
         tag: string[],
-    }
+        directory: {
+            defaultDirectory?: string,
+            userDirectory?: string,
+        }
+    };
     wizard: IWizardState;
     settings: ISettingsState;
 }

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -23,6 +23,7 @@ import { initStore } from "readium-desktop/main/redux/store/memory";
 import { DeviceIdManager } from "readium-desktop/main/services/device";
 import { LcpManager } from "readium-desktop/main/services/lcp";
 import { PublicationStorage } from "readium-desktop/main/storage/publication-storage";
+import { PublicationDirectory } from "readium-desktop/main/storage/publication-directory";
 import {
     _APP_NAME,
 } from "readium-desktop/preprocessor-directives";
@@ -173,10 +174,10 @@ export const memoryLoggerFilename = path.join(
     MEMORY_LOGGGER_FILENAME,
 );
 
-const USER_VAULT_FILENAME = "vault.json";
-export const userVaultConfigPath = path.join(
+const USER_PUBLICATION_DIRECTORY_FILENAME = "user_publication_directory.json";
+export const userPublicationDirectoryConfigPath = path.join(
     configDataFolderPath,
-    USER_VAULT_FILENAME,
+    USER_PUBLICATION_DIRECTORY_FILENAME,
 );
 const PUBLICATION_CONFIG_DIRECTORY_NAME = "publication";
 export const publicationConfigPath = path.join(
@@ -204,9 +205,7 @@ const publicationRepository = new PublicationRepository();
 const opdsFeedRepository = new OpdsFeedRepository();
 
 // Create filesystem storage for publications
-// TODO: let user change the publication folder as vault in runtime
-//      - need to persist this folder in redux-state and check integrity at start
-const publicationRepositoryPath = path.join(
+export const publicationRepositoryPath = path.join(
     USER_DATA_FOLDER,
     !FORCE_PROD_DB_IN_DEV && (__TH__IS_DEV__ || __TH__IS_CI__) ? "publications-dev" : "publications",
 );
@@ -330,7 +329,11 @@ container.bind<OpdsFeedViewConverter>(diSymbolTable["opds-feed-view-converter"])
     .to(OpdsFeedViewConverter).inSingletonScope();
 
 // Storage
-const publicationStorage = new PublicationStorage(publicationRepositoryPath, userVaultConfigPath);
+const publicationDirectory = new PublicationDirectory(publicationRepositoryPath);
+container.bind<PublicationDirectory>(diSymbolTable["publication-directory"]).toConstantValue(
+    publicationDirectory,
+);
+const publicationStorage = new PublicationStorage();
 container.bind<PublicationStorage>(diSymbolTable["publication-storage"]).toConstantValue(
     publicationStorage,
 );
@@ -407,6 +410,7 @@ interface IGet {
     //    (s: "locator-view-converter"): LocatorViewConverter;
     (s: "opds-feed-view-converter"): OpdsFeedViewConverter;
     (s: "publication-storage"): PublicationStorage;
+    (s: "publication-directory"): PublicationDirectory;
     (s: "publication-data"): PublicationData;
     // (s: "streamer"): Server;
     (s: "device-id-manager"): DeviceIdManager;

--- a/src/main/diSymbolTable.ts
+++ b/src/main/diSymbolTable.ts
@@ -11,6 +11,7 @@ export const diSymbolTable = {
 //    "locator-view-converter": Symbol("locator-view-converter"),
     "opds-feed-view-converter": Symbol("opds-feed-view-converter"),
     "publication-storage": Symbol("publication-storage"),
+    "publication-directory": Symbol("publication-directory"),
     "publication-data": Symbol("publication-data"),
     // "streamer": Symbol("streamer"),
     "device-id-manager": Symbol("device-id-manager"),

--- a/src/main/redux/middleware/sync.ts
+++ b/src/main/redux/middleware/sync.ts
@@ -102,6 +102,11 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     opdsActions.refresh.ID,
 
     publicationActions.checker.ID,
+    publicationActions.openFolder.ID,
+
+    catalogActions.setUserDirectory.ID,
+    catalogActions.openDefaultDirectory.ID,
+    catalogActions.openUserDirectory.ID,
 ];
 
 export const reduxSyncMiddleware: Middleware

--- a/src/main/redux/sagas/api/publication/index.ts
+++ b/src/main/redux/sagas/api/publication/index.ts
@@ -16,13 +16,11 @@ import { importFromFs, importFromLink, importFromString } from "./import";
 import { search, searchEqTitle } from "./search";
 import { updateTags } from "./updateTags";
 import { SagaGenerator } from "typed-redux-saga";
-import { openPublicationFolder } from "./openFolder";
 
 export const publicationApi: IPublicationApi = {
     findAll,
     get: getPublication,
     delete: deletePublication,
-    openFolder: openPublicationFolder,
     findByTag,
     search,
     exportPublication,

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -341,7 +341,11 @@ export function saga() {
                 try {
                     let nextUserDirectory = userDirectory;
 
-                    if (!userDirectory && !currentUserDirectory) {
+                    // - userDirectory + currentUserDirectory => reopen the picker at userDirectory and store the new selection in nextUserDirectory
+                    // - userDirectory + no currentUserDirectory => open the picker at userDirectory and store the new selection in nextUserDirectory
+                    // - no userDirectory + no currentUserDirectory => force an initial directory choice and store it in nextUserDirectory
+                    // - no userDirectory + currentUserDirectory => keep nextUserDirectory empty to remove the current directory
+                    if (userDirectory || !currentUserDirectory) {
                         const win = getLibraryWindowFromDi();
                         if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
                             debug("ERROR!! No library Browser window !!! exit");
@@ -349,26 +353,7 @@ export function saga() {
                         }
 
                         const res = yield* callTyped(() => dialog.showOpenDialog(win, {
-                            properties: ["openDirectory", "createDirectory"],
-                        }));
-
-                        if (res.canceled) {
-                            return;
-                        }
-
-                        nextUserDirectory = res.filePaths[0] || "";
-                        if (!nextUserDirectory) {
-                            return;
-                        }
-                    } else if (userDirectory) {
-                        const win = getLibraryWindowFromDi();
-                        if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
-                            debug("ERROR!! No library Browser window !!! exit");
-                            return;
-                        }
-
-                        const res = yield* callTyped(() => dialog.showOpenDialog(win, {
-                            defaultPath: userDirectory,
+                            ...(userDirectory ? { defaultPath: userDirectory } : {}),
                             properties: ["openDirectory", "createDirectory"],
                         }));
 
@@ -383,7 +368,9 @@ export function saga() {
                     }
 
                     yield* callTyped(() => publicationDirectory.setUserDirectory(nextUserDirectory));
-                    if (nextUserDirectory && currentUserDirectory && nextUserDirectory !== currentUserDirectory) {
+                    
+                    // Open the previous user directory so the user can find and move existing files if needed.
+                    if (currentUserDirectory && nextUserDirectory !== currentUserDirectory) {
                         yield* callTyped(() => shell.openPath(currentUserDirectory));
                         // yield* callTyped(() => shell.openPath(nextUserDirectory));
                     }

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -6,14 +6,16 @@
 // ==LICENSE-END==
 
 import debug_ from "debug";
-import { catalogActions, readerActions } from "readium-desktop/common/redux/actions";
+import { dialog, shell } from "electron";
+import { catalogActions, readerActions, toastActions } from "readium-desktop/common/redux/actions";
+import { ToastType } from "readium-desktop/common/models/toast";
 import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { error } from "readium-desktop/main/tools/error";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { all } from "redux-saga/effects";
 import { call as callTyped, put as putTyped, select as selectTyped, debounce as debounceTyped, SagaGenerator } from "typed-redux-saga/macro";
 import { RootState } from "../states";
-import { diMainGet, getReaderWindowFromDi } from "readium-desktop/main/di";
+import { diMainGet, getLibraryWindowFromDi, getReaderWindowFromDi } from "readium-desktop/main/di";
 // import { isPdfFn } from "readium-desktop/common/isManifestType";
 
 // import { PublicationView } from "readium-desktop/common/views/publication";
@@ -29,6 +31,7 @@ import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/
 import { PublicationView } from "readium-desktop/common/views/publication";
 import { EventPayload } from "readium-desktop/common/ipc/sync";
 import { SenderType } from "readium-desktop/common/models/sync";
+import { openPublicationFolder } from "./publication/openFolder";
 
 const filename_ = "readium-desktop:main:redux:sagas:catalog";
 const debug = debug_(filename_);
@@ -261,9 +264,17 @@ export function* getCatalog(): SagaGenerator<ILibraryRootState["publication"]> {
         },
     ];
     const publicationRepository = diMainGet("publication-repository");
+    const publicationDirectory = diMainGet("publication-directory");
     const allTags = yield* callTyped(() => publicationRepository.getAllTags());
 
-    return {catalog: {entries}, tag: allTags};
+    return {
+        catalog: {entries},
+        tag: allTags,
+        directory: {
+            defaultDirectory: publicationDirectory.defaultDirectory,
+            userDirectory: publicationDirectory.userDirectory,
+        },
+    };
 }
 
 function* getCatalogAndDispatchIt() {
@@ -272,6 +283,7 @@ function* getCatalogAndDispatchIt() {
 
     yield* putTyped(catalogActions.setCatalog.build(catalog));
     yield* putTyped(catalogActions.setTagView.build(tag));
+    yield* putTyped(catalogActions.setUserDirectory.build(diMainGet("publication-directory").userDirectory || ""));
 }
 
 function* updateResumePosition() {
@@ -313,6 +325,108 @@ export function saga() {
         spawnLeading(
             updateResumePosition,
             (e) => error(filename_ + ":updateResumePosition", e),
+        ),
+        takeSpawnLatest(
+            catalogActions.setUserDirectory.ID,
+            function* (action: catalogActions.setUserDirectory.TAction) {
+
+                const publicationDirectory = diMainGet("publication-directory");
+                const { userDirectory } = action.payload;
+                const currentUserDirectory = publicationDirectory.userDirectory || "";
+                const sender = action.sender as EventPayload["sender"];
+                if (sender?.type !== SenderType.Renderer) {
+                    debug("sender is not renderer !!!");
+                    return;
+                }
+                try {
+                    let nextUserDirectory = userDirectory;
+
+                    if (!userDirectory && !currentUserDirectory) {
+                        const win = getLibraryWindowFromDi();
+                        if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+                            debug("ERROR!! No library Browser window !!! exit");
+                            return;
+                        }
+
+                        const res = yield* callTyped(() => dialog.showOpenDialog(win, {
+                            properties: ["openDirectory", "createDirectory"],
+                        }));
+
+                        if (res.canceled) {
+                            return;
+                        }
+
+                        nextUserDirectory = res.filePaths[0] || "";
+                        if (!nextUserDirectory) {
+                            return;
+                        }
+                    } else if (userDirectory) {
+                        const win = getLibraryWindowFromDi();
+                        if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+                            debug("ERROR!! No library Browser window !!! exit");
+                            return;
+                        }
+
+                        const res = yield* callTyped(() => dialog.showOpenDialog(win, {
+                            defaultPath: userDirectory,
+                            properties: ["openDirectory", "createDirectory"],
+                        }));
+
+                        if (res.canceled) {
+                            return;
+                        }
+
+                        nextUserDirectory = res.filePaths[0] || "";
+                        if (!nextUserDirectory) {
+                            return;
+                        }
+                    }
+
+                    yield* callTyped(() => publicationDirectory.setUserDirectory(nextUserDirectory));
+                    if (nextUserDirectory && currentUserDirectory && nextUserDirectory !== currentUserDirectory) {
+                        yield* callTyped(() => shell.openPath(currentUserDirectory));
+                        // yield* callTyped(() => shell.openPath(nextUserDirectory));
+                    }
+                    yield* putTyped(toastActions.openRequest.build(
+                        ToastType.Success,
+                        nextUserDirectory ? "Publication directory updated." : "Publication directory removed.",
+                    ));
+                    yield* callTyped(getCatalogAndDispatchIt);
+                } catch (e) {
+                    const message = e instanceof Error ? e.message : `${e}`;
+                    yield* putTyped(toastActions.openRequest.build(
+                        ToastType.Error,
+                        `Failed to update publication directory: ${message}`,
+                    ));
+                }
+            },
+            (e) => error(filename_ + ":setUserDirectory", e),
+        ),
+        takeSpawnLatest(
+            catalogActions.openDefaultDirectory.ID,
+            function* () {
+                const publicationDirectory = diMainGet("publication-directory");
+                yield* callTyped(() => shell.openPath(publicationDirectory.defaultDirectory));
+            },
+            (e) => error(filename_ + ":openDefaultDirectory", e),
+        ),
+        takeSpawnLatest(
+            catalogActions.openUserDirectory.ID,
+            function* () {
+                const publicationDirectory = diMainGet("publication-directory");
+                if (!publicationDirectory.userDirectory) {
+                    return;
+                }
+                yield* callTyped(() => shell.openPath(publicationDirectory.userDirectory));
+            },
+            (e) => error(filename_ + ":openUserDirectory", e),
+        ),
+        takeSpawnLatest(
+            publicationActionsFromCommonAction.openFolder.ID,
+            function* (action: publicationActionsFromCommonAction.openFolder.TAction) {
+                yield* callTyped(openPublicationFolder, action.payload.identifier);
+            },
+            (e) => error(filename_ + ":openPublicationFolder", e),
         ),
         takeSpawnLatest(
             publicationActionsFromCommonAction.readingFinished.ID,

--- a/src/main/redux/sagas/publication/checker.ts
+++ b/src/main/redux/sagas/publication/checker.ts
@@ -144,7 +144,7 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
         thoriumAppVersion: _APP_VERSION,
         thoriumPackName: _PACK_NAME,
         thoriumUserDataPath: USER_DATA_FOLDER,
-        thoriumPublicationPath: yield* callTyped(() => diMainGet("publication-storage").getVaultPath()),
+        thoriumPublicationPath: yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath()),
     }, null, 4)}\n`;
     if (dumpLogs) {
         yield* callTyped(() => fs.promises.appendFile(appLogs, dump));

--- a/src/main/redux/sagas/publication/openFolder.ts
+++ b/src/main/redux/sagas/publication/openFolder.ts
@@ -11,7 +11,17 @@ import { SagaGenerator, call as callTyped } from "typed-redux-saga";
 
 export function* openPublicationFolder(identifier?: string): SagaGenerator<void> {
 
-    const folderPath = (yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(identifier)))
-        || (yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath()));
+    let folderPath: string;
+
+    if (!identifier) {
+        folderPath = yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath());
+    } else {
+        try {
+            folderPath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(identifier));
+        } catch {
+            folderPath = yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath());
+        }
+    }
+
     yield* callTyped(() => shell.openPath(folderPath));
 }

--- a/src/main/redux/sagas/publication/openFolder.ts
+++ b/src/main/redux/sagas/publication/openFolder.ts
@@ -5,18 +5,13 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { diMainGet } from "readium-desktop/main/di";
-// eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
-import { call } from "redux-saga/effects";
-import { SagaGenerator, call as callTyped } from "typed-redux-saga";
 import { shell } from "electron";
+import { diMainGet } from "readium-desktop/main/di";
+import { SagaGenerator, call as callTyped } from "typed-redux-saga";
 
 export function* openPublicationFolder(identifier?: string): SagaGenerator<void> {
 
-    const publicationStorage = diMainGet("publication-storage");
-    const vaultPath = yield* callTyped(() => publicationStorage.getVaultPath()); // userVault || defaultVault
-    
-    const folderPath = (yield* callTyped(() => publicationStorage.findPublicationPath(identifier))) || vaultPath;
-
-    yield call(() => shell.openPath(folderPath));
+    const folderPath = (yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(identifier)))
+        || (yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath()));
+    yield* callTyped(() => shell.openPath(folderPath));
 }

--- a/src/main/redux/sagas/win/library.ts
+++ b/src/main/redux/sagas/win/library.ts
@@ -10,7 +10,7 @@ import { winIpc } from "readium-desktop/common/ipc";
 import { takeSpawnEveryChannel } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
 import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLeading";
 import {
-    closeProcessLock, getLibraryWindowFromDi, getReaderWindowFromDi,
+    closeProcessLock, diMainGet, getLibraryWindowFromDi, getReaderWindowFromDi,
 } from "readium-desktop/main/di";
 import { error } from "readium-desktop/main/tools/error";
 import { winActions } from "readium-desktop/main/redux/actions";
@@ -125,6 +125,10 @@ function* winOpen(action: winActions.library.openSucess.TAction) {
                 entries: [],
             },
             tag: [],
+            directory: {
+                defaultDirectory: diMainGet("publication-directory").defaultDirectory,
+                userDirectory: diMainGet("publication-directory").userDirectory,
+            },
         },
         session: {
             // state: state.session.state,

--- a/src/main/storage/publication-directory.ts
+++ b/src/main/storage/publication-directory.ts
@@ -1,0 +1,102 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import * as fs from "fs";
+import { injectable } from "inversify";
+import debug_ from "debug";
+import { userPublicationDirectoryConfigPath } from "../di";
+import { rmrf } from "readium-desktop/utils/fs";
+
+const debug = debug_("readium-desktop:main/storage/publication-directory");
+
+@injectable()
+export class PublicationDirectory {
+    public readonly defaultDirectory: string;
+    public userDirectory?: string;
+
+    public constructor(defaultDirectory: string) {
+        this.defaultDirectory = defaultDirectory;
+        this.readUserDirectory().catch(() => {
+            // Ignore invalid or missing config.
+        });
+    }
+
+    /**
+     * Loads the persisted user directory in the background.
+     * If the path is valid, it becomes the preferred storage directory.
+     */
+    private async readUserDirectory(): Promise<void> {
+        try {
+            const jsonStr = await fs.promises.readFile(userPublicationDirectoryConfigPath, "utf-8");
+            const jsonObj = JSON.parse(jsonStr);
+            const directoryPath = Array.isArray(jsonObj.directory)
+                ? jsonObj.directory[0]
+                : undefined;
+
+            if (!directoryPath) {
+                return;
+            }
+
+            if (!(await this.isDirectory(directoryPath))) {
+                return;
+            }
+
+            this.userDirectory = directoryPath;
+            debug("Set publication storage directory to", directoryPath);
+        } catch (e) {
+            debug(e);
+        }
+    }
+
+    /**
+     * Persists a new user directory if the provided path is a valid directory.
+     */
+    public async setUserDirectory(directoryPath: string): Promise<void> {
+        if (!directoryPath) {
+            this.userDirectory = undefined;
+            await rmrf(userPublicationDirectoryConfigPath);
+            return;
+        }
+
+        if (!(await this.isDirectory(directoryPath))) {
+            return;
+        }
+
+        this.userDirectory = directoryPath;
+
+        const jsonStr = JSON.stringify(
+            { directory: [directoryPath] },
+            null,
+            4,
+        );
+
+        await fs.promises.writeFile(
+            userPublicationDirectoryConfigPath,
+            jsonStr,
+            "utf-8",
+        );
+    }
+
+    public async getDirectoryPath(): Promise<string> {
+        const userDirectory = this.userDirectory;
+
+        if (userDirectory && (await this.isDirectory(userDirectory))) {
+            return userDirectory;
+        }
+
+        return this.defaultDirectory;
+    }
+
+    private async isDirectory(path: string): Promise<boolean> {
+        try {
+            const stat = await fs.promises.stat(path);
+            return stat.isDirectory();
+        } catch {
+            return false;
+        }
+    }
+}

--- a/src/main/storage/publication-directory.ts
+++ b/src/main/storage/publication-directory.ts
@@ -20,6 +20,8 @@ export class PublicationDirectory {
 
     public constructor(defaultDirectory: string) {
         this.defaultDirectory = defaultDirectory;
+        // Best-effort async initialization: startup must keep working with the
+        // default directory even if the persisted user directory is missing or invalid.
         this.readUserDirectory().catch(() => {
             // Ignore invalid or missing config.
         });

--- a/src/main/storage/publication-directory.ts
+++ b/src/main/storage/publication-directory.ts
@@ -13,6 +13,21 @@ import { rmrf } from "readium-desktop/utils/fs";
 
 const debug = debug_("readium-desktop:main/storage/publication-directory");
 
+type UserDirectoryConfig = {
+    directory: [string, ...string[]];
+};
+
+function isUserDirectoryConfig(value: unknown): value is UserDirectoryConfig {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const directory = (value as { directory?: unknown }).directory;
+    return Array.isArray(directory)
+        && typeof directory[0] === "string"
+        && directory[0].length > 0;
+}
+
 @injectable()
 export class PublicationDirectory {
     public readonly defaultDirectory: string;
@@ -22,31 +37,22 @@ export class PublicationDirectory {
         this.defaultDirectory = defaultDirectory;
         // Best-effort async initialization: startup must keep working with the
         // default directory even if the persisted user directory is missing or invalid.
-        this.readUserDirectory().catch(() => {
-            // Ignore invalid or missing config.
-        });
+        void this.readUserDirectory();
     }
 
-    /**
-     * Loads the persisted user directory in the background.
-     * If the path is valid, it becomes the preferred storage directory.
-     */
+    // Load the persisted directory in the background and keep it only if it still exists.
     private async readUserDirectory(): Promise<void> {
         try {
             const jsonStr = await fs.promises.readFile(userPublicationDirectoryConfigPath, "utf-8");
-            const jsonObj = JSON.parse(jsonStr);
-            const directoryPath = Array.isArray(jsonObj.directory)
-                ? jsonObj.directory[0]
-                : undefined;
-
-            if (!directoryPath) {
+            const json = JSON.parse(jsonStr) as unknown;
+            if (!isUserDirectoryConfig(json)) {
                 return;
             }
-
-            if (!(await this.isDirectory(directoryPath))) {
+            const directoryPath = json.directory[0];
+            const isDirectory = await this.isDirectory(directoryPath);
+            if (!isDirectory) {
                 return;
             }
-
             this.userDirectory = directoryPath;
             debug("Set publication storage directory to", directoryPath);
         } catch (e) {
@@ -54,9 +60,6 @@ export class PublicationDirectory {
         }
     }
 
-    /**
-     * Persists a new user directory if the provided path is a valid directory.
-     */
     public async setUserDirectory(directoryPath: string): Promise<void> {
         if (!directoryPath) {
             this.userDirectory = undefined;
@@ -64,33 +67,23 @@ export class PublicationDirectory {
             return;
         }
 
-        if (!(await this.isDirectory(directoryPath))) {
+        const isDirectory = await this.isDirectory(directoryPath);
+        if (!isDirectory) {
             return;
         }
-
         this.userDirectory = directoryPath;
-
-        const jsonStr = JSON.stringify(
-            { directory: [directoryPath] },
-            null,
-            4,
-        );
-
-        await fs.promises.writeFile(
-            userPublicationDirectoryConfigPath,
-            jsonStr,
-            "utf-8",
-        );
+        const jsonStr = JSON.stringify({ directory: [directoryPath] }, null, 4);
+        await fs.promises.writeFile(userPublicationDirectoryConfigPath, jsonStr, "utf-8");
     }
 
     public async getDirectoryPath(): Promise<string> {
         const userDirectory = this.userDirectory;
 
-        if (userDirectory && (await this.isDirectory(userDirectory))) {
-            return userDirectory;
+        if (!userDirectory) {
+            return this.defaultDirectory;
         }
-
-        return this.defaultDirectory;
+        const isDirectory = await this.isDirectory(userDirectory);
+        return isDirectory ? userDirectory : this.defaultDirectory;
     }
 
     private async isDirectory(path: string): Promise<boolean> {

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -325,18 +325,20 @@ export class PublicationStorage {
             // ignore
         }
 
-        publicationPath = path.join(publicationDirectory.userDirectory, identifier);
-        if (publicationPath) {
-            try {
-                // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
-                const stats = await fs.promises.stat(publicationPath);
-                if (stats.isDirectory()) {
-                    defer(publicationPath);
-                    return publicationPath;
+        if (publicationDirectory.userDirectory) {
+            publicationPath = path.join(publicationDirectory.userDirectory, identifier);
+            if (publicationPath) {
+                try {
+                    // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
+                    const stats = await fs.promises.stat(publicationPath);
+                    if (stats.isDirectory()) {
+                        defer(publicationPath);
+                        return publicationPath;
+                    }
+                } catch (e) {
+                    debug(e);
+                    // ignore
                 }
-            } catch (e) {
-                debug(e);
-                // ignore
             }
         }
 

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -22,6 +22,7 @@ import debug_ from "debug";
 import { sanitizeForFilename } from "readium-desktop/common/safe-filename";
 import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
 import { IReaderStateReaderPersistence } from "readium-desktop/common/redux/states/renderer/readerRootState";
+import { diMainGet } from "../di";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
@@ -48,28 +49,6 @@ const jsonStringify = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.strin
 @injectable()
 export class PublicationStorage {
 
-    /**
-     * from di.ts
-     * %appData%\config-data-json{-dev}\
-     */
-    // private configDataFolderPath: string;
-
-    /**
-     * appData/userData default publication storage directory path
-     * aka: %appData%\publications{-dev}\<uuid>
-     */
-    private defaultVaultPath: string;
-
-    /**
-     * publication storage directory path choose by user
-     */
-    private userVaultPath: Promise<string>;
-
-    /**
-     * json config path of the user choosen vault
-     */
-    private userVaultConfigPath: string;
-
     private assertAndGetFileName = (type: TFileTypePubStorage) => {
         const fileName = type === "locator" ? "locator.json" : type === "config" ? "config.json" : type === "disableRTLFlip" ? "disableRTLFlip.json" : type === "divina" ? "divina.json" : type === "allowCustomConfig" ? "allowCustomConfig.json" : type === "noteTotalCount" ? "noteTotalCount.json" : type === "pdfConfig" ? "pdfConfig.json" : "";
         if (!fileName) {
@@ -77,75 +56,6 @@ export class PublicationStorage {
         }
         return fileName;
     };
-
-    public constructor(rootPath: string, userVaultConfigPath: string) {
-        this.userVaultConfigPath = userVaultConfigPath;
-        this.defaultVaultPath = rootPath;
-        this.userVaultPath = this.readUserVault().then((userVaultPath) => {
-            debug("USER_VAULT_PATH=", userVaultPath);
-            return userVaultPath;
-        }).catch((e: any): undefined => {
-            debug(`${e}`);
-            return undefined;
-        }); // promise not resolved
-    }
-
-    private async readUserVault(): Promise<string> {
-        let userVaultPath = "";
-        try {
-            const jsonStr = await fs.promises.readFile(this.userVaultConfigPath, { encoding: "utf-8" });
-            const jsonObj = JSON.parse(jsonStr);
-            userVaultPath = Array.isArray(jsonObj.vault) ? jsonObj.vault[0] : "";
-        } catch {
-            // ignore
-        }
-
-        if (!userVaultPath) {
-            return undefined;
-        }
-        try {
-            // fs.promises.access(userVaultPath, fs.constants.W_OK | fs.constants.R_OK);
-            const dirStat = await fs.promises.stat(userVaultPath);
-            if (!dirStat.isDirectory()) {
-                throw new Error(`Directory: (${userVaultPath}) not created`);
-            }
-        } catch {
-            return undefined;
-        }
-
-        debug("Set publication storage vault to", userVaultPath);
-
-        return userVaultPath;
-    }
-
-    public async setUserVault(directoryPath: string) {
-
-        if (!directoryPath) {
-            return ;
-        }
-
-        try {
-            // fs.promises.access(directoryPath, fs.constants.W_OK | fs.constants.R_OK);
-            const dirStat = await fs.promises.stat(directoryPath);
-            if (!dirStat.isDirectory()) {
-                throw new Error(`Directory: (${directoryPath}) not created`);
-            }
-        } catch {
-            return;
-        }
-
-        const jsonObj = { vault: [directoryPath] };
-        const jsonStr = JSON.stringify(jsonObj, null, 4);
-        await fs.promises.writeFile(this.userVaultConfigPath, jsonStr, { encoding: "utf-8" });
-    }
-
-    // private only
-    // public getRootPath() {
-    //     return this.defaultRootPath;
-    // }
-    public async getVaultPath() {
-        return (await this.userVaultPath) || this.defaultVaultPath;
-    }
 
     public async writeJsonObj(
         identifier: string,
@@ -226,7 +136,7 @@ export class PublicationStorage {
         assertUUIDv4(identifier);
 
         // Create a directory whose name is equals to publication identifier
-        const pubDirPath = path.join(await this.getVaultPath(), identifier);
+        const pubDirPath = path.join(await diMainGet("publication-directory").getDirectoryPath(), identifier);
 
         try {
             await fs.promises.mkdir(pubDirPath);
@@ -304,10 +214,10 @@ export class PublicationStorage {
         //     debug(`removePublication error (ignore) ${identifier} ${p}`);
         // }
 
+        const publicationDirectory = diMainGet("publication-directory");
         const p = await this.findPublicationPath(identifier);
-        const userVaultPath = await this.userVaultPath; // can be undefined;
-        const p1 = userVaultPath ? path.join(userVaultPath, identifier) : undefined;
-        const p2 = path.join(this.defaultVaultPath, identifier);
+        const p1 = publicationDirectory.userDirectory ?  path.join(publicationDirectory.userDirectory, identifier) : undefined;
+        const p2 = path.join(publicationDirectory.defaultDirectory, identifier);
         try {
             if (p1) {
                 await rmrf(p1);
@@ -401,13 +311,22 @@ export class PublicationStorage {
             }
         };
 
-        let publicationPath = "";
+        const publicationDirectory = diMainGet("publication-directory");
+        let publicationPath = path.join(publicationDirectory.defaultDirectory, identifier);
+        try {
+            // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
+            const stats = await fs.promises.stat(publicationPath);
+            if (stats.isDirectory()) {
+                defer(publicationPath);
+                return publicationPath;
+            }
+        } catch (e) {
+            debug(e);
+            // ignore
+        }
 
-        const userVaultPath = await this.userVaultPath; // can be undefined
-        if (userVaultPath) {
-
-            publicationPath = path.join(userVaultPath, identifier);
-
+        publicationPath = path.join(publicationDirectory.userDirectory, identifier);
+        if (publicationPath) {
             try {
                 // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
                 const stats = await fs.promises.stat(publicationPath);
@@ -421,18 +340,6 @@ export class PublicationStorage {
             }
         }
 
-        publicationPath = path.join(this.defaultVaultPath, identifier);
-        try {
-            // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
-            const stats = await fs.promises.stat(publicationPath);
-            if (stats.isDirectory()) {
-                defer(publicationPath);
-                return publicationPath;
-            }
-        } catch (e) {
-            debug(e);
-            // ignore
-        }
         throw new Error("publication folder path not found");
     }
 
@@ -452,11 +359,12 @@ export class PublicationStorage {
 
         const pubIdSet = new Set<string>();
 
-        const userVaultPath = await this.userVaultPath; // can be undefined
+        const publicationDirectory = diMainGet("publication-directory");
+        const userVaultPath = publicationDirectory.userDirectory; // can be undefined
         if (userVaultPath) {
             await this._loopOnDirectory(userVaultPath, pubIdSet);
         }
-        await this._loopOnDirectory(this.defaultVaultPath, pubIdSet);
+        await this._loopOnDirectory(publicationDirectory.defaultDirectory, pubIdSet);
         return [...pubIdSet.values()];
     }
 

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -215,9 +215,7 @@ export class PublicationStorage {
 
         assertUUIDv4(identifier);
 
-        if (this.__publicationEpubPathMap.has(identifier)) {
-            this.__publicationEpubPathMap.delete(identifier);
-        }
+        this.__publicationEpubPathMap.delete(identifier);
 
 
         // try {
@@ -249,22 +247,29 @@ export class PublicationStorage {
         // }
 
         const publicationDirectory = diMainGet("publication-directory");
-        const p = await this.findPublicationPath(identifier);
-        const p1 = publicationDirectory.userDirectory ?  path.join(publicationDirectory.userDirectory, identifier) : undefined;
-        const p2 = path.join(publicationDirectory.defaultDirectory, identifier);
+        const defaultPublicationDirectoryPath = path.join(publicationDirectory.defaultDirectory, identifier);
         try {
-            if (p1) {
-                await rmrf(p1);
+            const stat = await fs.promises.stat(defaultPublicationDirectoryPath);
+            if (stat.isDirectory()) {
+                await rmrf(defaultPublicationDirectoryPath);
             }
-        } catch (e) {
-            debug(p1 === p ? e : "ok");
-        }
-        try {
-            await rmrf(p2);
-        } catch (e) {
-            debug(p2 === p ? e : "ok");
+        } catch {
+            // ignore
         }
 
+
+        // TODO: rm or unlink?
+        if (publicationDirectory.userDirectory) {
+            const userPublicationDirectoryPath = path.join(publicationDirectory.userDirectory, identifier);
+            try {
+                const stat = await fs.promises.stat(userPublicationDirectoryPath);
+                if (stat.isDirectory()) {
+                    await rmrf(userPublicationDirectoryPath);
+                }
+            } catch {
+                // ignore
+            }
+        }
     }
 
     public async getPublicationEpubPath(identifier: string): Promise<string> {

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -135,40 +135,74 @@ export class PublicationStorage {
 
         assertUUIDv4(identifier);
 
-        // Create a directory whose name is equals to publication identifier
-        const pubDirPath = path.join(await diMainGet("publication-directory").getDirectoryPath(), identifier);
+        const publicationDirectory = diMainGet("publication-directory");
+        const directoryPath = await publicationDirectory.getDirectoryPath();
+        const defaultDirectoryPath = publicationDirectory.defaultDirectory;
+        // New imports should use the user directory when available.
+        const publicationDirectoryPath = path.join(directoryPath, identifier);
+        debug(`storePublication in directory ${publicationDirectoryPath}`);
 
         try {
-            await fs.promises.mkdir(pubDirPath);
+            return await this.storePublicationInDirectory(identifier, srcPath, publicationDirectoryPath);
+        } catch (e) {
+            if (directoryPath === defaultDirectoryPath) {
+                throw e;
+            }
+            // If writing to the configured external directory fails, retry in default storage.
+            debug(`storePublication failed in configured directory ${publicationDirectoryPath}, retry in default directory`, e);
+            try {
+                await rmrf(publicationDirectoryPath);
+            } catch (err) {
+                debug("storePublication cleanup before retry failed", err);
+            }
+            const defaultPublicationDirectoryPath = path.join(defaultDirectoryPath, identifier);
+            debug(`storePublication fallback to default directory ${defaultPublicationDirectoryPath} for ${identifier}`);
+            return this.storePublicationInDirectory(
+                identifier,
+                srcPath,
+                defaultPublicationDirectoryPath,
+            );
+        }
+    }
+
+    private async storePublicationInDirectory(
+        identifier: string,
+        srcPath: string,
+        publicationDirectoryPath: string,
+    ): Promise<File[]> {
+        debug(`storePublication write into ${publicationDirectoryPath} for ${identifier}`);
+
+        try {
+            await fs.promises.mkdir(publicationDirectoryPath);
         } catch (e: any) {
-            debug(`mkdir ${pubDirPath}: ${e}`);
+            debug(`mkdir ${publicationDirectoryPath}: ${e}`);
             if (e.code === "EEXIST") {
                 debug("Directory already exists");
                 debug("How to handle this error?");
                 debug("Do we have to clean the directory before using it?");
                 debug("For the moment let's remove the directory");
                 try {
-                    await rmrf(pubDirPath);
-                    await fs.promises.mkdir(pubDirPath);
-                } catch (e) {
-                    debug(e);
+                    await rmrf(publicationDirectoryPath);
+                    await fs.promises.mkdir(publicationDirectoryPath);
+                } catch (err) {
+                    debug(err);
                 }
             }
         }
 
-        const dirStat = await fs.promises.stat(pubDirPath);
+        const dirStat = await fs.promises.stat(publicationDirectoryPath);
         if (!dirStat.isDirectory()) {
-            throw new Error(`Directory: (${pubDirPath}) not created`);
+            throw new Error(`Directory: (${publicationDirectoryPath}) not created`);
         }
 
         const files: File[] = [];
 
         const bookFile = await this.storePublicationBook(
-            identifier, srcPath, pubDirPath);
+            identifier, srcPath, publicationDirectoryPath);
         files.push(bookFile);
 
         const coverFile = await this.storePublicationCover(
-            identifier, srcPath, pubDirPath);
+            identifier, srcPath, publicationDirectoryPath);
         if (coverFile) {
             files.push(coverFile);
         }

--- a/src/renderer/library/components/publication/menu/CatalogMenu.tsx
+++ b/src/renderer/library/components/publication/menu/CatalogMenu.tsx
@@ -29,7 +29,6 @@ import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
 import { getSaga } from "readium-desktop/renderer/library/createStore";
-import { useApi } from "readium-desktop/renderer/common/hooks/useApi";
 
 function useShiftKey() {
   const [isShiftPressed, setIsShiftPressed] = React.useState(false);
@@ -62,7 +61,6 @@ const CatalogMenu: React.FC<{ publicationView: PublicationView }> = (props) => {
     const [__] = useTranslator();
     const dispatch = useDispatch();
     const locale = useSelector((state: ILibraryRootState) => state.i18n.locale);
-    const [, openPublicationFolder] = useApi(undefined, "publication/openFolder");
     const isShiftKeyPressed = useShiftKey();
 
     const isPublicationMissingOrDeleted = props.publicationView.type === "missingOrDeleted";
@@ -100,7 +98,7 @@ const CatalogMenu: React.FC<{ publicationView: PublicationView }> = (props) => {
         <button
             className="R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE"
             onClick={debounce(() => {
-                openPublicationFolder(props.publicationView.identifier);
+                dispatch(publicationActions.openFolder.build(props.publicationView.identifier));
             }, 1000, { immediate: true })}
         >OPEN Folder</button >
     </>;

--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -11,6 +11,7 @@ import * as stylesSettings from "readium-desktop/renderer/assets/styles/componen
 import * as stylesGlobal from "readium-desktop/renderer/assets/styles/global.scss";
 import * as stylesAnnotations from "readium-desktop/renderer/assets/styles/components/annotations.scss";
 import * as stylesInput from "readium-desktop/renderer/assets/styles/components/inputs.scss";
+import * as stylesAlertModals from "readium-desktop/renderer/assets/styles/components/alert.modals.scss";
 import * as stylesDropDown from "readium-desktop/renderer/assets/styles/components/dropdown.scss";
 import * as stylesPopoverDialog from "readium-desktop/renderer/assets/styles/components/popoverDialog.scss";
 
@@ -18,6 +19,7 @@ import * as stylesPopoverDialog from "readium-desktop/renderer/assets/styles/com
 // import {I18nProvider} from 'react-aria';
 
 import * as React from "react";
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import * as Dialog from "@radix-ui/react-dialog";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as QuitIcon from "readium-desktop/renderer/assets/icons/close-icon.svg";
@@ -25,6 +27,7 @@ import * as CogIcon from "readium-desktop/renderer/assets/icons/cog-icon.svg";
 import * as PaletteIcon from "readium-desktop/renderer/assets/icons/palette-icon.svg";
 import * as KeyReturnIcon from "readium-desktop/renderer/assets/icons/keyreturn-icon.svg";
 import * as AvatarIcon from "readium-desktop/renderer/assets/icons/avatar-icon.svg";
+import * as LibraryIcon from "readium-desktop/renderer/assets/icons/library-icon.svg";
 import * as DeleteIcon from "readium-desktop/renderer/assets/icons/trash-icon.svg";
 import SVG, { ISVGProps } from "readium-desktop/renderer/common/components/SVG";
 import classNames from "classnames";
@@ -35,7 +38,7 @@ import { availableLanguages } from "readium-desktop/common/services/translator";
 // import * as ChevronDown from "readium-desktop/renderer/assets/icons/chevron-down.svg";
 import { ComboBox, ComboBoxItem } from "readium-desktop/renderer/common/components/ComboBox";
 import { useDispatch } from "readium-desktop/renderer/common/hooks/useDispatch";
-import { authActions, creatorActions, customizationActions, i18nActions, noteExport, screenReaderActions, settingsActions, themeActions } from "readium-desktop/common/redux/actions";
+import { authActions, catalogActions, creatorActions, customizationActions, i18nActions, noteExport, screenReaderActions, settingsActions, themeActions } from "readium-desktop/common/redux/actions";
 import * as BinIcon from "readium-desktop/renderer/assets/icons/trash-icon.svg";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
 import { TTheme } from "readium-desktop/common/redux/states/theme";
@@ -63,6 +66,46 @@ import moment from "moment";
 // import { TagGroup, TagList, Tag, Label } from "react-aria-components";
 
 interface ISettingsProps {};
+
+const StorageConfirmDialog = (props: {
+    open: boolean;
+    title: string;
+    description: string;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onOpenChange: (open: boolean) => void;
+}) => {
+    return (
+        <AlertDialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+            <AlertDialog.Portal>
+                <AlertDialog.Overlay className={stylesAlertModals.AlertDialogOverlay} />
+                <AlertDialog.Content className={stylesAlertModals.AlertDialogContent}>
+                    <AlertDialog.Title className={stylesAlertModals.AlertDialogTitle}>
+                        {props.title}
+                    </AlertDialog.Title>
+                    <AlertDialog.Description className={stylesAlertModals.AlertDialogDescription}>
+                        {props.description}
+                    </AlertDialog.Description>
+                    <div className={stylesAlertModals.AlertDialogButtonContainer}>
+                        <AlertDialog.Cancel asChild>
+                            <button className={classNames(stylesAlertModals.AlertDialogButton, stylesAlertModals.abort)}>
+                                Cancel
+                            </button>
+                        </AlertDialog.Cancel>
+                        <AlertDialog.Action asChild>
+                            <button
+                                className={classNames(stylesAlertModals.AlertDialogButton, stylesAlertModals.yes)}
+                                onClick={props.onConfirm}
+                            >
+                                {props.confirmLabel}
+                            </button>
+                        </AlertDialog.Action>
+                    </div>
+                </AlertDialog.Content>
+            </AlertDialog.Portal>
+        </AlertDialog.Root>
+    );
+};
 
 const TabTitle = (props: React.PropsWithChildren<{title: string}>) => {
     // const locale = useSelector((state: IRendererCommonRootState) => state.i18n.locale);
@@ -644,6 +687,226 @@ const Profiles = () => {
     );
 };
 
+const StorageSettings: React.FC<{}> = () => {
+    const locale = useSelector((state: ICommonRootState) => state.i18n.locale);
+    const isRTL = locale === "ar";
+    const dispatch = useDispatch();
+    const directoryState = useSelector((state: ILibraryRootState) => state.publication.directory);
+    const defaultDirectory = directoryState?.defaultDirectory || "";
+    const userDirectory = directoryState?.userDirectory || "";
+
+    const [isEditing, setIsEditing] = React.useState(false);
+    const [confirmAddOpen, setConfirmAddOpen] = React.useState(false);
+    const [confirmEditOpen, setConfirmEditOpen] = React.useState(false);
+    const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
+
+    const submitDirectory = React.useCallback((nextDirectory: string) => {
+        dispatch(catalogActions.setUserDirectory.build(nextDirectory));
+        setIsEditing(false);
+    }, [dispatch]);
+
+    const openFolderPicker = React.useCallback(() => {
+        dispatch(catalogActions.setUserDirectory.build(userDirectory));
+        setIsEditing(false);
+    }, [dispatch, userDirectory]);
+
+    if (!defaultDirectory) {
+        return <></>;
+    }
+
+    return (
+        <>
+            <StorageConfirmDialog
+                open={confirmAddOpen}
+                onOpenChange={setConfirmAddOpen}
+                title="Enable external publication storage"
+                description="This feature is currently in beta. Do you want to continue and configure an external publication storage directory?"
+                confirmLabel="Continue"
+                onConfirm={() => {
+                    setConfirmAddOpen(false);
+                    setIsEditing(true);
+                }}
+            />
+            <StorageConfirmDialog
+                open={confirmEditOpen}
+                onOpenChange={setConfirmEditOpen}
+                title="Edit external publication storage"
+                description="Changing the external publication storage directory requires manual care. Thorium will not migrate existing publications for you. Do you want to continue?"
+                confirmLabel="Edit directory"
+                onConfirm={() => {
+                    setConfirmEditOpen(false);
+                    setIsEditing(true);
+                }}
+            />
+            <StorageConfirmDialog
+                open={confirmDeleteOpen}
+                onOpenChange={setConfirmDeleteOpen}
+                title="Remove external publication storage"
+                description="Removing the configured external publication storage directory does not migrate publications back automatically. Do you want to remove this directory from Thorium configuration?"
+                confirmLabel="Remove directory"
+                onConfirm={() => {
+                    setConfirmDeleteOpen(false);
+                    submitDirectory("");
+                }}
+            />
+
+            <section className={stylesSettings.section} style={{ position: "relative", gap: "14px" }}>
+                <h4 dir={isRTL ? "rtl" : "ltr"}>Storage</h4>
+                <div className={stylesSettings.session_text} style={{ alignItems: "flex-start" }}>
+                    <SVG ariaHidden svg={InfoIcon} />
+                    <div dir={isRTL ? "rtl" : "ltr"} style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+                        <p>This external publication storage feature is currently in beta testing.</p>
+                        <p>No migration will be performed by Thorium. If you change storage location, moving publications is entirely your responsibility.</p>
+                        <p>You are responsible for the integrity and availability of this directory. Be careful with deletion, remote access, slow devices or network paths, and filesystem permissions.</p>
+                        <p>Publications stored by Thorium in this directory are immutable application data and reflect Thorium&apos;s internal storage structure. Editing, renaming, moving, or deleting files inside it can break publication reading and may crash the reader for affected items.</p>
+                        <p>You can consider this directory a vault managed by Thorium.</p>
+                    </div>
+                </div>
+
+                <div dir={isRTL ? "rtl" : "ltr"} style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+                    <div style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "12px",
+                        padding: "14px 16px",
+                        border: "1px solid var(--color-button-border)",
+                        borderRadius: "8px",
+                        background: "var(--color-gray-50)",
+                    }}>
+                        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                            <p style={{ margin: 0, fontWeight: 600 }}>Locations</p>
+                            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                <p style={{ margin: 0 }}><strong>Default internal storage</strong></p>
+                                <button
+                                    className={stylesButtons.button_transparency}
+                                    style={{
+                                        justifyContent: "flex-start",
+                                        width: "100%",
+                                        height: "auto",
+                                        minHeight: "unset",
+                                        textAlign: "left",
+                                        whiteSpace: "normal",
+                                        overflowWrap: "anywhere",
+                                        wordBreak: "break-word",
+                                        lineHeight: 1.4,
+                                    }}
+                                    onClick={() => dispatch(catalogActions.openDefaultDirectory.build())}
+                                >
+                                    {defaultDirectory}
+                                </button>
+                            </div>
+                            {userDirectory ?
+
+                                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                    <p style={{ margin: 0 }}><strong>External storage</strong></p>
+                                    <button
+                                        className={stylesButtons.button_transparency}
+                                        style={{
+                                            justifyContent: "flex-start",
+                                            width: "100%",
+                                            height: "auto",
+                                            minHeight: "unset",
+                                            textAlign: "left",
+                                            whiteSpace: "normal",
+                                            overflowWrap: "anywhere",
+                                            wordBreak: "break-word",
+                                            lineHeight: 1.4,
+                                        }}
+                                        onClick={() => dispatch(catalogActions.openUserDirectory.build())}
+                                    >
+                                        {userDirectory}
+                                    </button>
+                                </div> : <></>
+                            }
+                        </div>
+                    </div>
+
+                    <div style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "12px",
+                        padding: "16px",
+                        border: "1px solid var(--color-button-border)",
+                        borderRadius: "8px",
+                        background: "var(--color-neutral-base)",
+                        boxShadow: "0 1px 0 var(--color-gray-100)",
+                    }}>
+                        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                            <p style={{ margin: 0, fontWeight: 600 }}>Configuration</p>
+                            {!userDirectory && !isEditing ? (
+                                <div className={stylesSettings.session_text} style={{ margin: 0, alignItems: "flex-start" }}>
+                                    <SVG ariaHidden svg={InfoIcon} />
+                                    <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                        <p style={{ margin: 0, fontWeight: 600 }}>Not configured for the moment.</p>
+                                        <p style={{ margin: 0 }}>
+                                            Configure an external storage directory to store new publications outside of Thorium&apos;s default internal location.
+                                        </p>
+                                    </div>
+                                </div>
+                            ) : null}
+                            {userDirectory && !isEditing ? (
+                                <p style={{ margin: 0 }}>
+                                    The external storage directory is configured and ready to use for newly stored publications.
+                                </p>
+                            ) : null}
+                            {isEditing ? (
+                                <p style={{ margin: 0 }}>
+                                    Choose the folder that Thorium should use as external publication storage.
+                                </p>
+                            ) : null}
+                        </div>
+
+                        {!userDirectory && !isEditing ? (
+                            <button
+                                className={stylesSettings.btn_primary}
+                                onClick={() => setConfirmAddOpen(true)}
+                            >
+                                Add external storage directory
+                            </button>
+                        ) : null}
+
+                        {userDirectory && !isEditing ? (
+                            <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+                                <button
+                                    className={stylesSettings.btn_primary}
+                                    onClick={() => setConfirmEditOpen(true)}
+                                >
+                                    Change external storage directory
+                                </button>
+                                <button
+                                    className={stylesButtons.button_secondary_blue}
+                                    onClick={() => setConfirmDeleteOpen(true)}
+                                >
+                                    Remove external storage directory
+                                </button>
+                            </div>
+                        ) : null}
+
+                        {isEditing ? (
+                            <div style={{ display: "flex", gap: "10px", flexWrap: "wrap", alignItems: "center" }}>
+                                <button
+                                    className={stylesSettings.btn_primary}
+                                    onClick={openFolderPicker}
+                                >
+                                    Choose folder
+                                </button>
+                                <button
+                                    className={stylesButtons.button_transparency}
+                                    onClick={() => {
+                                        setIsEditing(false);
+                                    }}
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+            </section>
+        </>
+    );
+};
+
 const TabHeader = (props: React.PropsWithChildren<{title: string, advancedTrigger: boolean}>) => {
     const [__] = useTranslator();
     // const locale = useSelector((state: IRendererCommonRootState) => state.i18n.locale);
@@ -715,6 +978,10 @@ export const Settings: React.FC<ISettingsProps> = () => {
                             <SVG ariaHidden svg={AvatarIcon} />
                             <h3 dir={isRTL ? "rtl" : "ltr"}>{__("settings.tabs.profiles")}</h3>
                         </Tabs.Trigger>
+                        <Tabs.Trigger value="tab6" onFocus={() => setTabTitle("Storage")}>
+                            <SVG ariaHidden svg={LibraryIcon} />
+                            <h3 dir={isRTL ? "rtl" : "ltr"}>Storage</h3>
+                        </Tabs.Trigger>
                     </Tabs.List>
                     <div className={stylesSettings.settings_content} style={{ marginTop: "70px" }}>
                         <Tabs.Content value="tab1" tabIndex={-1}>
@@ -741,6 +1008,11 @@ export const Settings: React.FC<ISettingsProps> = () => {
                         <Tabs.Content value="tab5" tabIndex={-1}>
                             <div className={stylesSettings.settings_tab}>
                                 <Profiles />
+                            </div>
+                        </Tabs.Content>
+                        <Tabs.Content value="tab6" tabIndex={-1}>
+                            <div className={stylesSettings.settings_tab}>
+                                <StorageSettings />
                             </div>
                         </Tabs.Content>
                     </div>

--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -757,6 +757,7 @@ const StorageSettings: React.FC<{}> = () => {
                     <div dir={isRTL ? "rtl" : "ltr"} style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
                         <p>This external publication storage feature is currently in beta testing.</p>
                         <p>No migration will be performed by Thorium. If you change storage location, moving publications is entirely your responsibility.</p>
+                        <p>This feature only works with newer versions of Thorium. Publications added to the external storage folder will not appear in Thorium 3.4 or below.</p>
                         <p>You are responsible for the integrity and availability of this directory. Be careful with deletion, remote access, slow devices or network paths, and filesystem permissions.</p>
                         <p>Publications stored by Thorium in this directory are immutable application data and reflect Thorium&apos;s internal storage structure. Editing, renaming, moving, or deleting files inside it can break publication reading and may crash the reader for affected items.</p>
                         <p>You can consider this directory a vault managed by Thorium.</p>

--- a/src/renderer/library/redux/middleware/sync.ts
+++ b/src/renderer/library/redux/middleware/sync.ts
@@ -52,6 +52,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     readerActions.configSetDefault.ID, // readerConfig
 
     publicationActions.readingFinished.ID,
+    publicationActions.openFolder.ID,
     themeActions.setTheme.ID,
 
     // readerActions.bookmark.pop.ID,
@@ -84,6 +85,10 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     opdsActions.refresh.ID,
 
     winCommonActions.initSuccess.ID,
+    
+    catalogActions.setUserDirectory.ID,
+    catalogActions.openDefaultDirectory.ID,
+    catalogActions.openUserDirectory.ID,
 ];
 
 export const reduxSyncMiddleware = syncFactory(SYNCHRONIZABLE_ACTIONS);

--- a/src/renderer/library/redux/reducers/index.ts
+++ b/src/renderer/library/redux/reducers/index.ts
@@ -46,6 +46,7 @@ import { arrayReducer } from "readium-desktop/utils/redux-reducers/array.reducer
 import { ICustomizationProfileHistory } from "readium-desktop/common/redux/states/customization";
 import { customizationPackageWelcomeScreenReducer } from "readium-desktop/common/redux/reducers/customization/welcomeScreen";
 import { customizationPackageManifestReducer } from "readium-desktop/common/redux/reducers/customization/manifest";
+import { directoryReducer } from "readium-desktop/common/redux/reducers/directory";
 
 export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reducer<Partial<ILibraryRootState>>
     return combineReducers({ // ILibraryRootState
@@ -98,6 +99,7 @@ export const rootReducer = (routerReducer: Reducer<RouterState>) => { // : Reduc
         publication: combineReducers({
             catalog: catalogViewReducer,
             tag: tagReducer,
+            directory: directoryReducer,
         }),
         wizard: wizardReducer,
         creator: creatorReducer,


### PR DESCRIPTION
Fixes #3506 

**Summary**

- Adds a new `Storage` tab to Library Settings.
- Introduces support for configuring an external publication storage directory from the Library window.
- Keeps the default internal storage active as the fallback when no external directory is configured.

**What changed**

- Adds storage directory state to the library renderer state under `publication.directory`.
- Introduces a dedicated `PublicationDirectory` main-side service to manage:
  - the default storage directory
  - the optional configured external directory
  - persistence of the external directory configuration
- Updates publication storage filesystem handling to work with both in order storage locations:
  - the default internal storage directory
  - the optional external storage directory
- Adds Settings UI for:
  - displaying storage locations
  - configuring an external storage directory
  - changing the configured directory
  - removing the configured directory
  - opening the default and external directories from clickable paths
- Adds confirmation dialogs for add / change / remove flows.
- Adds user warning about:
  - beta status
  - no automatic migration
  - responsibility for folder stability and integrity
  - immutability of Thorium-managed stored files

**Behavioral impact**

- When no external directory is configured, publication storage continues to use the default internal directory.
- When an external directory is configured, newly stored publications use that directory.
- Removing the external directory configuration falls back to the default internal directory.
- Changing from one external directory to another can open the previous and new directories to help with manual migration.

**Code-level structure**

- New storage configuration state is exposed to the library UI.
- New catalog/publication actions were added for:
  - configuring the external storage directory
  - opening the default storage directory
  - opening the configured external storage directory
  - opening a publication’s storage folder from the catalog menu
- The publication folder opening flow is now aligned with direct renderer/main action handling instead of the older API-style path.

**UI scope**

- `Settings.tsx` gains the new `Storage` section and related interaction flow.
- Storage paths are rendered as clickable wrapped paths instead of large action buttons.
- The configuration block is visually separated from the informational block and current location display.

**Notes**

- No automatic migration is implemented.
- Existing publications are not moved by this change.
- The feature is intentionally explicit and guarded because it affects on-disk publication storage behavior.
- The feature is not backward compatible with 3.x version, publication added in the user directory will not be found in older versions.

**Captures**



<img width="1247" height="1021" alt="image" src="https://github.com/user-attachments/assets/6daf7d37-a833-4c70-b451-671a2ab39926" />

<img width="1247" height="1021" alt="image" src="https://github.com/user-attachments/assets/31d3469c-5a73-494f-adde-1f6582dae52a" />


<img width="1247" height="1021" alt="image" src="https://github.com/user-attachments/assets/ed3179b3-3546-4a10-bc54-53138ce62963" />

<img width="1252" height="1022" alt="image" src="https://github.com/user-attachments/assets/ea0794c5-1474-44a3-939a-c2528f2c4c36" />

<img width="1247" height="1021" alt="image" src="https://github.com/user-attachments/assets/fda91ea1-b27c-4719-a47f-69d4770a6007" />

<img width="1247" height="1021" alt="image" src="https://github.com/user-attachments/assets/84c908f3-ae7d-46b4-adcf-b23623b04aab" />

