### PR TITLE
Lost publications recovery process

### DIFF
--- a/src/common/api/interface/publicationApi.interface.ts
+++ b/src/common/api/interface/publicationApi.interface.ts
@@ -9,6 +9,12 @@ import { IOpdsLinkView, IOpdsPublicationView } from "readium-desktop/common/view
 import { PublicationView } from "readium-desktop/common/views/publication";
 import { SagaGenerator } from "typed-redux-saga";
 
+export interface IRecoverablePublication {
+    identifier: string;
+    title: string;
+    filePath: string;
+}
+
 export interface IPublicationApi {
     // get: (...a: [string]) => Promise<PublicationView> | void;
     get: (
@@ -53,6 +59,11 @@ export interface IPublicationApi {
     ) => SagaGenerator<void>;
     findAllRefresh: (
     ) => SagaGenerator<void>;
+    findAllRecoverable: (
+    ) => SagaGenerator<IRecoverablePublication[]>;
+    recover: (
+        identifiers?: string[],
+    ) => SagaGenerator<PublicationView[]>;
 }
 
 export interface IPublicationModuleApi {
@@ -68,4 +79,6 @@ export interface IPublicationModuleApi {
     "publication/searchEqTitle": IPublicationApi["searchEqTitle"];
     "publication/exportPublication": IPublicationApi["exportPublication"];
     "publication/findAllRefresh": IPublicationApi["findAllRefresh"];
+    "publication/findAllRecoverable": IPublicationApi["findAllRecoverable"];
+    "publication/recover": IPublicationApi["recover"];
 }

--- a/src/main/redux/sagas/api/publication/import/importFromFs.ts
+++ b/src/main/redux/sagas/api/publication/import/importFromFs.ts
@@ -8,6 +8,7 @@
 import debug_ from "debug";
 import * as path from "path";
 import { acceptedExtensionObject, isAcceptedExtension } from "readium-desktop/common/extension";
+import { computeFileHash, extractCrc32OnZip } from "readium-desktop/main/tools/crc";
 import { PublicationDocument } from "readium-desktop/main/db/document/publication";
 import { diMainGet } from "readium-desktop/main/di";
 import { pdfPackager } from "readium-desktop/main/pdf/packager";
@@ -58,8 +59,13 @@ export function* importFromFsService(
         }));
     }
 
-    const publicationStorage = diMainGet("publication-storage");
-    const hash = yield* callTyped(() => publicationStorage.getStoredPublicationHash(filePath));
+    const hash =
+        isLCPLicense ?
+            undefined :
+            (isPDF ?
+                yield* callTyped(() => computeFileHash(filePath)) :
+                ((isOPF || isNccHTML) ? undefined : yield* callTyped(() => extractCrc32OnZip(filePath)))
+            );
 
     const publicationRepository = diMainGet("publication-repository");
 

--- a/src/main/redux/sagas/api/publication/import/importFromFs.ts
+++ b/src/main/redux/sagas/api/publication/import/importFromFs.ts
@@ -8,7 +8,6 @@
 import debug_ from "debug";
 import * as path from "path";
 import { acceptedExtensionObject, isAcceptedExtension } from "readium-desktop/common/extension";
-import { computeFileHash, extractCrc32OnZip } from "readium-desktop/main/tools/crc";
 import { PublicationDocument } from "readium-desktop/main/db/document/publication";
 import { diMainGet } from "readium-desktop/main/di";
 import { pdfPackager } from "readium-desktop/main/pdf/packager";
@@ -31,6 +30,7 @@ export function* importFromFsService(
     filePath: string,
     willBeImmediatelyFollowedByOpen: boolean,
     lcpHashedPassphrase?: string,
+    preservedIdentifier?: string,
 ): SagaGenerator<[publicationDoc: PublicationDocument, alreadyImported: boolean]> {
 
     debug("importFromFsService", filePath);
@@ -58,15 +58,17 @@ export function* importFromFsService(
         }));
     }
 
-    const hash =
-        isLCPLicense ?
-            undefined :
-            (isPDF ?
-                yield* callTyped(() => computeFileHash(filePath)) :
-                ((isOPF || isNccHTML) ? undefined : yield* callTyped(() => extractCrc32OnZip(filePath)))
-            );
+    const publicationStorage = diMainGet("publication-storage");
+    const hash = yield* callTyped(() => publicationStorage.getStoredPublicationHash(filePath));
 
     const publicationRepository = diMainGet("publication-repository");
+
+    const publicationDocumentWithPreservedIdentifier = preservedIdentifier
+        ? yield* callTyped(() => publicationRepository.findByPublicationIdentifier(preservedIdentifier))
+        : undefined;
+    if (publicationDocumentWithPreservedIdentifier) {
+        return [publicationDocumentWithPreservedIdentifier, true];
+    }
 
     const publicationDocumentInRepository = hash
         ? yield* callTyped(() => publicationRepository.findByHashId(hash))
@@ -99,7 +101,7 @@ export function* importFromFsService(
         }
 
         publicationDocument = yield* callTyped(
-            () => importPublicationFromFS(publicationFilePath, willBeImmediatelyFollowedByOpen, hash, lcpHashedPassphrase));
+            () => importPublicationFromFS(publicationFilePath, willBeImmediatelyFollowedByOpen, hash, lcpHashedPassphrase, preservedIdentifier));
 
         if (cleanFct) {
             yield call(() => cleanFct());

--- a/src/main/redux/sagas/api/publication/import/importPublicationFromFs.ts
+++ b/src/main/redux/sagas/api/publication/import/importPublicationFromFs.ts
@@ -49,6 +49,7 @@ export async function importPublicationFromFS(
     willBeImmediatelyFollowedByOpen: boolean,
     hash?: string,
     lcpHashedPassphrase?: string,
+    preservedIdentifier?: string,
 ): Promise<PublicationDocument> {
 
     debug("importPublicationFromFS", filePath);
@@ -203,7 +204,7 @@ export async function importPublicationFromFS(
     const locale = store.getState().i18n.locale;
 
     const pubDocument: PublicationDocumentWithoutTimestampable = {
-        identifier: uuidv4(),
+        identifier: preservedIdentifier || uuidv4(),
         // resources: {
         //     // Legacy Base64 data blobs
 
@@ -238,9 +239,11 @@ export async function importPublicationFromFS(
 
     // Store publication on filesystem
     debug("[START] Store publication on filesystem", filePath);
-    const files = await publicationStorage.storePublication(
-        pubDocument.identifier, filePath,
-    );
+    const files = preservedIdentifier ?
+        await publicationStorage.getStoredPublicationFiles(pubDocument.identifier) :
+        await publicationStorage.storePublication(
+            pubDocument.identifier, filePath,
+        );
     debug("[END] Store publication on filesystem - END", filePath);
 
     // Add extracted files to document

--- a/src/main/redux/sagas/api/publication/index.ts
+++ b/src/main/redux/sagas/api/publication/index.ts
@@ -13,6 +13,7 @@ import { findAll } from "./findAll";
 import { findByTag } from "./findByTag";
 import { getPublication } from "./getPublication";
 import { importFromFs, importFromLink, importFromString } from "./import";
+import { findAllRecoverable, recover } from "./recovery";
 import { search, searchEqTitle } from "./search";
 import { updateTags } from "./updateTags";
 import { SagaGenerator } from "typed-redux-saga";
@@ -32,4 +33,6 @@ export const publicationApi: IPublicationApi = {
 
     // used as a fake refresh signal for components subscribing around publication/findAll
     findAllRefresh: function* (): SagaGenerator<void> { },
+    findAllRecoverable,
+    recover,
 };

--- a/src/main/redux/sagas/api/publication/recovery.ts
+++ b/src/main/redux/sagas/api/publication/recovery.ts
@@ -1,0 +1,129 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { IRecoverablePublication } from "readium-desktop/common/api/interface/publicationApi.interface";
+import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
+import { ToastType } from "readium-desktop/common/models/toast";
+import { toastActions } from "readium-desktop/common/redux/actions";
+import { availableLanguages } from "readium-desktop/common/services/translator";
+import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationViewConverter } from "readium-desktop/main/converter/publication";
+import { PublicationDocument } from "readium-desktop/main/db/document/publication";
+import { diMainGet } from "readium-desktop/main/di";
+import { IPublicationStorageRecoverablePublication } from "readium-desktop/main/storage/publication-storage";
+
+import { PublicationParsePromise } from "@r2-shared-js/parser/publication-parser";
+import debug_ from "debug";
+import { SagaGenerator } from "typed-redux-saga";
+import { call as callTyped, put as putTyped } from "typed-redux-saga/macro";
+
+import { importFromFsService } from "./import/importFromFs";
+
+const debug = debug_("readium-desktop:main#saga/api/publication/recovery");
+
+const convertDoc = async (doc: PublicationDocument, publicationViewConverter: PublicationViewConverter) => {
+    try {
+        return await publicationViewConverter.convertDocumentToView(doc);
+    } catch (e) {
+        debug("Error to convert recovered document to publicationView", e);
+        return publicationViewConverter.convertUnavailableDocumentToMinimalPublicationView(doc);
+    }
+};
+
+const getRecoverablePublicationTitle = async (
+    publication: IPublicationStorageRecoverablePublication,
+    locale: keyof typeof availableLanguages,
+): Promise<string | undefined> => {
+    let r2Publication;
+    try {
+        r2Publication = await PublicationParsePromise(publication.filePath);
+        return convertMultiLangStringToString(r2Publication.Metadata?.Title, locale) || publication.identifier;
+    } catch (e) {
+        debug("Recoverable publication parse failed", publication.identifier, publication.filePath, e);
+        return undefined;
+    } finally {
+        try {
+            r2Publication?.freeDestroy();
+        } catch (e) {
+            debug(e);
+        }
+    }
+};
+
+const findRecoverablePublicationData = async (): Promise<IRecoverablePublication[]> => {
+    const publicationRepository = diMainGet("publication-repository");
+    const publicationStorage = diMainGet("publication-storage");
+    const store = diMainGet("store");
+    const locale = store.getState().i18n.locale as keyof typeof availableLanguages;
+
+    const publicationDocuments = publicationRepository.findAll();
+    const recoverablePublications = await publicationStorage.listRecoverablePublications(publicationDocuments);
+    const publications: IRecoverablePublication[] = [];
+
+    for (const recoverablePublication of recoverablePublications) {
+        const title = await getRecoverablePublicationTitle(recoverablePublication, locale);
+        if (!title) {
+            continue;
+        }
+        publications.push({
+            identifier: recoverablePublication.identifier,
+            filePath: recoverablePublication.filePath,
+            title,
+        });
+    }
+
+    return publications;
+};
+
+export function* findAllRecoverable(): SagaGenerator<IRecoverablePublication[]> {
+    return yield* callTyped(findRecoverablePublicationData);
+}
+
+export function* recover(identifiers?: string[]): SagaGenerator<PublicationView[]> {
+    const recoverablePublications = yield* callTyped(findRecoverablePublicationData);
+    const identifierSet = identifiers?.length ? new Set(identifiers) : undefined;
+    const publicationsToRecover = identifierSet ?
+        recoverablePublications.filter((publication) => identifierSet.has(publication.identifier)) :
+        recoverablePublications;
+
+    const publicationViewConverter = diMainGet("publication-view-converter");
+    const publicationViews: PublicationView[] = [];
+
+    for (const publication of publicationsToRecover) {
+        try {
+            const [publicationDocument, alreadyImported] = yield* callTyped(
+                importFromFsService,
+                publication.filePath,
+                false,
+                undefined,
+                publication.identifier,
+            );
+            if (alreadyImported) {
+                debug("Publication recovery skipped because a database record already exists", publication.identifier, publication.filePath);
+                continue;
+            }
+            const publicationView = yield* callTyped(() => convertDoc(publicationDocument, publicationViewConverter));
+            publicationViews.push(publicationView);
+        } catch (e) {
+            debug("Publication recovery failed", publication.identifier, publication.filePath, e);
+        }
+    }
+
+    if (publicationViews.length) {
+        yield* putTyped(toastActions.openRequest.build(
+            ToastType.Success,
+            `${publicationViews.length} publication${publicationViews.length > 1 ? "s" : ""} recovered.`,
+        ));
+    } else if (publicationsToRecover.length) {
+        yield* putTyped(toastActions.openRequest.build(
+            ToastType.Error,
+            "Publication recovery failed.",
+        ));
+    }
+
+    return publicationViews;
+}

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -280,11 +280,11 @@ export function* getCatalog(): SagaGenerator<ILibraryRootState["publication"]> {
 
 function* getCatalogAndDispatchIt() {
 
-    const {catalog, tag} = yield* callTyped(getCatalog);
+    const { catalog, tag, directory: { userDirectory } } = yield* callTyped(getCatalog);
 
     yield* putTyped(catalogActions.setCatalog.build(catalog));
     yield* putTyped(catalogActions.setTagView.build(tag));
-    yield* putTyped(catalogActions.setUserDirectory.build(diMainGet("publication-directory").userDirectory || ""));
+    yield* putTyped(catalogActions.setUserDirectory.build(userDirectory || ""));
 }
 
 function* updateResumePosition() {

--- a/src/main/redux/sagas/catalog.ts
+++ b/src/main/redux/sagas/catalog.ts
@@ -265,6 +265,7 @@ export function* getCatalog(): SagaGenerator<ILibraryRootState["publication"]> {
     ];
     const publicationRepository = diMainGet("publication-repository");
     const publicationDirectory = diMainGet("publication-directory");
+    yield* callTyped(() => publicationDirectory.ready());
     const allTags = yield* callTyped(() => publicationRepository.getAllTags());
 
     return {

--- a/src/main/redux/sagas/index.ts
+++ b/src/main/redux/sagas/index.ts
@@ -11,7 +11,7 @@ import { keyboardActions, versionUpdateActions } from "readium-desktop/common/re
 import { keyboardShortcuts } from "readium-desktop/main/keyboard";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
 import { all, call, put, take } from "redux-saga/effects";
-import { select as selectTyped, call as callTyped, spawn as spawnTyped} from "typed-redux-saga/macro";
+import { select as selectTyped, call as callTyped, spawn as spawnTyped, delay as delayTyped} from "typed-redux-saga/macro";
 import { RootState } from "../states";
 import { _APP_VERSION, _APP_NAME, _PACK_NAME } from "readium-desktop/preprocessor-directives";
 // import { THttpGetCallback } from "readium-desktop/common/utils/http";
@@ -83,6 +83,7 @@ export function* rootSaga() {
     // Integrity checker for publications between FS and DB
     yield* spawnTyped(function* () {
         try {
+            yield* delayTyped(1000 * 10); // wait 10 seconds before starting the checker
             yield* callTyped(publicationIntegrityChecker);
         } catch (e) {
             error(filename_, e);

--- a/src/main/redux/sagas/publication/checker.ts
+++ b/src/main/redux/sagas/publication/checker.ts
@@ -15,7 +15,6 @@ import { USER_DATA_FOLDER, FORCE_PROD_DB_IN_DEV } from "readium-desktop/common/c
 import { IPublicationCheckerState } from "readium-desktop/common/redux/states/publicationsChecker";
 import { publicationActions } from "readium-desktop/common/redux/actions";
 import { winActions } from "../../actions";
-import { tryCatch } from "readium-desktop/utils/tryCatch";
 import { appendFileWithRotation } from "readium-desktop/utils/log";
 
 // TODO: use app.getPath("logs"); instead
@@ -65,33 +64,6 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
     const publicationIdentifierApprovedMatchedDiskDataBaseArray = publicationIdentifierDataBase.filter((id) => approvedPublicationIdentifierDisk.includes(id));
     const recoverablePublicationIdentifierDisk = approvedPublicationIdentifierDisk.filter((id) => !publicationIdentifierDataBase.includes(id));
 
-    // debug("==> Publication Id rejected in Disk:");
-    // for (const id of rejectedPublicationIdentifierDisk) {
-    //     debug(`pubId: ${id}`);
-    //     try {
-    //         const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
-    //         debug(`filePath: ${filePath}`);
-    //         debug("file in directory:");
-    //         const files = yield* callTyped(() => fs.promises.readdir(filePath));
-    //         for (const file of files) {
-    //             const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
-    //             debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
-    //         }
-
-    //     } catch {
-    //         debug(`pubId: ${id} throw an error when reading the directory !`);
-    //     }
-
-    //     try {
-    //         const publicationDocument = yield* callTyped(() => diMainGet("publication-repository").findByPublicationIdentifier(id));
-    //         debug(`publicationDocument: ${JSON.stringify(publicationDocument, null, 4)}`);
-    //     } catch {
-    //         debug("Not found on DataBase");
-    //     }
-    //     dumpLogs = true;
-    // }
-    // debug("--------");
-
     debug("==> publication storage integrity issues:");
     for (const issue of issues) {
         debug(`type: ${issue.type}`);
@@ -124,26 +96,6 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
         dumpLogs = true;
     }
     debug("--------");
-
-    // debug("==> publication identifier found on disk but NOT found on database:");
-    // for (const id of publicationIdentifierNotFoundOnDataBaseButFoundOnDisk) {
-    //     debug(`pubId: ${id}`);
-    //     try {
-    //         const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
-    //         debug(`filePath: ${filePath}`);
-    //         debug("file in directory:");
-    //         const files = yield* callTyped(() => fs.promises.readdir(filePath));
-    //         for (const file of files) {
-    //             const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
-    //             debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
-    //         }
-
-    //     } catch {
-    //         debug(`pubId: ${id} throw an error when reading the directory !`);
-    //     }
-    //     dumpLogs = true;
-    // }
-    // debug("--------");
 
     debug(`${publicationIdentifierDisk.length} UUID directories were found on disk, of which ${approvedPublicationIdentifierDisk.length} contain an approved publication archive book.`);
     debug(`${publicationIdentifierDataBase.length} publication(s) found in database`);

--- a/src/main/redux/sagas/publication/checker.ts
+++ b/src/main/redux/sagas/publication/checker.ts
@@ -51,7 +51,11 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
     const publicationDocuments = yield* callTyped(() => diMainGet("publication-repository").findAll());
     const publicationIdentifierDataBase = publicationDocuments.map(({ identifier }) => identifier);
  
-    const { good: approvedPublicationIdentifierDisk, bad: rejectedPublicationIdentifierDisk } = yield* callTyped(() => diMainGet("publication-storage").checkPublicationsIntegrity());
+    const {
+        good: approvedPublicationIdentifierDisk,
+        bad: rejectedPublicationIdentifierDisk,
+        issues,
+    } = yield* callTyped(() => diMainGet("publication-storage").checkPublicationsIntegrity(publicationDocuments));
     const publicationIdentifierDisk = [...approvedPublicationIdentifierDisk, ...rejectedPublicationIdentifierDisk];
     
     yield* delayTyped(1);
@@ -59,30 +63,55 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
     const publicationIdentifierNotFoundOnDataBaseButFoundOnDisk: string[] = publicationIdentifierDisk.filter((id) => !publicationIdentifierDataBase.includes(id));
     const publicationIdentifierMatchedDiskDataBaseArray = publicationIdentifierDataBase.filter((id) => publicationIdentifierDisk.includes(id));
     const publicationIdentifierApprovedMatchedDiskDataBaseArray = publicationIdentifierDataBase.filter((id) => approvedPublicationIdentifierDisk.includes(id));
+    const recoverablePublicationIdentifierDisk = approvedPublicationIdentifierDisk.filter((id) => !publicationIdentifierDataBase.includes(id));
 
-    debug("==> Publication Id rejected in Disk:");
-    for (const id of rejectedPublicationIdentifierDisk) {
-        debug(`pubId: ${id}`);
-        try {
-            const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
-            debug(`filePath: ${filePath}`);
-            debug("file in directory:");
-            const files = yield* callTyped(() => fs.promises.readdir(filePath));
-            for (const file of files) {
-                const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
-                debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
-            }
+    // debug("==> Publication Id rejected in Disk:");
+    // for (const id of rejectedPublicationIdentifierDisk) {
+    //     debug(`pubId: ${id}`);
+    //     try {
+    //         const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
+    //         debug(`filePath: ${filePath}`);
+    //         debug("file in directory:");
+    //         const files = yield* callTyped(() => fs.promises.readdir(filePath));
+    //         for (const file of files) {
+    //             const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
+    //             debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
+    //         }
 
-        } catch {
-            debug(`pubId: ${id} throw an error when reading the directory !`);
+    //     } catch {
+    //         debug(`pubId: ${id} throw an error when reading the directory !`);
+    //     }
+
+    //     try {
+    //         const publicationDocument = yield* callTyped(() => diMainGet("publication-repository").findByPublicationIdentifier(id));
+    //         debug(`publicationDocument: ${JSON.stringify(publicationDocument, null, 4)}`);
+    //     } catch {
+    //         debug("Not found on DataBase");
+    //     }
+    //     dumpLogs = true;
+    // }
+    // debug("--------");
+
+    debug("==> publication storage integrity issues:");
+    for (const issue of issues) {
+        debug(`type: ${issue.type}`);
+        debug(`pubId: ${issue.identifier}`);
+        if (issue.directoryPath?.length) {
+            debug(`directoryPath: ${issue.directoryPath.join(" | ")}`);
         }
-
-        try {
-            const publicationDocument = yield* callTyped(() => diMainGet("publication-repository").findByPublicationIdentifier(id));
-            debug(`publicationDocument: ${JSON.stringify(publicationDocument, null, 4)}`);
-        } catch {
-            debug("Not found on DataBase");
+        if (issue.filePath) {
+            debug(`filePath: ${issue.filePath}`);
         }
+        if (issue.fileUrl) {
+            debug(`fileUrl: ${issue.fileUrl}`);
+        }
+        if (issue.hash) {
+            debug(`hash: ${issue.hash}`);
+        }
+        if (issue.matchingIdentifier) {
+            debug(`matchingIdentifier: ${issue.matchingIdentifier.join(" | ")}`);
+        }
+        debug(`message: ${issue.message}`);
         dumpLogs = true;
     }
     debug("--------");
@@ -96,30 +125,31 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
     }
     debug("--------");
 
-    debug("==> publication identifier found on disk but NOT found on database:");
-    for (const id of publicationIdentifierNotFoundOnDataBaseButFoundOnDisk) {
-        debug(`pubId: ${id}`);
-        try {
-            const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
-            debug(`filePath: ${filePath}`);
-            debug("file in directory:");
-            const files = yield* callTyped(() => fs.promises.readdir(filePath));
-            for (const file of files) {
-                const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
-                debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
-            }
+    // debug("==> publication identifier found on disk but NOT found on database:");
+    // for (const id of publicationIdentifierNotFoundOnDataBaseButFoundOnDisk) {
+    //     debug(`pubId: ${id}`);
+    //     try {
+    //         const filePath = yield* callTyped(() => diMainGet("publication-storage").findPublicationPath(id));
+    //         debug(`filePath: ${filePath}`);
+    //         debug("file in directory:");
+    //         const files = yield* callTyped(() => fs.promises.readdir(filePath));
+    //         for (const file of files) {
+    //             const stat = yield* callTyped(() => tryCatch(() => fs.promises.stat(path.join(filePath, file)), ""));
+    //             debug(`\t${file} size=${stat?.size} isFile=${stat?.isFile()}`);
+    //         }
 
-        } catch {
-            debug(`pubId: ${id} throw an error when reading the directory !`);
-        }
-        dumpLogs = true;
-    }
-    debug("--------");
+    //     } catch {
+    //         debug(`pubId: ${id} throw an error when reading the directory !`);
+    //     }
+    //     dumpLogs = true;
+    // }
+    // debug("--------");
 
     debug(`${publicationIdentifierDisk.length} UUID directories were found on disk, of which ${approvedPublicationIdentifierDisk.length} contain an approved publication archive book.`);
     debug(`${publicationIdentifierDataBase.length} publication(s) found in database`);
     debug(`${publicationIdentifierNotFoundOnDiskButFoundOnDataBase.length} publication(s) found in database but not found on the disk`);
     debug(`${publicationIdentifierNotFoundOnDataBaseButFoundOnDisk.length} publication(s) found in disk but not found on the database`);
+    debug(`${recoverablePublicationIdentifierDisk.length} publication(s) found in disk, approved by the integrity checker, and recoverable because they are missing from the database`);
     debug(`${publicationIdentifierMatchedDiskDataBaseArray.length} publication(s) matched between the database and the disk`);
     debug(`${publicationIdentifierApprovedMatchedDiskDataBaseArray.length} publication(s) approved and matched between the database and the disk (this is the number of publications you can see in Thorium All Books...)`);
     if (publicationIdentifierNotFoundOnDiskButFoundOnDataBase.length || publicationIdentifierNotFoundOnDataBaseButFoundOnDisk.length) {
@@ -127,14 +157,6 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
     }
     yield* delayTyped(1);
 
-    const publicationCheckerState: IPublicationCheckerState = {
-        publicationIdentifierDataBase,
-        // publicationIdentifierDisk = [...approvedPublicationIdentifierDisk, ...rejectedPublicationIdentifierDisk];
-        approvedPublicationIdentifierDisk, rejectedPublicationIdentifierDisk,
-        dump,
-    };
-
-    yield* delayTyped(1);
     dump += `Process: ${JSON.stringify({
         node_version: process.version,
         platform: process.platform,
@@ -147,6 +169,15 @@ export function* publicationIntegrityChecker(): SagaGenerator<void> {
         thoriumUserDataPath: USER_DATA_FOLDER,
         thoriumPublicationPath: yield* callTyped(() => diMainGet("publication-directory").getDirectoryPath()),
     }, null, 4)}\n`;
+    yield* delayTyped(1);
+
+    const publicationCheckerState: IPublicationCheckerState = {
+        publicationIdentifierDataBase,
+        // publicationIdentifierDisk = [...approvedPublicationIdentifierDisk, ...rejectedPublicationIdentifierDisk];
+        approvedPublicationIdentifierDisk, rejectedPublicationIdentifierDisk,
+        dump,
+    };
+
     if (dumpLogs) {
         yield* callTyped(() => appendFileWithRotation(appLogs, dump));
 

--- a/src/main/storage/publication-directory.ts
+++ b/src/main/storage/publication-directory.ts
@@ -32,12 +32,13 @@ function isUserDirectoryConfig(value: unknown): value is UserDirectoryConfig {
 export class PublicationDirectory {
     public readonly defaultDirectory: string;
     public userDirectory?: string;
+    private readonly readyPromise: Promise<void>;
 
     public constructor(defaultDirectory: string) {
         this.defaultDirectory = defaultDirectory;
         // Best-effort async initialization: startup must keep working with the
         // default directory even if the persisted user directory is missing or invalid.
-        void this.readUserDirectory();
+        this.readyPromise = this.readUserDirectory();
     }
 
     // Load the persisted directory in the background and keep it only if it still exists.
@@ -60,7 +61,13 @@ export class PublicationDirectory {
         }
     }
 
+    public async ready(): Promise<void> {
+        await this.readyPromise;
+    }
+
     public async setUserDirectory(directoryPath: string): Promise<void> {
+        await this.ready();
+
         if (!directoryPath) {
             this.userDirectory = undefined;
             await rmrf(userPublicationDirectoryConfigPath);
@@ -77,6 +84,8 @@ export class PublicationDirectory {
     }
 
     public async getDirectoryPath(): Promise<string> {
+        await this.ready();
+
         const userDirectory = this.userDirectory;
 
         if (!userDirectory) {

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -9,11 +9,12 @@ import { dialog } from "electron";
 import * as fs from "fs";
 import { injectable } from "inversify";
 import * as path from "path";
-import { acceptedExtensionObject, publicationExtensionStoredOnDisk } from "readium-desktop/common/extension";
+import { acceptedExtensionObject, isAcceptedExtension, publicationExtensionStoredOnDisk } from "readium-desktop/common/extension";
 import { File } from "readium-desktop/common/models/file";
 import { PublicationView } from "readium-desktop/common/views/publication";
 import { ContentType } from "readium-desktop/utils/contentType";
-import { getFileSize, rmrf } from "readium-desktop/utils/fs";
+import { getFilePathNormalize, getFileSize, rmrf } from "readium-desktop/utils/fs";
+import { findMimeTypeWithExtension } from "readium-desktop/utils/mimeTypes";
 
 import { PublicationParsePromise } from "@r2-shared-js/parser/publication-parser";
 import { streamToBufferPromise } from "@r2-utils-js/_utils/stream/BufferUtils";
@@ -23,11 +24,49 @@ import { sanitizeForFilename } from "readium-desktop/common/safe-filename";
 import { URL_PROTOCOL_STORE } from "readium-desktop/common/streamerProtocol";
 import { IReaderStateReaderPersistence } from "readium-desktop/common/redux/states/renderer/readerRootState";
 import { diMainGet } from "../di";
+import { PublicationDocument } from "../db/document/publication";
+import { computeFileHash, extractCrc32OnZip } from "../tools/crc";
 
 const debug = debug_("readium-desktop:main/storage/pub-storage");
 
 export type TFileTypePubStorage = Extract<keyof IReaderStateReaderPersistence, "locator" | "config" | "disableRTLFlip" | "divina" | "allowCustomConfig" | "noteTotalCount" | "pdfConfig">;
 // "bound" is not included, saved only in publication-data
+
+interface IPublicationStoragePathEntry {
+    identifier: string;
+    directoryPath: string;
+}
+
+export type TPublicationStorageIntegrityIssueType =
+    "duplicate-directory"
+    | "duplicate-database-hash"
+    | "disk-hash-already-in-database"
+    | "missing-directory"
+    | "missing-archive"
+    | "missing-document-file"
+    | "invalid-document-file-url";
+
+export interface IPublicationStorageIntegrityIssue {
+    type: TPublicationStorageIntegrityIssueType;
+    identifier: string;
+    message: string;
+    directoryPath?: string[];
+    filePath?: string;
+    fileUrl?: string;
+    hash?: string;
+    matchingIdentifier?: string[];
+}
+
+export interface IPublicationStorageIntegrityResult {
+    good: string[];
+    bad: string[];
+    issues: IPublicationStorageIntegrityIssue[];
+}
+
+export interface IPublicationStorageRecoverablePublication {
+    identifier: string;
+    filePath: string;
+}
 
 const isUUIDv4 = (uuid: string) => /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/.test(uuid);
 const assertUUIDv4 = (uuid: string) => {
@@ -35,6 +74,8 @@ const assertUUIDv4 = (uuid: string) => {
         throw new Error("not an uuidv4 identifier !");
     }
 };
+
+const toFilePathArray = (filePath: string | undefined): string[] | undefined => filePath ? [filePath] : undefined;
 
 const jsonStringify = (d: any) => (__TH__IS_DEV__ || __TH__IS_CI__) ? JSON.stringify(d, null, 4) : JSON.stringify(d);
 
@@ -136,6 +177,7 @@ export class PublicationStorage {
         assertUUIDv4(identifier);
 
         const publicationDirectory = diMainGet("publication-directory");
+        await publicationDirectory.ready();
         const directoryPath = await publicationDirectory.getDirectoryPath();
         const defaultDirectoryPath = publicationDirectory.defaultDirectory;
         // New imports should use the user directory when available.
@@ -247,6 +289,7 @@ export class PublicationStorage {
         // }
 
         const publicationDirectory = diMainGet("publication-directory");
+        await publicationDirectory.ready();
         const defaultPublicationDirectoryPath = path.join(publicationDirectory.defaultDirectory, identifier);
         try {
             const stat = await fs.promises.stat(defaultPublicationDirectoryPath);
@@ -341,97 +384,424 @@ export class PublicationStorage {
 
         debug("FindPublicationPath", identifier);
 
-        const defer = (pubPath: string) => {
+        const entries = await this.getPublicationPathEntries(identifier);
+        const firstEntry = entries[0];
+        if (firstEntry) {
             if (this.__publicationEpubPathMap.has(identifier)) {
-                if (path.dirname(this.__publicationEpubPathMap.get(identifier)) !== pubPath) {
+                if (path.dirname(this.__publicationEpubPathMap.get(identifier)) !== firstEntry.directoryPath) {
                     debug("publicationEpubPath cache invalidation for", identifier);
                     this.__publicationEpubPathMap.delete(identifier);
                 }
             }
-        };
-
-        const publicationDirectory = diMainGet("publication-directory");
-        let publicationPath = path.join(publicationDirectory.defaultDirectory, identifier);
-        try {
-            // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
-            const stats = await fs.promises.stat(publicationPath);
-            if (stats.isDirectory()) {
-                defer(publicationPath);
-                return publicationPath;
-            }
-        } catch (e) {
-            debug(e);
-            // ignore
-        }
-
-        if (publicationDirectory.userDirectory) {
-            publicationPath = path.join(publicationDirectory.userDirectory, identifier);
-            if (publicationPath) {
-                try {
-                    // await fs.promises.access(publicationPath, fs.constants.R_OK | fs.constants.W_OK);
-                    const stats = await fs.promises.stat(publicationPath);
-                    if (stats.isDirectory()) {
-                        defer(publicationPath);
-                        return publicationPath;
-                    }
-                } catch (e) {
-                    debug(e);
-                    // ignore
-                }
-            }
+            return firstEntry.directoryPath;
         }
 
         throw new Error("publication folder path not found");
     }
 
-    private _loopOnDirectory = async (dir: string, pubs: Set<string>) => {
-        const files = await fs.promises.readdir(dir, { withFileTypes: true });
+    private async getPublicationRoots(): Promise<string[]> {
 
-        for (const file of files) {
-            if (
-                isUUIDv4(file.name) &&
-                file.isDirectory()
-            ) {
-                pubs.add(file.name);
+        const publicationDirectory = diMainGet("publication-directory");
+        await publicationDirectory.ready();
+
+        const roots = [
+            publicationDirectory.defaultDirectory,
+        ];
+        if (
+            publicationDirectory.userDirectory
+            && getFilePathNormalize(publicationDirectory.userDirectory) !== getFilePathNormalize(publicationDirectory.defaultDirectory)
+        ) {
+            roots.push(publicationDirectory.userDirectory);
+        }
+        return roots;
+    }
+
+    private async getPublicationPathEntries(identifier: string): Promise<IPublicationStoragePathEntry[]> {
+
+        assertUUIDv4(identifier);
+
+        const entries: IPublicationStoragePathEntry[] = [];
+        const roots = await this.getPublicationRoots();
+        for (const rootPath of roots) {
+            const publicationPath = path.join(rootPath, identifier);
+            try {
+                const stats = await fs.promises.stat(publicationPath);
+                if (stats.isDirectory()) {
+                    entries.push({
+                        identifier,
+                        directoryPath: publicationPath,
+                    });
+                }
+            } catch (e) {
+                debug(e);
             }
         }
-    };
+        return entries;
+    }
+
+    private async listPublicationIdPathEntries(): Promise<IPublicationStoragePathEntry[]> {
+
+        const roots = await this.getPublicationRoots();
+        const entries: IPublicationStoragePathEntry[] = [];
+        for (const rootPath of roots) {
+            let files: fs.Dirent[];
+            try {
+                files = await fs.promises.readdir(rootPath, { withFileTypes: true });
+            } catch (e) {
+                debug(`Cannot read publication storage directory ${rootPath}`, e);
+                continue;
+            }
+
+            for (const file of files) {
+                if (
+                    isUUIDv4(file.name) &&
+                    file.isDirectory()
+                ) {
+                    entries.push({
+                        identifier: file.name,
+                        directoryPath: path.join(rootPath, file.name),
+                    });
+                }
+            }
+        }
+        return entries;
+    }
+
     public async listPublicationIdPath(): Promise<string[]> {
 
         const pubIdSet = new Set<string>();
-
-        const publicationDirectory = diMainGet("publication-directory");
-        const userVaultPath = publicationDirectory.userDirectory; // can be undefined
-        if (userVaultPath) {
-            await this._loopOnDirectory(userVaultPath, pubIdSet);
+        const entries = await this.listPublicationIdPathEntries();
+        for (const entry of entries) {
+            pubIdSet.add(entry.identifier);
         }
-        await this._loopOnDirectory(publicationDirectory.defaultDirectory, pubIdSet);
         return [...pubIdSet.values()];
     }
 
-    public async checkPublicationsIntegrity(): Promise<{ good: string[], bad: string[] }> {
+    private getFileNameFromDocumentFileUrl(identifier: string, fileUrl: string): string | undefined {
 
-        const pubsId = await this.listPublicationIdPath();
+        if (!fileUrl) {
+            return undefined;
+        }
+
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(fileUrl);
+        } catch {
+            return undefined;
+        }
+
+        if (parsedUrl.protocol !== `${URL_PROTOCOL_STORE}:`) {
+            return undefined;
+        }
+
+        if (parsedUrl.hostname.toLowerCase() !== identifier.toLowerCase()) {
+            return undefined;
+        }
+
+        try {
+            const fileName = decodeURIComponent(parsedUrl.pathname).replace(/^\/+/, "");
+            if (!fileName || fileName === "." || fileName === ".." || fileName !== path.basename(fileName)) {
+                return undefined;
+            }
+            return fileName;
+        } catch {
+            return undefined;
+        }
+    }
+
+    private async checkDocumentFilesIntegrity(
+        document: PublicationDocument,
+        publicationPath: string,
+    ): Promise<IPublicationStorageIntegrityIssue[]> {
+
+        const issues: IPublicationStorageIntegrityIssue[] = [];
+        const files: File[] = [
+            ...(document.files || []),
+            ...(document.coverFile ? [document.coverFile] : []),
+        ];
+
+        if (!files.length) {
+            issues.push({
+                type: "missing-document-file",
+                identifier: document.identifier,
+                directoryPath: toFilePathArray(publicationPath),
+                message: `Publication ${document.identifier} has no file metadata in the database.`,
+            });
+            return issues;
+        }
+
+        for (const file of files) {
+            const fileName = this.getFileNameFromDocumentFileUrl(document.identifier, file.url);
+            if (!fileName) {
+                issues.push({
+                    type: "invalid-document-file-url",
+                    identifier: document.identifier,
+                    fileUrl: file.url,
+                    directoryPath: toFilePathArray(publicationPath),
+                    message: `Publication ${document.identifier} contains an invalid stored file URL: ${file.url}`,
+                });
+                continue;
+            }
+
+            const filePath = path.join(publicationPath, fileName);
+            try {
+                const stat = await fs.promises.stat(filePath);
+                if (!stat.isFile() || stat.size <= 0) {
+                    issues.push({
+                        type: "missing-document-file",
+                        identifier: document.identifier,
+                        fileUrl: file.url,
+                        filePath,
+                        directoryPath: toFilePathArray(publicationPath),
+                        message: `Publication ${document.identifier} database file reference is not a readable file: ${filePath}`,
+                    });
+                }
+            } catch {
+                issues.push({
+                    type: "missing-document-file",
+                    identifier: document.identifier,
+                    fileUrl: file.url,
+                    filePath,
+                    directoryPath: toFilePathArray(publicationPath),
+                    message: `Publication ${document.identifier} database file reference is missing on disk: ${filePath}`,
+                });
+            }
+        }
+
+        return issues;
+    }
+
+    public async getStoredPublicationHash(
+        filePath: string,
+    ): Promise<string | undefined> {
+        const ext = path.extname(filePath);
+        const isLCPLicense = isAcceptedExtension("lcpLicence", ext);
+        const isPDF = isAcceptedExtension("pdf", ext);
+        const isOPF = isAcceptedExtension("opf", ext);
+        const isNccHTML = filePath.replace(/\\/g, "/").toLowerCase().endsWith("/" + acceptedExtensionObject.nccHtml);
+
+        if (isLCPLicense || isOPF || isNccHTML) {
+            return undefined;
+        }
+
+        try {
+            return isPDF ?
+                await computeFileHash(filePath) :
+                await extractCrc32OnZip(filePath);
+        } catch (e) {
+            debug("Cannot compute stored publication hash", filePath, e);
+            return undefined;
+        }
+    }
+
+    public async checkPublicationsIntegrity(
+        publicationDocuments: PublicationDocument[] = [],
+    ): Promise<IPublicationStorageIntegrityResult> {
+
+        const entries = await this.listPublicationIdPathEntries();
+        const entriesByIdentifier = new Map<string, IPublicationStoragePathEntry[]>();
+        for (const entry of entries) {
+            const entriesForIdentifier = entriesByIdentifier.get(entry.identifier) || [];
+            entriesForIdentifier.push(entry);
+            entriesByIdentifier.set(entry.identifier, entriesForIdentifier);
+        }
+
+        const documentsByIdentifier = new Map<string, PublicationDocument>();
+        const documentsByHash = new Map<string, PublicationDocument[]>();
+        for (const document of publicationDocuments) {
+            documentsByIdentifier.set(document.identifier, document);
+            if (document.hash) {
+                const docs = documentsByHash.get(document.hash) || [];
+                docs.push(document);
+                documentsByHash.set(document.hash, docs);
+            }
+        }
 
         const good: string[] = [];
         const bad: string[] = [];
-        for (const pubId of pubsId) {
+        const issues: IPublicationStorageIntegrityIssue[] = [];
+        const duplicateHashPublicationIdentifierSet = new Set<string>();
+        for (const [hash, documents] of documentsByHash) {
+            if (documents.length < 2) {
+                continue;
+            }
+            for (const document of documents) {
+                duplicateHashPublicationIdentifierSet.add(document.identifier);
+                issues.push({
+                    type: "duplicate-database-hash",
+                    identifier: document.identifier,
+                    hash,
+                    matchingIdentifier: documents
+                        .map(({ identifier }) => identifier)
+                        .filter((identifier) => identifier !== document.identifier),
+                    message: `Publication ${document.identifier} has database hash ${hash}, which is also used by another publication.`,
+                });
+            }
+        }
+
+        for (const [pubId, pathEntries] of entriesByIdentifier) {
+            let publicationIsGood = true;
+            const publicationPath = pathEntries[0]?.directoryPath;
+            let publicationArchivePath: string | undefined;
+
+            if (pathEntries.length > 1) {
+                publicationIsGood = false;
+                issues.push({
+                    type: "duplicate-directory",
+                    identifier: pubId,
+                    directoryPath: pathEntries.map((entry) => entry.directoryPath),
+                    message: `Publication ${pubId} is present in multiple storage directories.`,
+                });
+            }
+
             try {
-                if (await this.getPublicationEpubPath(pubId)) {
-                    good.push(pubId);
-                    continue;
+                publicationArchivePath = await this.getPublicationEpubPath(pubId);
+                if (publicationArchivePath) {
+                    // archive exists
                 }
             } catch {
-                // ignore
+                publicationIsGood = false;
+                issues.push({
+                    type: "missing-archive",
+                    identifier: pubId,
+                    directoryPath: toFilePathArray(publicationPath),
+                    message: `Publication ${pubId} storage directory does not contain a readable publication archive.`,
+                });
             }
-            bad.push(pubId);
+
+            const document = documentsByIdentifier.get(pubId);
+            if (duplicateHashPublicationIdentifierSet.has(pubId)) {
+                publicationIsGood = false;
+            }
+            if (document && publicationPath) {
+                const documentIssues = await this.checkDocumentFilesIntegrity(document, publicationPath);
+                if (documentIssues.length) {
+                    publicationIsGood = false;
+                    issues.push(...documentIssues);
+                }
+            }
+            if (!document && publicationArchivePath) {
+                const hash = await this.getStoredPublicationHash(publicationArchivePath);
+                const matchingDocument = documentsByHash.get(hash) || [];
+                if (matchingDocument.length) {
+                    publicationIsGood = false;
+                    issues.push({
+                        type: "disk-hash-already-in-database",
+                        identifier: pubId,
+                        directoryPath: toFilePathArray(publicationPath),
+                        filePath: publicationArchivePath,
+                        hash,
+                        matchingIdentifier: matchingDocument.map(({ identifier }) => identifier),
+                        message: `Publication ${pubId} is missing from the database, but its hash ${hash} already exists on publication(s) ${matchingDocument.map(({ identifier }) => identifier).join(" | ")}.`,
+                    });
+                }
+            }
+
+            if (publicationIsGood) {
+                good.push(pubId);
+            } else {
+                bad.push(pubId);
+            }
+        }
+
+        for (const document of publicationDocuments) {
+            if (!entriesByIdentifier.has(document.identifier)) {
+                issues.push({
+                    type: "missing-directory",
+                    identifier: document.identifier,
+                    message: `Publication ${document.identifier} is present in the database but missing from publication storage.`,
+                });
+            }
         }
 
         return {
             good,
             bad,
+            issues,
         };
 
+    }
+
+    public async listRecoverablePublications(
+        publicationDocuments: PublicationDocument[],
+    ): Promise<IPublicationStorageRecoverablePublication[]> {
+
+        const publicationIdentifierDataBase = new Set(publicationDocuments.map(({ identifier }) => identifier));
+        const integrity = await this.checkPublicationsIntegrity(publicationDocuments);
+        const recoverablePublicationIdentifierDisk = integrity.good.filter((id) => !publicationIdentifierDataBase.has(id));
+        const recoverablePublications: IPublicationStorageRecoverablePublication[] = [];
+
+        for (const identifier of recoverablePublicationIdentifierDisk) {
+            try {
+                const filePath = await this.getPublicationEpubPath(identifier);
+                recoverablePublications.push({
+                    identifier,
+                    filePath,
+                });
+            } catch (e) {
+                debug(e);
+            }
+        }
+
+        return recoverablePublications;
+    }
+
+    private getStoredPublicationContentType(ext: string): string {
+        const normalizedExt = ext.startsWith(".") ? ext : `.${ext}`;
+        if (normalizedExt === acceptedExtensionObject.audiobook) {
+            return ContentType.AudioBookPacked;
+        }
+        if (normalizedExt === acceptedExtensionObject.audiobookLcp || normalizedExt === acceptedExtensionObject.audiobookLcpAlt) {
+            return ContentType.AudioBookPackedLcp;
+        }
+        if (normalizedExt === acceptedExtensionObject.divina) {
+            return ContentType.DivinaPacked;
+        }
+        if (normalizedExt === acceptedExtensionObject.webpub) {
+            return ContentType.webpubPacked;
+        }
+        if (normalizedExt === acceptedExtensionObject.pdfLcp) {
+            return ContentType.lcppdf;
+        }
+        if (normalizedExt === acceptedExtensionObject.daisy) {
+            return ContentType.Zip;
+        }
+
+        return findMimeTypeWithExtension(normalizedExt) || ContentType.Epub;
+    }
+
+    public async getStoredPublicationFiles(identifier: string): Promise<File[]> {
+
+        assertUUIDv4(identifier);
+
+        const publicationDirectoryPath = await this.findPublicationPath(identifier);
+        const files = await fs.promises.readdir(publicationDirectoryPath, { withFileTypes: true });
+        const publicationFiles: File[] = [];
+
+        for (const file of files) {
+            if (!file.isFile()) {
+                continue;
+            }
+
+            const extWithDot = path.extname(file.name).toLowerCase();
+            if (
+                !publicationExtensionStoredOnDisk.includes(extWithDot)
+                && !file.name.toLowerCase().startsWith("cover.")
+            ) {
+                continue;
+            }
+
+            const ext = extWithDot.slice(1);
+            const filePath = path.join(publicationDirectoryPath, file.name);
+            publicationFiles.push({
+                url: `${URL_PROTOCOL_STORE}://${identifier}/${file.name}`,
+                ext,
+                contentType: this.getStoredPublicationContentType(extWithDot),
+                size: getFileSize(filePath),
+            });
+        }
+
+        return publicationFiles;
     }
 
     private async storePublicationBook(

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -571,18 +571,11 @@ export class PublicationStorage {
         return issues;
     }
 
-    public async getStoredPublicationHash(
+    private async getStoredPublicationHash(
         filePath: string,
     ): Promise<string | undefined> {
         const ext = path.extname(filePath);
-        const isLCPLicense = isAcceptedExtension("lcpLicence", ext);
         const isPDF = isAcceptedExtension("pdf", ext);
-        const isOPF = isAcceptedExtension("opf", ext);
-        const isNccHTML = filePath.replace(/\\/g, "/").toLowerCase().endsWith("/" + acceptedExtensionObject.nccHtml);
-
-        if (isLCPLicense || isOPF || isNccHTML) {
-            return undefined;
-        }
 
         try {
             return isPDF ?

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -399,21 +399,21 @@ export class PublicationStorage {
         throw new Error("publication folder path not found");
     }
 
-    private async getPublicationRoots(): Promise<string[]> {
+    private async getPublicationDirectories(): Promise<string[]> {
 
         const publicationDirectory = diMainGet("publication-directory");
         await publicationDirectory.ready();
 
-        const roots = [
+        const directories = [
             publicationDirectory.defaultDirectory,
         ];
         if (
             publicationDirectory.userDirectory
             && getFilePathNormalize(publicationDirectory.userDirectory) !== getFilePathNormalize(publicationDirectory.defaultDirectory)
         ) {
-            roots.push(publicationDirectory.userDirectory);
+            directories.push(publicationDirectory.userDirectory);
         }
-        return roots;
+        return directories;
     }
 
     private async getPublicationPathEntries(identifier: string): Promise<IPublicationStoragePathEntry[]> {
@@ -421,9 +421,9 @@ export class PublicationStorage {
         assertUUIDv4(identifier);
 
         const entries: IPublicationStoragePathEntry[] = [];
-        const roots = await this.getPublicationRoots();
-        for (const rootPath of roots) {
-            const publicationPath = path.join(rootPath, identifier);
+        const directories = await this.getPublicationDirectories();
+        for (const directoryPath of directories) {
+            const publicationPath = path.join(directoryPath, identifier);
             try {
                 const stats = await fs.promises.stat(publicationPath);
                 if (stats.isDirectory()) {
@@ -441,14 +441,14 @@ export class PublicationStorage {
 
     private async listPublicationIdPathEntries(): Promise<IPublicationStoragePathEntry[]> {
 
-        const roots = await this.getPublicationRoots();
+        const directories = await this.getPublicationDirectories();
         const entries: IPublicationStoragePathEntry[] = [];
-        for (const rootPath of roots) {
+        for (const directoryPath of directories) {
             let files: fs.Dirent[];
             try {
-                files = await fs.promises.readdir(rootPath, { withFileTypes: true });
+                files = await fs.promises.readdir(directoryPath, { withFileTypes: true });
             } catch (e) {
-                debug(`Cannot read publication storage directory ${rootPath}`, e);
+                debug(`Cannot read publication storage directory ${directoryPath}`, e);
                 continue;
             }
 
@@ -459,7 +459,7 @@ export class PublicationStorage {
                 ) {
                     entries.push({
                         identifier: file.name,
-                        directoryPath: path.join(rootPath, file.name),
+                        directoryPath: path.join(directoryPath, file.name),
                     });
                 }
             }

--- a/src/renderer/common/hooks/useApi.ts
+++ b/src/renderer/common/hooks/useApi.ts
@@ -30,12 +30,12 @@ export function useApi<T extends TApiMethodName>(_requestId: string | undefined,
             store.dispatch(apiActions.clean.build(requestId));
         };
     }, [requestId, store]);
-    const apiAction = (...requestData: Parameters<TApiMethod[T]>) => {
+    const apiAction = React.useCallback((...requestData: Parameters<TApiMethod[T]>) => {
         const splitPath = apiPath.split("/");
         const moduleId = splitPath[0] as TModuleApi;
         const methodId = splitPath[1] as TMethodApi;
         store.dispatch(apiActions.request.build(requestId, moduleId, methodId, requestData));
-    };
+    }, [apiPath, requestId, store]);
 
     const apiResult = useSyncExternalStore(store.subscribe, () => store.getState().api[requestId]);
     return [apiResult, apiAction];

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -179,6 +179,7 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
             // "catalog/addEntry",
             "publication/updateTags",
             "publication/findAllRefresh",
+            "publication/recover",
         ], () => {
             apiAction("publication/findAll")
                 .then((publicationViews) => {

--- a/src/renderer/library/components/settings/Settings.tsx
+++ b/src/renderer/library/components/settings/Settings.tsx
@@ -53,6 +53,7 @@ import debounce from "debounce";
 import { INoteCreator } from "readium-desktop/common/redux/states/creator";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import { ApiappHowDoesItWorkInfoBox } from "../dialog/ApiappAddForm";
+import SettingsRecovery from "./SettingsRecovery";
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { TextArea } from "react-aria-components";
 import { noteExportHtmlMustacheTemplate } from "readium-desktop/common/readium/annotation/htmlTemplate";
@@ -903,6 +904,11 @@ const StorageSettings: React.FC<{}> = () => {
                             </div>
                         ) : null}
                     </div>
+
+                    <SettingsRecovery
+                        defaultDirectory={defaultDirectory}
+                        userDirectory={userDirectory}
+                    />
                 </div>
             </section>
         </>

--- a/src/renderer/library/components/settings/SettingsRecovery.tsx
+++ b/src/renderer/library/components/settings/SettingsRecovery.tsx
@@ -1,0 +1,181 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import * as stylesAlertModals from "readium-desktop/renderer/assets/styles/components/alert.modals.scss";
+import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
+import * as stylesSettings from "readium-desktop/renderer/assets/styles/components/settings.scss";
+
+import * as React from "react";
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import classNames from "classnames";
+import * as InfoIcon from "readium-desktop/renderer/assets/icons/info-icon.svg";
+import SVG from "readium-desktop/renderer/common/components/SVG";
+import { useApi } from "readium-desktop/renderer/common/hooks/useApi";
+
+const SettingsRecoveryConfirmDialog = (props: {
+    open: boolean;
+    title: string;
+    description: string;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onOpenChange: (open: boolean) => void;
+}) => {
+    return (
+        <AlertDialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+            <AlertDialog.Portal>
+                <AlertDialog.Overlay className={stylesAlertModals.AlertDialogOverlay} />
+                <AlertDialog.Content className={stylesAlertModals.AlertDialogContent}>
+                    <AlertDialog.Title className={stylesAlertModals.AlertDialogTitle}>
+                        {props.title}
+                    </AlertDialog.Title>
+                    <AlertDialog.Description className={stylesAlertModals.AlertDialogDescription}>
+                        {props.description}
+                    </AlertDialog.Description>
+                    <div className={stylesAlertModals.AlertDialogButtonContainer}>
+                        <AlertDialog.Cancel asChild>
+                            <button className={classNames(stylesAlertModals.AlertDialogButton, stylesAlertModals.abort)}>
+                                Cancel
+                            </button>
+                        </AlertDialog.Cancel>
+                        <AlertDialog.Action asChild>
+                            <button
+                                className={classNames(stylesAlertModals.AlertDialogButton, stylesAlertModals.yes)}
+                                onClick={props.onConfirm}
+                            >
+                                {props.confirmLabel}
+                            </button>
+                        </AlertDialog.Action>
+                    </div>
+                </AlertDialog.Content>
+            </AlertDialog.Portal>
+        </AlertDialog.Root>
+    );
+};
+
+const SettingsRecovery = (props: {
+    defaultDirectory: string;
+    userDirectory: string;
+}) => {
+    const [confirmRecoveryOpen, setConfirmRecoveryOpen] = React.useState(false);
+    const [isRecoveryLoading, setIsRecoveryLoading] = React.useState(false);
+    const [isRecoveryChecked, setIsRecoveryChecked] = React.useState(false);
+    const [isRecovering, setIsRecovering] = React.useState(false);
+    const [findAllRecoverableResult, findAllRecoverableAction] = useApi(undefined, "publication/findAllRecoverable");
+    const [recoverResult, recoverAction] = useApi(undefined, "publication/recover");
+    const findAllRecoverableTime = findAllRecoverableResult?.data?.time;
+    const recoverTime = recoverResult?.data?.time;
+    const recoverablePublications = React.useMemo(
+        () => findAllRecoverableResult?.data?.error ?
+            [] :
+            (findAllRecoverableResult?.data?.result || []),
+        [findAllRecoverableResult],
+    );
+
+    const checkRecoverablePublications = React.useCallback(() => {
+        setIsRecoveryLoading(true);
+        findAllRecoverableAction();
+    }, [findAllRecoverableAction]);
+
+    React.useEffect(() => {
+        if (!findAllRecoverableTime) {
+            return;
+        }
+        setIsRecoveryChecked(true);
+        setIsRecoveryLoading(false);
+    }, [findAllRecoverableTime]);
+
+    React.useEffect(() => {
+        if (!recoverTime) {
+            return;
+        }
+        setIsRecovering(false);
+        checkRecoverablePublications();
+    }, [recoverTime, checkRecoverablePublications]);
+
+    React.useEffect(() => {
+        setIsRecoveryChecked(false);
+    }, [props.defaultDirectory, props.userDirectory]);
+
+    const recoverPublications = React.useCallback(() => {
+        setConfirmRecoveryOpen(false);
+        setIsRecovering(true);
+        recoverAction(recoverablePublications.map(({ identifier }) => identifier));
+    }, [recoverAction, recoverablePublications]);
+
+    return (
+        <>
+            <SettingsRecoveryConfirmDialog
+                open={confirmRecoveryOpen}
+                onOpenChange={setConfirmRecoveryOpen}
+                title="Recover publications"
+                description={`Thorium found ${recoverablePublications.length} publication${recoverablePublications.length > 1 ? "s" : ""} on disk that ${recoverablePublications.length > 1 ? "are" : "is"} missing from the database. Do you want to import ${recoverablePublications.length > 1 ? "them" : "it"} back into Thorium?`}
+                confirmLabel="Recover"
+                onConfirm={recoverPublications}
+            />
+
+            <div style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "12px",
+                padding: "16px",
+                border: "1px solid var(--color-button-border)",
+                borderRadius: "8px",
+                background: "var(--color-neutral-base)",
+                boxShadow: "0 1px 0 var(--color-gray-100)",
+            }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                    <p style={{ margin: 0, fontWeight: 600 }}>Recovery</p>
+                    {!isRecoveryChecked && !isRecoveryLoading ? (
+                        <p style={{ margin: 0 }}>
+                            Check publication storage to find publications that can be safely recovered.
+                        </p>
+                    ) : null}
+                    {isRecoveryLoading ? (
+                        <p style={{ margin: 0 }}>Checking publication storage...</p>
+                    ) : null}
+                    {isRecoveryChecked && !isRecoveryLoading && recoverablePublications.length ? (
+                        <div className={stylesSettings.session_text} style={{ margin: 0, alignItems: "flex-start" }}>
+                            <SVG ariaHidden svg={InfoIcon} />
+                            <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                                <p style={{ margin: 0, fontWeight: 600 }}>
+                                    One or more publications were found on disk but are missing from the database. Recovery is possible.
+                                </p>
+                                <p style={{ margin: 0 }}>
+                                    {recoverablePublications.length} publication{recoverablePublications.length > 1 ? "s" : ""} can be recovered with the original storage identifier.
+                                </p>
+                            </div>
+                        </div>
+                    ) : null}
+                    {isRecoveryChecked && !isRecoveryLoading && !recoverablePublications.length ? (
+                        <p style={{ margin: 0 }}>No recoverable publications were found.</p>
+                    ) : null}
+                </div>
+
+                <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+                    {isRecoveryChecked && recoverablePublications.length ? (
+                        <button
+                            className={stylesSettings.btn_primary}
+                            disabled={isRecoveryLoading || isRecovering}
+                            onClick={() => setConfirmRecoveryOpen(true)}
+                        >
+                            {isRecovering ? "Recovering..." : "Recover publications"}
+                        </button>
+                    ) : null}
+                    <button
+                        className={isRecoveryChecked ? stylesButtons.button_transparency : stylesSettings.btn_primary}
+                        disabled={isRecoveryLoading || isRecovering}
+                        onClick={checkRecoverablePublications}
+                    >
+                        {isRecoveryChecked ? "Check again" : "Check for recoverable publications"}
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default SettingsRecovery;

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -6,7 +6,7 @@
 // ==LICENSE-END==
 
 import * as fs from "fs";
-// import * as path from "path";
+import * as path from "path";
 
 // export function rmDirSync(dirPath: string): void {
 //     let filenames = [];
@@ -35,6 +35,10 @@ export function getFileSize(filePath: string): number {
     return stats.size;
 }
 
+export function getFilePathNormalize(filePath: string): string {
+    const resolved = path.resolve(filePath);
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
 
 export const rmrf = async (dirOrFile: string) => {
     return await fs.promises.rm(dirOrFile, { recursive: true, retryDelay: 100, maxRetries: 3, force: true });


### PR DESCRIPTION
fix #3394 

Added a recovery procedure for publications present on disk but missing from the database. In Settings > Storage, users can now perform a manual recovery check, verify if recoverable publications have been found, and restore them without having to run the scan when the application starts.

Under the hood, publication storage integrity checks were expanded to inspect both default and external storage path, detect duplicate or inconsistent records, and identify only safe recovery candidates. Recovery reuses the original publication identifier, avoids re-importing duplicates already present in the database.

changes:
- Added a dedicated recovery section in `Settings > Storage`.
- Moved recovery UI logic into a standalone `SettingsRecovery` component.
- Changed recovery checks to run only when the user clicks a button, not on initial mount.
- Added a confirmation dialog before recovering publications.
- Added main process "API" for `publication/findAllRecoverable` and `publication/recover`.
- Implemented discovery of recoverable publications that exist on disk but are missing from the database.
- Added publication integrity checks across default and external storage folder path.
- Added detection for duplicate directories, duplicate database hashes, missing archives, missing DB-linked files, and invalid stored file URLs.
- Prevented recovery/import when a publication with the same identifier already exists in the database.
- Prevented recovery/import when a matching stored hash is already present in the database.
- Reused the original publication identifier during recovery so restored records keep the same storage identity.
- Added support for rebuilding stored publication file metadata from the existing filesystem during recovery.
- Added a shared path-normalization helper in `utils/fs` for comparing storage directory on windows safely.
- Ensured publication directory configuration is fully loaded before catalog and storage operations run.
- Expanded publication checker logging to report detailed integrity issues and recoverable publication counts with dump to a file.



Screenshots:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/36f76838-f921-4b58-a2be-7c0c97953da5" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/e66b056f-6156-40e8-a80c-2c9f79f9ac2e" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/7b273f7f-7823-49f2-afa9-9487b4376da5" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/092e3850-9250-4bb4-9635-f8e2de6bceda" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/66c33053-4c5d-461d-b608-89464293cf4e" />


Tests:

- `Detect recoverable publication from disk`
  - Import a publication into Thorium.
  - Remove its database record while keeping the publication files on disk.
  - Open `Settings > Storage` and click `Check for recoverable publications`.
  - Verify the recovery section reports one recoverable publication.
  - Click `Recover publications` and confirm the dialog.
  - Verify the publication appears again in the library with the same identifier-backed storage.

- `No recoverable publication when database and disk are in sync`
  - Import one or more publications normally.
  - Open `Settings > Storage`.
  - Click `Check for recoverable publications`.
  - Verify the UI reports that no recoverable publications were found.
  - Verify the recover button is not shown.

- `Recovery check is manual, not automatic`
  - Open `Settings > Storage` with publications present on disk but missing from the database.
  - Verify the recovery section does not immediately show analytics or recovery results on load.
  - Verify only the check button is visible before any user action.
  - Click the check button and verify the results then appear.

- `Duplicate database identifier blocks recovery`
  - Prepare a disk publication folder whose identifier already exists in the database.
  - Open `Settings > Storage` and run the recovery check.
  - Verify the publication is not offered as recoverable.
  - Verify integrity logging reports the identifier conflict path if logs are inspected.

- `Duplicate hash in database blocks recovery`
  - Prepare a disk publication missing from the database, but with content matching a publication already stored in the database.
  - Run the recovery check from `Settings > Storage`.
  - Verify the publication is excluded from recoverable results.
  - Verify the checker reports that the disk hash already exists in the database.

- `Duplicate directory detection across default and external storage`
  - Configure an external storage directory.
  - Create the same publication identifier folder in both default and external storage.
  - Run the recovery check.
  - Verify the publication is not considered recoverable.
  - Verify the integrity result reports duplicate directories with both paths.

- `Missing archive is rejected`
  - Create a publication folder with a valid UUID but remove the actual book archive from it.
  - Run the recovery check.
  - Verify the publication is not listed as recoverable.
  - Verify the issue is reported as a missing archive.
  
-  `Invalid stored file URL is detected`
   - Import a publication, then corrupt the stored file URL in the database record.
   - Run integrity detection.
   - Verify the checker reports an invalid document file URL.
   - Verify the publication is not treated as healthy.


- `Recovery preserves original identifier`
  - Prepare a publication that exists on disk only.
  - Run the recovery flow.
  - Verify the restored database record uses the original identifier from the storage folder.
  - Verify reading state and stored file URLs resolve under that same identifier.

- `Recovery after external storage directory change`
  - Import publications with external storage enabled.
  - Remove the DB record for one publication while leaving its files in external storage.
  - Restart the app and open `Settings > Storage`.
  - Run the recovery check.
  - Verify the publication is still found and can be recovered from the configured external root.

- `Recover multiple publications in one action`
  - Prepare several publications on disk with no matching database records.
  - Run the recovery check.
  - Verify the count shown in the UI matches the number of recoverable publications.
  - Trigger recovery and confirm.
  - Verify all publications are restored and the success toast reports the correct count.

- `Check again refreshes recovery results`
  - Run a recovery check when one publication is recoverable.
  - Recover it or otherwise change on-disk state.
  - Click `Check again`.
  - Verify the displayed result updates to reflect the latest integrity state.

- `Hash computation skips unsupported formats safely`
  - Prepare recovery candidates for supported and unsupported hash cases such as PDF.
  - Run integrity detection.
  - Verify unsupported hash cases are handled without crashing and are filtered according to the recovery rules.
