### PR TITLE
Add an appendFileRotation helper utility function that rotates logs to a backup file when the log file exceeds 1 MB

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { appActions } from "./main/redux/actions";
 import { app } from "electron";
 import { _APP_NAME, _APP_VERSION, _PACK_NAME } from "readium-desktop/preprocessor-directives";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
+import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 
 // isURL() excludes the file: and data: URL protocols, as well as http://localhost but not http://127.0.0.1 or http(s)://IP:PORT more generally (note that ftp: is accepted)
 // import isURL from "validator/lib/isURL";
@@ -136,4 +137,4 @@ dump += `Date: ${(new Date()).toISOString()}\n`;
 
 dump += `Process: ${processInfoStr}\n`;
 dump += "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$44\n";
-fs.appendFileSync(appLogs, dump);
+appendFileSyncWithRotation(appLogs, dump);

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -26,6 +26,7 @@ import { PublicationView } from "readium-desktop/common/views/publication";
 import { isAcceptedExtension } from "readium-desktop/common/extension";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
 import { PersistRootState } from "../redux/states";
+import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 
 // Logger
 const debug = debug_("readium-desktop:cli:process");
@@ -295,7 +296,7 @@ const yargsInit = () =>
                     dump += "pathArgv not defined\n";
                 }
                 dump += "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$44\n";
-                fs.appendFileSync(appLogs, dump);
+                appendFileSyncWithRotation(appLogs, dump);
             },
         )
         .help()
@@ -372,7 +373,7 @@ export function commandLineMainEntry(
     }
 
     dump += "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$44\n";
-    fs.appendFileSync(appLogs, dump);
+    appendFileSyncWithRotation(appLogs, dump);
 }
 
 // arrow function to filter declared option in yargs

--- a/src/main/cli/lock.ts
+++ b/src/main/cli/lock.ts
@@ -17,6 +17,7 @@ import { getOpenFileFromCliChannel } from "../event";
 import { isOpenUrl, setOpenUrl } from "./url";
 import { _APP_NAME, _APP_VERSION, _PACK_NAME } from "readium-desktop/preprocessor-directives";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
+import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 
 // Logger
 const filename = "readium-desktop:main:lock";
@@ -149,7 +150,7 @@ export function lockInstance() {
             commandLineMainEntry(argvFormated);
 
             dump += "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$44\n";
-            fs.appendFileSync(appLogs, dump);
+            appendFileSyncWithRotation(appLogs, dump);
         });
     }
     return gotTheLock;

--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -38,6 +38,7 @@ import * as fs from "fs";import { fileProvisionning } from "./customization";
 import { customizationWellKnownFolder } from "readium-desktop/main/customization/provisioning";
 import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/constant";
 import { ToastType } from "readium-desktop/common/models/toast";
+import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 
 // Logger
 const debug = debug_("readium-desktop:main:saga:event");
@@ -277,7 +278,7 @@ export function saga() {
                     debug(e);
                     yield* putTyped(toastActions.openRequest.build(ToastType.Error, `OPDS Deep link ${e}`));
                 } finally {
-                    try { fs.appendFileSync(appLogs, dump); } catch { }
+                    try { appendFileSyncWithRotation(appLogs, dump); } catch { }
                 }
             }
 

--- a/src/main/redux/sagas/publication/checker.ts
+++ b/src/main/redux/sagas/publication/checker.ts
@@ -16,6 +16,7 @@ import { IPublicationCheckerState } from "readium-desktop/common/redux/states/pu
 import { publicationActions } from "readium-desktop/common/redux/actions";
 import { winActions } from "../../actions";
 import { tryCatch } from "readium-desktop/utils/tryCatch";
+import { appendFileWithRotation } from "readium-desktop/utils/log";
 
 // TODO: use app.getPath("logs"); instead
 const folderPath = path.join(
@@ -147,7 +148,7 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
         thoriumPublicationPath: yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath()),
     }, null, 4)}\n`;
     if (dumpLogs) {
-        yield* callTyped(() => fs.promises.appendFile(appLogs, dump));
+        yield* callTyped(() => appendFileWithRotation(appLogs, dump));
 
         yield* takeTyped(winActions.library.openSucess.ID);
         yield* delayTyped(1000); // 1s

--- a/src/main/redux/store/memory.ts
+++ b/src/main/redux/store/memory.ts
@@ -43,6 +43,7 @@ import crypto from "node:crypto";
 import { JsonStringifySortedKeys } from "readium-desktop/common/utils/json";
 import { _APP_VERSION } from "readium-desktop/preprocessor-directives";
 import * as ramda from "ramda";
+import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 
 // import { composeWithDevTools } from "remote-redux-devtools";
 const REDUX_REMOTE_DEVTOOLS_PORT = 7770;
@@ -53,7 +54,7 @@ const debugStdout = debug_(_dbgn);
 const debug = (...a: Parameters<debug_.Debugger>) => {
     debugStdout(...a);
     tryCatchSync(() =>
-        fs.appendFileSync(memoryLoggerFilename, a.map((v) => `${+new Date()} ${JSON.stringify(v)}`).join("\n") + "\n"),
+        appendFileSyncWithRotation(memoryLoggerFilename, a.map((v) => `${+new Date()} ${JSON.stringify(v)}`).join("\n") + "\n"),
         "",
     );
 };

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,73 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import * as fs from "fs";
+
+// const DEFAULT_MAX_LOG_BYTES = 1024;
+const DEFAULT_MAX_LOG_BYTES = 1024 * 1024;
+
+const rotateLogFileSync = (filePath: string, backupFilePath: string) => {
+    try {
+        fs.rmSync(backupFilePath, { force: true });
+    } catch {
+        // ignore
+    }
+    try {
+        fs.renameSync(filePath, backupFilePath);
+    } catch {
+        // ignore
+    }
+};
+
+const rotateLogFile = async (filePath: string, backupFilePath: string) => {
+    try {
+        await fs.promises.rm(backupFilePath, { force: true });
+    } catch {
+        // ignore
+    }
+    try {
+        await fs.promises.rename(filePath, backupFilePath);
+    } catch {
+        // ignore
+    }
+};
+
+export const appendFileSyncWithRotation = (
+    filePath: string,
+    data: string,
+    maxBytes = DEFAULT_MAX_LOG_BYTES,
+    backupFilePath = `${filePath}.1`,
+) => {
+    try {
+        const stats = fs.statSync(filePath);
+        const dataSize = Buffer.byteLength(data);
+        if (stats.size > 0 && stats.size + dataSize > maxBytes) {
+            rotateLogFileSync(filePath, backupFilePath);
+        }
+    } catch {
+        // ignore
+    }
+    fs.appendFileSync(filePath, data);
+};
+
+export const appendFileWithRotation = async (
+    filePath: string,
+    data: string,
+    maxBytes = DEFAULT_MAX_LOG_BYTES,
+    backupFilePath = `${filePath}.1`,
+) => {
+    try {
+        const stats = await fs.promises.stat(filePath);
+        const dataSize = Buffer.byteLength(data);
+        if (stats.size > 0 && stats.size + dataSize > maxBytes) {
+            await rotateLogFile(filePath, backupFilePath);
+        }
+    } catch {
+        // ignore
+    }
+    await fs.promises.appendFile(filePath, data);
+};


### PR DESCRIPTION
Fixes #3429 

- Add a helper that rotates the logs to a backup file when the log file exceeds 1 MB