### PR TITLE
Fix: guard unavailable publications from opening in library

### DIFF
--- a/src/common/views/publication.ts
+++ b/src/common/views/publication.ts
@@ -24,9 +24,12 @@ export interface CustomCoverView {
     bottomColor: string;
 }
 
+export type PublicationViewStatus = "success" | "error";
+
 export interface PublicationView extends Identifiable {
 
-    type?: "missingOrDeleted";
+    // Post-check that the publication storage is valid for opening
+    isOpenable: boolean;
     isAudio?: boolean;
     isDivina?: boolean;
     isPDF?: boolean;
@@ -79,3 +82,7 @@ export interface PublicationView extends Identifiable {
 
     lastReadingLocation?: MiniLocatorExtended;
 }
+
+export const canOpenPublication = (
+    publicationView: Partial<Pick<PublicationView, "isOpenable">>,
+) => publicationView.isOpenable !== false;

--- a/src/common/views/publication.ts
+++ b/src/common/views/publication.ts
@@ -24,8 +24,6 @@ export interface CustomCoverView {
     bottomColor: string;
 }
 
-export type PublicationViewStatus = "success" | "error";
-
 export interface PublicationView extends Identifiable {
 
     // Post-check that the publication storage is valid for opening

--- a/src/main/converter/publication.ts
+++ b/src/main/converter/publication.ts
@@ -222,14 +222,12 @@ export class PublicationViewConverter {
         }
 
         const {
-            publicationDirectory,
+            // publicationDirectory,
             isOpenable,
         } = await getPublicationStorageState(document.identifier);
 
         return {
 
-            status: "error",
-            publicationDirectory,
             isOpenable,
             identifier: document.identifier, // preserve Identifiable identifier
 
@@ -340,14 +338,12 @@ export class PublicationViewConverter {
         const trimStrings = (texts: string | string[]): string[] => Array.isArray(texts) ? texts.filter((item) => item && typeof item === "string").map((item) => item.trim()) : texts && typeof texts === "string" ? [texts.trim()] : [];
 
         const {
-            publicationDirectory,
+            // publicationDirectory,
             isOpenable,
         } = await getPublicationStorageState(document.identifier);
 
         return {
 
-            status: "success",
-            publicationDirectory,
             isOpenable,
             isAudio,
             isDivina,

--- a/src/main/converter/publication.ts
+++ b/src/main/converter/publication.ts
@@ -42,6 +42,23 @@ interface ICache {
 }
 const _pubCache: Record<string, ICache> = {};
 
+const getPublicationStorageState = async (identifier: string): Promise<{
+    publicationDirectory: string;
+    isOpenable: boolean;
+}> => {
+    let publicationDirectory = "";
+    try {
+        publicationDirectory = await diMainGet("publication-storage").findPublicationPath(identifier);
+    } catch {
+        debug("publication not found on disk");
+    }
+
+    return {
+        publicationDirectory,
+        isOpenable: Boolean(publicationDirectory),
+    };
+};
+
 @injectable()
 export class PublicationViewConverter {
 
@@ -187,7 +204,7 @@ export class PublicationViewConverter {
         }
     }
 
-    public async convertDocumentMissingOrDeletedToMinimalPublicationView(document: PublicationDocument): Promise<PublicationView> {
+    public async convertUnavailableDocumentToMinimalPublicationView(document: PublicationDocument): Promise<PublicationView> {
 
         const store = diMainGet("store");
         const state = store.getState();
@@ -204,9 +221,16 @@ export class PublicationViewConverter {
             };
         }
 
+        const {
+            publicationDirectory,
+            isOpenable,
+        } = await getPublicationStorageState(document.identifier);
+
         return {
 
-            type: "missingOrDeleted",
+            status: "error",
+            publicationDirectory,
+            isOpenable,
             identifier: document.identifier, // preserve Identifiable identifier
 
             readingFinished,
@@ -315,11 +339,16 @@ export class PublicationViewConverter {
 
         const trimStrings = (texts: string | string[]): string[] => Array.isArray(texts) ? texts.filter((item) => item && typeof item === "string").map((item) => item.trim()) : texts && typeof texts === "string" ? [texts.trim()] : [];
 
+        const {
+            publicationDirectory,
+            isOpenable,
+        } = await getPublicationStorageState(document.identifier);
+
         return {
 
-            // When a publication is found on disk but cannot be found in the database, we should mitigate the risk by setting a missingOrDeleted error.
-            type: document.doNotPresentInReduxStoreDataBaseButFoundOnDisk_dummyDocument ? "missingOrDeleted" : undefined,
-            
+            status: "success",
+            publicationDirectory,
+            isOpenable,
             isAudio,
             isDivina,
             isPDF,

--- a/src/main/redux/sagas/api/publication/findAll.ts
+++ b/src/main/redux/sagas/api/publication/findAll.ts
@@ -38,7 +38,7 @@ const convertDocs = async (docs: PublicationDocument[], publicationViewConverter
             debug("Error When convert document to view, the publication is not deleted, so let's mitigate the publication error for the next time");
             debug(e);
 
-            const pub = await publicationViewConverter.convertDocumentMissingOrDeletedToMinimalPublicationView(doc);
+            const pub = await publicationViewConverter.convertUnavailableDocumentToMinimalPublicationView(doc);
             pubs.push(pub);
 
             // yield* callTyped(errorDeletePub, doc, e as Error);

--- a/src/main/redux/sagas/api/publication/import/index.ts
+++ b/src/main/redux/sagas/api/publication/import/index.ts
@@ -9,7 +9,7 @@ import debug_ from "debug";
 import { ToastType } from "readium-desktop/common/models/toast";
 import { toastActions } from "readium-desktop/common/redux/actions";
 import { IOpdsLinkView, IOpdsPublicationView } from "readium-desktop/common/views/opds";
-import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationView, canOpenPublication } from "readium-desktop/common/views/publication";
 import { diMainGet } from "readium-desktop/main/di";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { put } from "redux-saga/effects";
@@ -35,7 +35,7 @@ const convertDoc = async (doc: PublicationDocument, publicationViewConverter: Pu
     return await publicationViewConverter.convertDocumentToView(doc);
     } catch (e) {
         debug("Error to convert document to publicationView", e);
-        const pub = await publicationViewConverter.convertDocumentMissingOrDeletedToMinimalPublicationView(doc);
+        const pub = await publicationViewConverter.convertUnavailableDocumentToMinimalPublicationView(doc);
         debug("Convert to minimal view", pub);
         return pub;
     }
@@ -66,7 +66,7 @@ export function* importFromLink(
             if (deep < 1) {
                 deep = 1;
 
-                if (publicationView.type === "missingOrDeleted") {
+                if (!canOpenPublication(publicationView)) {
 
                     debug(`${publicationDocument?.identifier} => ${publicationDocument?.title} should be removed`);
                     const str = `The publication is missing or deleted: ${publicationDocument?.identifier} => ${publicationDocument?.title}. The directory must be deleted.`;
@@ -191,7 +191,7 @@ export function* importFromFs(
                         if (deep < 1) {
                             deep = 1;
 
-                            if (publicationView.type === "missingOrDeleted") {
+                            if (!canOpenPublication(publicationView)) {
 
                                 debug(`${publicationDocument?.identifier} => ${publicationDocument?.title} should be removed`);
                                 const str = `The publication is missing or deleted: ${publicationDocument?.identifier} => ${publicationDocument?.title}. The directory must be deleted.`;

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -141,7 +141,7 @@ function* getPublicationView() {
             debug("Error When convert document to view, the publication is not deleted, so let's mitigate the publication error for the next time");
             debug(e);
 
-            const pub = yield* callTyped(() => publicationViewConverter.convertDocumentMissingOrDeletedToMinimalPublicationView(doc));
+                    const pub = yield* callTyped(() => publicationViewConverter.convertUnavailableDocumentToMinimalPublicationView(doc));
             lastAddedPublicationsView.push(pub);
 
             // yield* callTyped(errorDeletePub, doc, e as Error);
@@ -162,7 +162,7 @@ function* getPublicationView() {
             debug("Error When convert document to view, the publication is not deleted, so let's mitigate the publication error for the next time");
             debug(e);
 
-            const pub = yield* callTyped(() => publicationViewConverter.convertDocumentMissingOrDeletedToMinimalPublicationView(doc));
+                    const pub = yield* callTyped(() => publicationViewConverter.convertUnavailableDocumentToMinimalPublicationView(doc));
             lastReadPublicationsView.push(pub);
 
             // yield* callTyped(errorDeletePub, doc, e as Error);

--- a/src/renderer/common/components/Cover.tsx
+++ b/src/renderer/common/components/Cover.tsx
@@ -39,7 +39,7 @@ interface IBaseProps {
     onKeyUp?: (e: React.KeyboardEvent<HTMLImageElement>) => void;
     forwardedRef?:  React.ForwardedRef<HTMLImageElement>;
     imgRadixProp?: any;
-    hasEnded?: boolean;
+    isPublicationUnavailable?: boolean;
 }
 
 // IProps may typically extend:
@@ -51,7 +51,7 @@ interface IProps extends IBaseProps, ReturnType<typeof mapStateToProps>, Transla
 }
 
 interface IState {
-    imgUrl: string,
+    imgUrl?: string | undefined,
     imgErroredOnce: boolean,
 }
 
@@ -64,7 +64,7 @@ class Cover extends React.Component<IProps, IState> {
 
         const { cover } = this.props.publicationViewMaybeOpds;
 
-        let imgUrl = "";
+        let imgUrl: string | undefined;
         if (cover) {
             const coverUrl = cover.coverUrl || cover.coverLinks[0]?.url;
             const thumbnailUrl = cover.coverUrl || cover.thumbnailLinks[0]?.url;
@@ -115,7 +115,7 @@ class Cover extends React.Component<IProps, IState> {
             needsSpinner = true;
         }
 
-        const isPublicationMissingOrDeleted = publicationViewMaybeOpds.type === "missingOrDeleted";
+        const isPublicationUnavailable = this.props.isPublicationUnavailable;
 
         // let tagString = "";
         // for (const tag of publicationViewMaybeOpds.tags) {
@@ -128,8 +128,8 @@ class Cover extends React.Component<IProps, IState> {
 
         if (this.state.imgUrl) {
             return (
-                <div className={isPublicationMissingOrDeleted ? stylesPublications.publication_missing_wrapper : ""}>
-                    {isPublicationMissingOrDeleted ?
+                <div className={isPublicationUnavailable ? stylesPublications.publication_missing_wrapper : ""}>
+                    {isPublicationUnavailable ?
                     <div className={stylesPublications.publication_missing_container}>
                         <SVG ariaHidden svg={FileBroken} className={stylesPublications.publication_missing_icon} />
                     </div>
@@ -177,8 +177,8 @@ class Cover extends React.Component<IProps, IState> {
         const pubTitleStr = pubTitleLangStr && pubTitleLangStr[1] ? pubTitleLangStr[1] : "";
 
         return (
-            <div className={isPublicationMissingOrDeleted ? stylesPublications.publication_missing_wrapper : ""} style={{width: "100%"}}>
-                {isPublicationMissingOrDeleted ?
+            <div className={isPublicationUnavailable ? stylesPublications.publication_missing_wrapper : ""} style={{width: "100%"}}>
+                {isPublicationUnavailable ?
                     <div className={stylesPublications.publication_missing_container}>
                         <SVG ariaHidden svg={FileBroken} className={stylesPublications.publication_missing_icon} />
                     </div>
@@ -196,14 +196,6 @@ class Cover extends React.Component<IProps, IState> {
             {/* {!this.props.publicationViewMaybeOpds.lastReadTimeStamp ?
             <div className={stylesPublications.corner}></div>
             : <></>} */}
-            {
-                    publicationViewMaybeOpds.type === "missingOrDeleted"
-                        ? <div aria-label={this.props.__("catalog.missing")} style={{ position: "absolute", width: "inherit", height: "inherit", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.7 }}>
-                            <div aria-hidden style={{ height: "70px", width: "70px", borderRadius: "50%", background: "var(--color-error-text)", padding: "10px" }}>
-                                <SVG ariaHidden svg={FileBroken} className={stylesPublications.publication_missing_icon} />
-                            </div>
-                        </div> : <></>
-            }
             {
             needsSpinner
             ?
@@ -235,7 +227,12 @@ const mapStateToProps = (state: IRendererCommonRootState) => ({
 const CoverWithTranslator = connect(mapStateToProps)(withTranslator(Cover));
 export default CoverWithTranslator;
 
-export const CoverWithForwardedRef = React.forwardRef<HTMLImageElement, IBaseProps>(({publicationViewMaybeOpds, coverType, ...props}, forwardedRef) => {
+export const CoverWithForwardedRef = React.forwardRef<HTMLImageElement, IBaseProps>(({
+    publicationViewMaybeOpds,
+    coverType,
+    isPublicationUnavailable,
+    ...props
+}, forwardedRef) => {
     const [__] = useTranslator();
 
     return (
@@ -245,7 +242,7 @@ export const CoverWithForwardedRef = React.forwardRef<HTMLImageElement, IBasePro
             coverType={coverType}
             forwardedRef={forwardedRef}
             imgRadixProp={props}
-            hasEnded={props.hasEnded}
+            isPublicationUnavailable={isPublicationUnavailable}
         />
     );
 });

--- a/src/renderer/library/components/publication/PublicationCard.tsx
+++ b/src/renderer/library/components/publication/PublicationCard.tsx
@@ -7,14 +7,16 @@
 
 import * as stylesPublications from "readium-desktop/renderer/assets/styles/components/publications.scss";
 import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
+import * as stylesAlertModals from "readium-desktop/renderer/assets/styles/components/alert.modals.scss";
 
 import * as React from "react";
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { connect } from "react-redux";
 import { DialogTypeName } from "readium-desktop/common/models/dialog";
 import { readerActions } from "readium-desktop/common/redux/actions";
 import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
 import { IOpdsPublicationView } from "readium-desktop/common/views/opds";
-import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationView, canOpenPublication } from "readium-desktop/common/views/publication";
 import * as MenuIcon from "readium-desktop/renderer/assets/icons/menu.svg";
 
 import Cover from "readium-desktop/renderer/common/components/Cover";
@@ -73,7 +75,11 @@ class PublicationCard extends React.Component<IProps> {
         const pubTitleStr = pubTitleLangStr && pubTitleLangStr[1] ? pubTitleLangStr[1] : "";
 
         const publicationView = publicationViewMaybeOpds as PublicationView;
-        const isPublicationMissingOrDeleted = publicationView.type === "missingOrDeleted";
+        const isLocalPublication = !isOpds;
+        const canOpenLocalPublication = isLocalPublication &&
+            canOpenPublication(publicationView);
+        const showUnavailablePublicationState = isLocalPublication &&
+            !canOpenLocalPublication;
 
         let pubFormat = "EPUB";
         if (publicationView.isAudio) {
@@ -93,8 +99,6 @@ class PublicationCard extends React.Component<IProps> {
         const now = moment().locale([this.props.locale, "en"]);
         let hasEnded = false;
         const isLcp = publicationView.lcp?.rights ? true : false;
-
-        // const isPublicationMissingOrDeleted = publicationView.type === "missingOrDeleted";
 
         if (lcpRightsEndDate) {
             const momentEnd = moment(lcpRightsEndDate).locale([this.props.locale, "en"]);
@@ -142,13 +146,12 @@ class PublicationCard extends React.Component<IProps> {
                             <PublicationInfoOpdsWithRadixTrigger asChild>
                                 <button
                                    className={classNames(
-                                        stylesPublications.publication_main_container, 
-                                        { [stylesPublications.expired]: hasEnded || isPublicationMissingOrDeleted },
+                                        stylesPublications.publication_main_container,
                                     )}
                                     title={`${publicationViewMaybeOpds.documentTitle} - ${authors}`}
                                     tabIndex={0}
                                 >
-                                    <Cover publicationViewMaybeOpds={publicationViewMaybeOpds} hasEnded={hasEnded} />
+                                    <Cover publicationViewMaybeOpds={publicationViewMaybeOpds} />
                                     <div className={stylesPublications.publication_title_wrapper}>
                                         <p aria-hidden className={stylesPublications.publication_title}
                                             dir={pubTitleIsRTL ? "rtl" : undefined}>
@@ -163,30 +166,94 @@ class PublicationCard extends React.Component<IProps> {
                             <PublicationInfoOpdsWithRadixContent />
                         </PublicationInfoOpdsWithRadix>
                         :
-                        <a
-                            onClick={(e) => this.handleLocalBookshelfBookClick(e)}
-                            onKeyUp={
-                                (e) =>
-                                    (e.key === "Enter") && this.handleLocalBookshelfBookClick(e)
-                            }
-                            title={`${publicationViewMaybeOpds.documentTitle} - ${authors}`}
-                            className={classNames(
-                                        stylesPublications.publication_main_container, 
-                                        { [stylesPublications.expired]: hasEnded || isPublicationMissingOrDeleted },
-                                    )}
-                            tabIndex={0}
-                        >
-                            <Cover publicationViewMaybeOpds={publicationViewMaybeOpds} hasEnded={hasEnded} />
-                            <div className={stylesPublications.publication_title_wrapper}>
-                                <p aria-hidden className={stylesPublications.publication_title}
-                                    dir={pubTitleIsRTL ? "rtl" : undefined}>
-                                    {pubTitleStr}
-                                </p>
-                                <p aria-hidden className={stylesPublications.publication_authors}>
-                                    {this.truncateAuthors(authors)}
-                                </p>
-                            </div>
-                        </a>
+                        canOpenLocalPublication ?
+                            <a
+                                onClick={(e) => this.handleLocalBookshelfBookClick(e)}
+                                onKeyUp={
+                                    (e) =>
+                                        (e.key === "Enter") && this.handleLocalBookshelfBookClick(e)
+                                }
+                                title={`${publicationViewMaybeOpds.documentTitle} - ${authors}`}
+                                className={classNames(
+                                            stylesPublications.publication_main_container,
+                                            { [stylesPublications.expired]: hasEnded || showUnavailablePublicationState },
+                                        )}
+                                tabIndex={0}
+                            >
+                                <Cover
+                                    publicationViewMaybeOpds={publicationViewMaybeOpds}
+                                    isPublicationUnavailable={showUnavailablePublicationState}
+                                />
+                                <div className={stylesPublications.publication_title_wrapper}>
+                                    <p aria-hidden className={stylesPublications.publication_title}
+                                        dir={pubTitleIsRTL ? "rtl" : undefined}>
+                                        {pubTitleStr}
+                                    </p>
+                                    <p aria-hidden className={stylesPublications.publication_authors}>
+                                        {this.truncateAuthors(authors)}
+                                    </p>
+                                </div>
+                            </a>
+                        :
+                            <AlertDialog.Root>
+                                <AlertDialog.Trigger asChild>
+                                    <a
+                                        title={`${publicationViewMaybeOpds.documentTitle} - ${authors}`}
+                                        className={classNames(
+                                                    stylesPublications.publication_main_container,
+                                                    { [stylesPublications.expired]: hasEnded || showUnavailablePublicationState },
+                                                )}
+                                        role="button"
+                                        tabIndex={0}
+                                        onKeyDown={(e) => {
+                                            if (e.key === " " || e.altKey || e.ctrlKey) {
+                                                e.preventDefault();
+                                            }
+                                        }}
+                                        onKeyUp={(e) => {
+                                            if (e.key === " ") {
+                                                e.preventDefault();
+                                                e.currentTarget.click();
+                                            }
+                                        }}
+                                    >
+                                        <Cover
+                                            publicationViewMaybeOpds={publicationViewMaybeOpds}
+                                            isPublicationUnavailable={showUnavailablePublicationState}
+                                        />
+                                        <div className={stylesPublications.publication_title_wrapper}>
+                                            <p aria-hidden className={stylesPublications.publication_title}
+                                                dir={pubTitleIsRTL ? "rtl" : undefined}>
+                                                {pubTitleStr}
+                                            </p>
+                                            <p aria-hidden className={stylesPublications.publication_authors}>
+                                                {this.truncateAuthors(authors)}
+                                            </p>
+                                        </div>
+                                    </a>
+                                </AlertDialog.Trigger>
+                                <AlertDialog.Portal>
+                                    <AlertDialog.Overlay className={stylesAlertModals.AlertDialogOverlay}/>
+                                    <AlertDialog.Content className={stylesAlertModals.AlertDialogContent}>
+                                        <AlertDialog.Title className={stylesAlertModals.AlertDialogTitle}>
+                                            {__("catalog.missing")}
+                                        </AlertDialog.Title>
+                                        <AlertDialog.Description className={stylesAlertModals.AlertDialogDescription}>
+                                            {publicationView.documentTitle}
+                                            <br />
+                                            This publication cannot be opened because its stored files are unavailable.
+                                            Re-import it, or go to Settings and then Storage to add or change the external publication folder.
+                                        </AlertDialog.Description>
+                                        <div className={stylesAlertModals.AlertDialogButtonContainer}>
+                                            <AlertDialog.Cancel asChild>
+                                                <button className={stylesButtons.button_secondary_blue} type="button">
+                                                    {__("dialog.cancel")}
+                                                </button>
+                                            </AlertDialog.Cancel>
+                                        </div>
+                                    </AlertDialog.Content>
+                                </AlertDialog.Portal>
+                            </AlertDialog.Root>
                 }
                 <div className={stylesPublications.publication_infos_wrapper}>
                     <div className={stylesPublications.publication_infos}>
@@ -236,8 +303,7 @@ class PublicationCard extends React.Component<IProps> {
 
     private handleLocalBookshelfBookClick(e: React.SyntheticEvent) {
         e.preventDefault();
-        const { publicationViewMaybeOpds } = this.props;
-        this.props.openReader(publicationViewMaybeOpds as PublicationView);
+        this.props.openReader(this.props.publicationViewMaybeOpds as PublicationView);
     }
 
     /* function Truncate very long titles at 60 characters */

--- a/src/renderer/library/components/publication/menu/CatalogMenu.tsx
+++ b/src/renderer/library/components/publication/menu/CatalogMenu.tsx
@@ -7,7 +7,7 @@
 
 
 import * as React from "react";
-import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationView, canOpenPublication } from "readium-desktop/common/views/publication";
 import PublicationExportButton from "./PublicationExportButton";
 import DeletePublicationConfirm from "../../dialog/DeletePublicationConfirm";
 import { PublicationInfoLibWithRadix, PublicationInfoLibWithRadixContent, PublicationInfoLibWithRadixTrigger } from "../../dialog/publicationInfos/PublicationInfo";
@@ -63,7 +63,7 @@ const CatalogMenu: React.FC<{ publicationView: PublicationView }> = (props) => {
     const locale = useSelector((state: ILibraryRootState) => state.i18n.locale);
     const isShiftKeyPressed = useShiftKey();
 
-    const isPublicationMissingOrDeleted = props.publicationView.type === "missingOrDeleted";
+    const canOpen = canOpenPublication(props.publicationView);
 
     const noteExport = <button
         className="R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE"
@@ -105,7 +105,7 @@ const CatalogMenu: React.FC<{ publicationView: PublicationView }> = (props) => {
 
     return (
         <>
-        { isPublicationMissingOrDeleted ? 
+        { !canOpen ?
             <>
                 <DeletePublicationConfirm
                     trigger={(

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -70,7 +70,7 @@ import moment from "moment";
 import { availableLanguages, I18nFunction } from "readium-desktop/common/services/translator";
 import * as React from "react";
 import { connect } from "react-redux";
-import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationView, canOpenPublication } from "readium-desktop/common/views/publication";
 import {
     TranslatorProps, withTranslator,
 } from "readium-desktop/renderer/common/components/hoc/translator";
@@ -654,7 +654,7 @@ interface IColumnValue_Cover extends IColumnValue_BaseString {
 
     title: string,
     publicationViewIdentifier: string,
-    missingOrDeleted?: boolean;
+    isOpenable?: boolean;
 };
 interface ITableCellProps_Value_Cover {
     value: IColumnValue_Cover;
@@ -666,7 +666,7 @@ const CellCoverImage: React.FC<ITableCellProps_Column & ITableCellProps_GenericC
             onClick={() => props.openReader(props.value.publicationViewIdentifier)}
         >
             {
-                props.value.missingOrDeleted
+                props.value.isOpenable === false
                     ? <div aria-label={props.__("catalog.missing")} style={{ position: "absolute", width: "78px", height: "100px", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.7 }}>
                         <div aria-hidden style={{ height: "40px", width: "40px", borderRadius: "50%", background: "var(--color-error-text)", padding: "10px" }}>
                             <SVG aria-hidden svg={FileBroken} className={stylesPublications.publication_missing_icon} />
@@ -1690,7 +1690,7 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
                     label: publicationView.cover?.thumbnailUrl ?? publicationView.cover?.coverUrl ?? "",
                     publicationViewIdentifier: publicationView.identifier,
                     title: publicationView.documentTitle,
-                    missingOrDeleted: publicationView.type === "missingOrDeleted",
+                    isOpenable: canOpenPublication(publicationView),
                 },
                 colTitle: { // IColumnValue_Title
                     label: publicationView.documentTitle,


### PR DESCRIPTION
Fixes #3531

Changes:
- add isOpenable to PublicationView
- use findPublicationPath when building publication views
- stop trying to open local publications whose files are no longer available
- show unavailable state consistently in cards, covers, menus, and AllPublicationsList
- open an alert dialog that tells users to re-import or change the external storage path in Settings

Behaviors:
- publications remain listed even when their stored files are unavailable
- unavailable publications cannot open the reader
- UI now fails safely when external storage config no longer matches files on disk


Strings not localized: 
Ln244: This publication cannot be opened because its stored files are unavailable.
Ln245: Re-import it, or go to Settings and then Storage to add or change the external publication folder.