### PR TITLE
IPV4 250ms timeout when IPV6 addresses provided from DNS but not supported from the server

### DIFF
--- a/src/main/network/http.ts
+++ b/src/main/network/http.ts
@@ -50,6 +50,7 @@ const filename_ = "readium-desktop:main/http";
 const debug = debug_(filename_);
 
 const DEFAULT_HTTP_TIMEOUT = 30000;
+const DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT = 5000;
 
 let authenticationToken: Record<string, IOpdsAuthenticationToken> = {};
 
@@ -247,15 +248,27 @@ async function httpFetchRawResponse(
     // https://github.com/node-fetch/node-fetch#custom-agent
     // httpAgent doesn't works // err: Protocol "http:" not supported. Expected "https:
     // https://github.com/edrlab/thorium-reader/issues/1323#issuecomment-911772951
-    const httpsAgent = new https.Agent({
-        timeout: options.timeout || DEFAULT_HTTP_TIMEOUT,
+    const requestTimeout = options.timeout || DEFAULT_HTTP_TIMEOUT;
+    const autoSelectFamilyAttemptTimeout = Math.min(
+        requestTimeout,
+        DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT,
+    );
+
+    const httpAgentOptions: http.AgentOptions = {
+        timeout: requestTimeout,
+        autoSelectFamilyAttemptTimeout,
+    };
+
+    const httpsAgentOptions: https.AgentOptions = {
+        ...httpAgentOptions,
         rejectUnauthorized: !__TH__IS_DEV__,
-    });
-    const httpAgent = new http.Agent({
-        timeout: options.timeout || DEFAULT_HTTP_TIMEOUT,
-    });
+    };
+
+    const httpsAgent = new https.Agent(httpsAgentOptions);
+    const httpAgent = new http.Agent(httpAgentOptions);
 
     const proxyAgent = new ProxyAgent({
+        ...httpsAgentOptions,
         httpAgent: httpAgent,
         httpsAgent: httpsAgent,
         // getProxyForUrl: (url) => {
@@ -284,7 +297,7 @@ async function httpFetchRawResponse(
     //     });
     //     options.agent = httpsAgent;
     // }
-    options.timeout = options.timeout || DEFAULT_HTTP_TIMEOUT;
+    options.timeout = requestTimeout;
 
     options.maxRedirect = MAX_FOLLOW_REDIRECT;
 


### PR DESCRIPTION
I asked ChatGPT about issue #3444 (and it seems the author of the issue does the same thing, lol).

It seems justified, and the fixes look valid.

Here’s ChatGPT’s explanation:

`autoSelectFamilyAttemptTimeout` is a Node TCP connection option used when Node’s address-family auto-selection is enabled.

In plain English: when a hostname resolves to both IPv4 and IPv6 addresses, Node tries them in sequence so it can quickly pick the one that works. That behavior is often called Happy Eyeballs. `autoSelectFamilyAttemptTimeout` is the per-address wait time, in milliseconds, before Node gives up on the current connection attempt and tries the next resolved address.

For this issue, the failure path was roughly:

```text
content-lcp.editions-ellipses.fr
  -> IPv4 address exists and works, but connection latency is about 270ms
  -> IPv6 address exists in DNS, but the server does not actually accept IPv6

Node tries IPv4
  -> default attempt timeout is 250ms in the affected runtime
  -> IPv4 is aborted just before it would connect

Node tries IPv6
  -> IPv6 fails

Result
  -> AggregateError / ETIMEDOUT
  -> Thorium reports the LCPL publication download failure
```

Node docs for the option: [socket.connect `autoSelectFamilyAttemptTimeout`](https://nodejs.org/api/net.html).


The question is why this is not a de facto default configuration for IPv4/IPv6, especially since IPv6 is not widely used. But I have the feeling the DNS may be misconfigured—why does it return an IPv6 address when the server does not support it?