### PR TITLE
fix: refresh all publications after reading status or storage directory changes

### DIFF
--- a/src/common/api/interface/publicationApi.interface.ts
+++ b/src/common/api/interface/publicationApi.interface.ts
@@ -51,7 +51,7 @@ export interface IPublicationApi {
     exportPublication: (
         publicationView: PublicationView,
     ) => SagaGenerator<void>;
-    readingFinishedRefresh: (
+    findAllRefresh: (
     ) => SagaGenerator<void>;
 }
 
@@ -67,5 +67,5 @@ export interface IPublicationModuleApi {
     "publication/search": IPublicationApi["search"];
     "publication/searchEqTitle": IPublicationApi["searchEqTitle"];
     "publication/exportPublication": IPublicationApi["exportPublication"];
-    "publication/readingFinishedRefresh": IPublicationApi["readingFinishedRefresh"];
+    "publication/findAllRefresh": IPublicationApi["findAllRefresh"];
 }

--- a/src/main/redux/sagas/api/publication/index.ts
+++ b/src/main/redux/sagas/api/publication/index.ts
@@ -30,6 +30,6 @@ export const publicationApi: IPublicationApi = {
     searchEqTitle,
     updateTags,
 
-    // see readingFinished action : just used to refresh AllPublicationPage.tsx when set as finished
-    readingFinishedRefresh: function* (): SagaGenerator<void> { },
+    // used as a fake refresh signal for components subscribing around publication/findAll
+    findAllRefresh: function* (): SagaGenerator<void> { },
 };

--- a/src/renderer/library/components/publication/menu/CatalogMenu.tsx
+++ b/src/renderer/library/components/publication/menu/CatalogMenu.tsx
@@ -151,7 +151,7 @@ const CatalogMenu: React.FC<{ publicationView: PublicationView }> = (props) => {
                         dispatch(publicationActions.readingFinished.build(pubId));
 
                         // just to refresh allPublicationPage.tsx
-                        apiDispatch(dispatch)()("publication/readingFinishedRefresh")();
+                        apiDispatch(dispatch)()("publication/findAllRefresh")();
                     }}>
                     <SVG ariaHidden svg={DoubleCheckIcon} />
                     {__("publication.markAsRead")}

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -178,7 +178,7 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
             "publication/importFromLink",
             // "catalog/addEntry",
             "publication/updateTags",
-            "publication/readingFinishedRefresh",
+            "publication/findAllRefresh",
         ], () => {
             apiAction("publication/findAll")
                 .then((publicationViews) => {

--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -700,12 +700,13 @@ const StorageSettings: React.FC<{}> = () => {
     const [confirmEditOpen, setConfirmEditOpen] = React.useState(false);
     const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
 
-    const submitDirectory = React.useCallback((nextDirectory: string) => {
-        dispatch(catalogActions.setUserDirectory.build(nextDirectory));
+    const removeUserDirectory = React.useCallback(() => {
+        dispatch(catalogActions.setUserDirectory.build(""));
         setIsEditing(false);
     }, [dispatch]);
 
     const openFolderPicker = React.useCallback(() => {
+        // trigger the file picker on the last userDirectory if available
         dispatch(catalogActions.setUserDirectory.build(userDirectory));
         setIsEditing(false);
     }, [dispatch, userDirectory]);
@@ -746,7 +747,7 @@ const StorageSettings: React.FC<{}> = () => {
                 confirmLabel="Remove directory"
                 onConfirm={() => {
                     setConfirmDeleteOpen(false);
-                    submitDirectory("");
+                    removeUserDirectory();
                 }}
             />
 

--- a/src/renderer/library/redux/sagas/index.ts
+++ b/src/renderer/library/redux/sagas/index.ts
@@ -6,7 +6,7 @@
 // ==LICENSE-END==
 
 import debug_ from "debug";
-import { winCommonActions } from "readium-desktop/common/redux/actions";
+import { catalogActions, publicationActions, winCommonActions } from "readium-desktop/common/redux/actions";
 import * as publicationInfoSyncTags from "readium-desktop/renderer/common/redux/sagas/dialog/publicationInfosSyncTags";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { all, call, put, take } from "redux-saga/effects";
@@ -21,6 +21,9 @@ import * as opds from "./opds";
 import * as sameFileImport from "./sameFileImport";
 import * as winInit from "./win";
 import * as customization from "./customization";
+import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
+import { getStore } from "../../createStore";
+import { apiDispatch } from "readium-desktop/renderer/common/redux/api/api";
 
 // Logger
 const filename_ = "readium-desktop:renderer:library:saga:index";
@@ -51,7 +54,30 @@ export function* rootSaga() {
         load.saga(),
 
         customization.saga(),
+
+        takeSpawnEvery(
+            [
+                catalogActions.setUserDirectory.ID,
+                publicationActions.readingFinished.ID,
+            ],
+            () => {
+
+
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                console.log("REFRESHHHHH !!!!");
+                // just to refresh allPublicationPage.tsx
+                const dispatch = getStore().dispatch;
+                apiDispatch(dispatch)()("publication/findAllRefresh")();
+            },
+        ),
     ]);
-    
+
     yield put(winCommonActions.initSuccess.build());
 }

--- a/src/renderer/library/redux/sagas/index.ts
+++ b/src/renderer/library/redux/sagas/index.ts
@@ -61,17 +61,6 @@ export function* rootSaga() {
                 publicationActions.readingFinished.ID,
             ],
             () => {
-
-
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
-                console.log("REFRESHHHHH !!!!");
                 // just to refresh allPublicationPage.tsx
                 const dispatch = getStore().dispatch;
                 apiDispatch(dispatch)()("publication/findAllRefresh")();

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -3401,23 +3401,23 @@ const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
             // TODO: quick fix to refresh AllPublication component grid view
             // when a book is set as finished and then open / readed
             //
-            // dispatch a stub api endpoint "readingFinishedRefresh" just to trigger
+            // dispatch a stub api endpoint "findAllRefresh" just to trigger
             // AllPublication grid view, this is a legacy usage of the ReduxApi
             // originaly developped. Now we should use the react/redux data update mechanism
             // instead to call a fake IPC API
             //
-            // So call readingFinishedRefresh API at each call of setLocator function
+            // So call findAllRefresh API at each call of setLocator function
             // trigger too often the refresh, needed only at start or when the book is
             // check as set as finished in library/AllPublication compoment during the reading
             // setLocator is heavealy called with tts enabled or in an audiobook
-            // so we just called readingFinishedRefresh 2 times at start
+            // so we just called findAllRefresh 2 times at start
             // (first time is not handled by the library, second time is it)
             //
             // It's not a good practice to do that, but it works!
             //
             if (__READING_FINISHED_CALL_COUNTER < 2) {
                 __READING_FINISHED_CALL_COUNTER++;
-                apiDispatch(dispatch)()("publication/readingFinishedRefresh")();
+                apiDispatch(dispatch)()("publication/findAllRefresh")();
             }
         },
         setConfig: (config: Partial<ReaderConfig>) => {

--- a/src/renderer/reader/components/ReaderFooter.tsx
+++ b/src/renderer/reader/components/ReaderFooter.tsx
@@ -39,7 +39,6 @@ import { TDispatch } from "readium-desktop/typings/redux";
 import { publicationActions } from "readium-desktop/common/redux/actions";
 import { connect } from "react-redux";
 import { PublicationView } from "readium-desktop/common/views/publication";
-import { apiDispatch } from "readium-desktop/renderer/common/redux/api/api";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 
 const isFixedLayout = (link: Link, publication: R2Publication): boolean => {
@@ -731,12 +730,6 @@ const mapStateToProps = (state: IReaderRootState, _props: IBaseProps) => {
 
 const finishReadingDebounce = debounce((dispatch: TDispatch, pubId: string) => {
     dispatch(publicationActions.readingFinished.build(pubId));
-
-    // just to refresh allPublicationPage.tsx
-    apiDispatch(dispatch)()("publication/readingFinishedRefresh")();
-
-    // close the reader from the main process after the readingFinished action is received
-    // setTimeout(() => dispatch(readerActions.closeRequest.build()), 1000);
 }, 500);
 
 const mapDispatchToProps = (dispatch: TDispatch) => {


### PR DESCRIPTION
Fixes #3536 

`AllPublicationPage` now refreshes properly when publication availability changes.

Replaced the old readingFinishedRefresh stub API trigger with findAllRefresh

If a publication is still in the database but its files are no longer available:
- the page updates consistently
- the item is shown with the correct unavailable state
- the user is no longer allowed to open it as if it were valid


