### PR TITLE
[PARKED FOR NOW] Disable nodeIntregration

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start:dev:renderer:library": "webpack-dev-server --config webpack.config.renderer-library.js",
     "start:dev:renderer:reader": "webpack-dev-server --config webpack.config.renderer-reader.js",
     "start:dev:renderer:pdf": "webpack --config webpack.config.renderer-pdf.js && webpack --config webpack.config.renderer-pdf-extract.js",
-    "start:dev:renderer:preload": "webpack --config webpack.config.preload.js",
+    "start:dev:renderer:preload": "webpack --config webpack.config.preload.js && webpack --config webpack.config.renderer-preload-library.js",
     "start:dev:main:electron": "cross-env DEBUG=r2:*,readium-desktop:*,proxy-agent,-readium-desktop:main#streamerNoHttp,-readium-desktop:main#streamerCommon,-readium-desktop:main#sessions NODE_ENV=development electron  --remote-debugging-port=9223 --remote-allow-origins=\"*\" .",
     "start:dev:main": "npm run build:dev:main && npm run start:dev:main:electron",
     "start:devex": "cross-env WEBPACK=bundle-external npm run start:dev",
@@ -178,6 +178,7 @@
       "styles_library.css",
       "styles_reader.css",
       "preload.js",
+      "preload_library.js",
       "main.js",
       "package.json",
       "fonts"

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -35,6 +35,19 @@ const ENABLE_DEV_TOOLS = __TH__IS_DEV__ || __TH__IS_CI__;
 // so the garbage collector doesn't close it.
 let libWindow: BrowserWindow = null;
 
+const logLibraryWindowError = (eventName: string, payload: unknown) => {
+    let payloadStr = "";
+    try {
+        payloadStr = JSON.stringify(payload, null, 2);
+    } catch {
+        payloadStr = String(payload);
+    }
+
+    const message = `[LibraryWindow:${eventName}] ${payloadStr}`;
+    debug(message);
+    console.error(message);
+};
+
 // Opens the main window, with a native menu bar.
 export function* createLibraryWindow(_action: winActions.library.openRequest.TAction) {
 
@@ -42,6 +55,11 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
     let windowBound = yield* selectTyped(
         (state: RootState) => state.win.session.library.windowBound);
     windowBound = normalizeWinBoundRectangle(windowBound);
+
+    // see: src\main\pdf\extract.ts
+    const preloadPath = path.normalize(path.join(__dirname, "preload_library.js")).replace(/\\/g, "/");
+
+    debug("SHOW preload PATH", preloadPath);
 
     libWindow = new BrowserWindow({
         ...windowBound,
@@ -51,8 +69,9 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
             // enableRemoteModule: false,
             allowRunningInsecureContent: false,
             backgroundThrottling: true,
-            devTools: ENABLE_DEV_TOOLS, // this does not automatically open devtools, just enables them (see Electron API openDevTools())
+            devTools: true, // ENABLE_DEV_TOOLS, // this does not automatically open devtools, just enables them (see Electron API openDevTools())
             nodeIntegration: true, // ==> disables sandbox https://www.electronjs.org/docs/latest/tutorial/sandbox
+            preload: preloadPath,
             sandbox: false,
             contextIsolation: false, // must be false because nodeIntegration, see https://github.com/electron/electron/issues/23506
             nodeIntegrationInWorker: false,
@@ -62,6 +81,40 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
         icon: path.join(__dirname, "assets/icons/icon.png"),
     });
     debug("LibraryWindow new BrowserWindow instancied");
+
+    libWindow.webContents.on("console-message", (_event, level, message, line, sourceId) => {
+        logLibraryWindowError("console-message", {
+            level,
+            message,
+            line,
+            sourceId,
+        });
+    });
+
+    libWindow.webContents.on("preload-error", (_event, preloadPath_, error) => {
+        logLibraryWindowError("preload-error", {
+            preloadPath: preloadPath_,
+            message: error.message,
+            stack: error.stack,
+        });
+    });
+
+    libWindow.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        logLibraryWindowError("did-fail-load", {
+            errorCode,
+            errorDescription,
+            validatedURL,
+            isMainFrame,
+        });
+    });
+
+    libWindow.webContents.on("render-process-gone", (_event, details) => {
+        logLibraryWindowError("render-process-gone", details);
+    });
+
+    libWindow.on("unresponsive", () => {
+        logLibraryWindowError("unresponsive", {});
+    });
 
     if (ENABLE_DEV_TOOLS) {
         const wc = libWindow.webContents;

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -70,10 +70,11 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
             allowRunningInsecureContent: false,
             backgroundThrottling: true,
             devTools: true, // ENABLE_DEV_TOOLS, // this does not automatically open devtools, just enables them (see Electron API openDevTools())
-            nodeIntegration: true, // ==> disables sandbox https://www.electronjs.org/docs/latest/tutorial/sandbox
+            nodeIntegration: false,
             preload: preloadPath,
+            // Keep sandbox disabled so the preload can provide a strict allowlisted require() bridge for Webpack externals.
             sandbox: false,
-            contextIsolation: false, // must be false because nodeIntegration, see https://github.com/electron/electron/issues/23506
+            contextIsolation: true,
             nodeIntegrationInWorker: false,
             webSecurity: true,
             webviewTag: false,

--- a/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
@@ -40,6 +40,7 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
     assertUUIDv4(publicationIdentifier);
     
     const winBound = yield* callTyped(readerNewWindowBound, publicationIdentifier);
+    const preloadPath = path.normalize(path.join(__dirname, "preload_library.js")).replace(/\\/g, "/");
     const readerWindow = new BrowserWindow({
         ...winBound,
         minWidth: WINDOW_MIN_WIDTH,
@@ -50,6 +51,7 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
             backgroundThrottling: false,
             devTools: ENABLE_DEV_TOOLS, // this does not automatically open devtools, just enables them (see Electron API openDevTools())
             nodeIntegration: true, // ==> disables sandbox https://www.electronjs.org/docs/latest/tutorial/sandbox
+            preload: preloadPath,
             sandbox: false,
             contextIsolation: false, // must be false because nodeIntegration, see https://github.com/electron/electron/issues/23506
             nodeIntegrationInWorker: false,

--- a/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createReaderWindow.ts
@@ -35,12 +35,28 @@ debug("_");
 
 const ENABLE_DEV_TOOLS = __TH__IS_DEV__ || __TH__IS_CI__;
 
+const logReaderWindowError = (eventName: string, payload: unknown) => {
+    let payloadStr = "";
+    try {
+        payloadStr = JSON.stringify(payload, null, 2);
+    } catch {
+        payloadStr = String(payload);
+    }
+
+    const message = `[ReaderWindow:${eventName}] ${payloadStr}`;
+    debug(message);
+    console.error(message);
+};
+
 export function* createReaderWindow(publicationIdentifier: string, manifestUrl: string,  windowIdentifier: string /* winBound, reduxState*/) {
     assertUUIDv4(windowIdentifier);
     assertUUIDv4(publicationIdentifier);
     
     const winBound = yield* callTyped(readerNewWindowBound, publicationIdentifier);
     const preloadPath = path.normalize(path.join(__dirname, "preload_library.js")).replace(/\\/g, "/");
+
+    debug("SHOW preload PATH", preloadPath);
+
     const readerWindow = new BrowserWindow({
         ...winBound,
         minWidth: WINDOW_MIN_WIDTH,
@@ -50,16 +66,66 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
             allowRunningInsecureContent: false,
             backgroundThrottling: false,
             devTools: ENABLE_DEV_TOOLS, // this does not automatically open devtools, just enables them (see Electron API openDevTools())
-            nodeIntegration: true, // ==> disables sandbox https://www.electronjs.org/docs/latest/tutorial/sandbox
+            // set nodeIntegration to true for now because the Reader bundle still loads @r2-navigator-js/electron renderer modules.
+            nodeIntegration: true,
             preload: preloadPath,
             sandbox: false,
-            contextIsolation: false, // must be false because nodeIntegration, see https://github.com/electron/electron/issues/23506
+            contextIsolation: true,
             nodeIntegrationInWorker: false,
             webSecurity: true,
             webviewTag: true,
         },
         icon: path.join(__dirname, "assets/icons/icon.png"),
     });
+    debug("ReaderWindow new BrowserWindow instancied");
+
+    readerWindow.webContents.on("console-message", (_event, level, message, line, sourceId) => {
+        logReaderWindowError("console-message", {
+            windowIdentifier,
+            publicationIdentifier,
+            level,
+            message,
+            line,
+            sourceId,
+        });
+    });
+
+    readerWindow.webContents.on("preload-error", (_event, preloadPath_, error) => {
+        logReaderWindowError("preload-error", {
+            windowIdentifier,
+            publicationIdentifier,
+            preloadPath: preloadPath_,
+            message: error.message,
+            stack: error.stack,
+        });
+    });
+
+    readerWindow.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        logReaderWindowError("did-fail-load", {
+            windowIdentifier,
+            publicationIdentifier,
+            errorCode,
+            errorDescription,
+            validatedURL,
+            isMainFrame,
+        });
+    });
+
+    readerWindow.webContents.on("render-process-gone", (_event, details) => {
+        logReaderWindowError("render-process-gone", {
+            windowIdentifier,
+            publicationIdentifier,
+            details,
+        });
+    });
+
+    readerWindow.on("unresponsive", () => {
+        logReaderWindowError("unresponsive", {
+            windowIdentifier,
+            publicationIdentifier,
+        });
+    });
+
     readerWindow.on("focus", () => {
         readerWindow.webContents?.send("window-focus");
     });
@@ -215,6 +281,7 @@ export function* createReaderWindow(publicationIdentifier: string, manifestUrl: 
 
             if (!readerWindow.isDestroyed() && !readerWindow.webContents.isDestroyed()) {
                 try {
+                    debug("ReaderWindow load url to the webview");
                     await readerWindow.webContents.loadURL(readerUrl, { extraHeaders: "pragma: no-cache\n" });
                 } catch (e) {
                     debug("Load url rejected", e);

--- a/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
@@ -18,7 +18,6 @@ import { convertMultiLangStringToLangString, langStringIsRTL } from "readium-des
 import DOMPurify from "dompurify";
 import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
-import { shell } from "electron";
 import isURL from "validator/lib/isURL";
 
 // Logger
@@ -453,7 +452,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
                                     {a11y_certifiedBy.length
                                         ? a11y_certifiedBy.map((certifier, i) => <li key={"certifier_" + i}>{
                                             // isURL() excludes the file: and data: URL protocols, as well as http://localhost but not http://127.0.0.1 or http(s)://IP:PORT more generally (note that ftp: is accepted)
-                                            certifier && isURL(certifier) ? <a title={certifier} onClick={async (e) => { e.preventDefault(); if (certifier && /^https?:\/\//.test(certifier)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await shell.openExternal(certifier); } }} href={certifier}>
+                                            certifier && isURL(certifier) ? <a title={certifier} onClick={async (e) => { e.preventDefault(); if (certifier && /^https?:\/\//.test(certifier)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await window.electronApi.openExternal(certifier); } }} href={certifier}>
                                             {__("publ-a11y-display-guide.conformance.conformance-details-certifier-report.compact")}
                                         </a> :
                                             __("publ-a11y-display-guide.conformance.conformance-certifier.compact") + " " + certifier
@@ -462,7 +461,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
                                     {a11y_certifierCredential.length
                                         ? a11y_certifierCredential.map((certifier_credentials, i) => <li key={"certifier_credentials_" + i}>{
                                             // isURL() excludes the file: and data: URL protocols, as well as http://localhost but not http://127.0.0.1 or http(s)://IP:PORT more generally (note that ftp: is accepted)
-                                            certifier_credentials && isURL(certifier_credentials) ? <a title={certifier_credentials} onClick={async (e) => { e.preventDefault(); if (certifier_credentials && /^https?:\/\//.test(certifier_credentials)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await shell.openExternal(certifier_credentials); } }} href={certifier_credentials}>
+                                            certifier_credentials && isURL(certifier_credentials) ? <a title={certifier_credentials} onClick={async (e) => { e.preventDefault(); if (certifier_credentials && /^https?:\/\//.test(certifier_credentials)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await window.electronApi.openExternal(certifier_credentials); } }} href={certifier_credentials}>
                                             {__("publ-a11y-display-guide.conformance.conformance-details-certifier-report.compact")}
                                         </a> :
                                             __("publ-a11y-display-guide.conformance.conformance-certifier-credentials.compact") + " " + certifier_credentials
@@ -481,7 +480,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
                                     {a11y_certifierReport.length
                                         ? a11y_certifierReport.map((certifier_report, i) => <li key={"certifier_report_" + i} title={certifier_report}>{
                                             // isURL() excludes the file: and data: URL protocols, as well as http://localhost but not http://127.0.0.1 or http(s)://IP:PORT more generally (note that ftp: is accepted)
-                                            certifier_report && isURL(certifier_report) ? <a title={certifier_report} onClick={async (e) => { e.preventDefault(); if (certifier_report && /^https?:\/\//.test(certifier_report)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await shell.openExternal(certifier_report); } }} href={certifier_report}>
+                                            certifier_report && isURL(certifier_report) ? <a title={certifier_report} onClick={async (e) => { e.preventDefault(); if (certifier_report && /^https?:\/\//.test(certifier_report)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */ await window.electronApi.openExternal(certifier_report); } }} href={certifier_report}>
                                             {__("publ-a11y-display-guide.conformance.conformance-details-certifier-report.compact")}
                                         </a> : __("publ-a11y-display-guide.conformance.conformance-details-certifier-report.compact") + " " + certifier_report}</li>)
                                         : <></>}

--- a/src/renderer/common/components/dialog/publicationInfos/publicationInfoA11y.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/publicationInfoA11y.tsx
@@ -9,7 +9,6 @@
 // import * as stylesBookDetailsDialog from "readium-desktop/renderer/assets/styles/bookDetailsDialog.scss";
 // import * as stylePublication from "readium-desktop/renderer/assets/styles/publicationInfos.scss";
 
-// import { shell } from "electron";
 // import classNames from "classnames";
 // import debug_ from "debug";
 // import DOMPurify from "dompurify";
@@ -213,7 +212,7 @@
 //                             onClick={async (ev) => {
 //                                 ev.preventDefault(); // necessary because href, see comment above
 //                                 if (value && /^https?:\/\//.test(value)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-//                                     await shell.openExternal(value);
+//                                     await window.electronApi.openExternal(value);
 //                                 }
 //                             }}
 //                             href={value} title={value} aria-label={__("publication.accessibility.certifierReport")}>{__("publication.accessibility.certifierReport")}</a></li>;

--- a/src/renderer/common/components/toast/Toast.tsx
+++ b/src/renderer/common/components/toast/Toast.tsx
@@ -7,7 +7,6 @@
 
 import * as stylesToasts from "readium-desktop/renderer/assets/styles/components/toasts.scss";
 
-import { clipboard } from "electron";
 import classNames from "classnames";
 import * as React from "react";
 import { ToastType } from "readium-desktop/common/models/toast";
@@ -172,7 +171,7 @@ export class Toast extends React.Component<IProps, IState> {
                     onClick={() => {
                         const clipBoardType = "clipboard";
                         try {
-                            clipboard.writeText(this.props.message, clipBoardType);
+                            window.electronApi.clipboardWriteText(this.props.message, clipBoardType);
 
                             // https://www.electronjs.org/docs/latest/tutorial/notifications
                             new Notification(capitalizedAppName, {

--- a/src/renderer/common/keyboard.ts
+++ b/src/renderer/common/keyboard.ts
@@ -11,8 +11,6 @@ import {
     DEBUG_KEYBOARD, IKeyboardEvent, keyboardShortcutMatch, TKeyboardShortcut,
 } from "readium-desktop/common/keyboard";
 
-import { ipcRenderer } from "electron";
-
 type TDocument = typeof document;
 export interface TKeyboardDocument extends TDocument {
     _keyModifierShift: boolean;
@@ -182,7 +180,7 @@ export function ensureKeyboardListenerIsInstalled() {
     doc._keyModifierMeta = false;
     doc._keyModifierAlt = false;
 
-    ipcRenderer.on("window-focus", () => {
+    window.electronApi.ipcOn("window-focus", () => {
         if (DEBUG_KEYBOARD) {
             console.log("electron window FOCUS");
         }
@@ -191,7 +189,7 @@ export function ensureKeyboardListenerIsInstalled() {
         doc._keyModifierMeta = false;
         doc._keyModifierAlt = false;
     });
-    ipcRenderer.on("window-blur", () => {
+    window.electronApi.ipcOn("window-blur", () => {
         if (DEBUG_KEYBOARD) {
             console.log("electron window BLUR");
         }

--- a/src/renderer/common/logics/filePath.ts
+++ b/src/renderer/common/logics/filePath.ts
@@ -1,0 +1,8 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+export const getFilePath = (file: File): string => window.electronApi.getPathForFile(file);

--- a/src/renderer/common/redux/middleware/syncFactory.ts
+++ b/src/renderer/common/redux/middleware/syncFactory.ts
@@ -5,7 +5,6 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { ipcRenderer } from "electron";
 import { syncIpc } from "readium-desktop/common/ipc";
 import { ActionWithSender, SenderType } from "readium-desktop/common/models/sync";
 import { IRendererCommonRootState } from "readium-desktop/common/redux/states/rendererCommonRootState";
@@ -31,7 +30,7 @@ export function syncFactory(SYNCHRONIZABLE_ACTIONS: string[]) {
                 }
 
                 // Send this action to the main process
-                ipcRenderer.send(syncIpc.CHANNEL, {
+                window.electronApi.ipcSend(syncIpc.CHANNEL, {
                     type: syncIpc.EventType.RendererAction,
                     payload: {
                         action: ActionSerializer.serialize(action as ActionWithSender),

--- a/src/renderer/library/components/App.tsx
+++ b/src/renderer/library/components/App.tsx
@@ -12,7 +12,6 @@ import "reflect-metadata";
 import "readium-desktop/renderer/assets/styles/global.scss";
 import * as stylesInputs from "readium-desktop/renderer/assets/styles/components/inputs.scss";
 
-import { webUtils } from "electron";
 import classNames from "classnames";
 import { HistoryRouter } from "redux-first-history/rr6";
 import * as path from "path";
@@ -24,6 +23,7 @@ import { DialogTypeName } from "readium-desktop/common/models/dialog";
 import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
 import ToastManager from "readium-desktop/renderer/common/components/toast/ToastManager";
 import { ensureKeyboardListenerIsInstalled } from "readium-desktop/renderer/common/keyboard";
+import { getFilePath } from "readium-desktop/renderer/common/logics/filePath";
 import { TranslatorContext } from "readium-desktop/renderer/common/translator.context";
 import { apiAction } from "readium-desktop/renderer/library/apiAction";
 import DialogManager from "readium-desktop/renderer/library/components/dialog/DialogManager";
@@ -44,9 +44,7 @@ import { CustomizationProfileDialog } from "readium-desktop/renderer/common/comp
 // eslintxx-disable-next-line @typescript-eslint/no-unused-expressions
 // globalScssStyle.__LOAD_FILE_SELECTOR_NOT_USED_JUST_TO_TRIGGER_WEBPACK_SCSS_FILE__;
 
-import { shell } from "electron";
-
-(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? shell.openExternal(url) : Promise.resolve(); // needed after markdown marked parsing for sanitizing the external anchor href
+(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? window.electronApi.openExternal(url) : Promise.resolve(); // needed after markdown marked parsing for sanitizing the external anchor href
 
 export default class App extends React.Component<{}, undefined> {
 
@@ -63,7 +61,7 @@ export default class App extends React.Component<{}, undefined> {
         const files = Array.from((event as React.DragEvent<HTMLElement>).dataTransfer.files);
         // console.log("getFiles: " + files.length);
         // console.log("getFile: " + files[0]);
-        // const absolutePath = webUtils.getPathForFile(files[0]);
+        // const absolutePath = getFilePath(files[0]);
         // console.log("absolutePath zz: " + absolutePath);
         return files;
     };
@@ -78,8 +76,8 @@ export default class App extends React.Component<{}, undefined> {
             .filter(
                 (file) => {
                     // with drag-and-drop (unlike input@type=file) the File `path` property is equal to `name`!
-                    // const absolutePath = file.path ? file.path : webUtils.getPathForFile(file);
-                    const absolutePath = webUtils.getPathForFile(file);
+                    // const absolutePath = file.path ? file.path : getFilePath(file);
+                    const absolutePath = getFilePath(file);
                     // console.log("absolutePath 1: " + absolutePath);
                     return absolutePath.replace(/\\/g, "/").toLowerCase().endsWith("/" + acceptedExtensionObject.nccHtml) || acceptedExtension(path.extname(absolutePath));
                 },
@@ -87,8 +85,8 @@ export default class App extends React.Component<{}, undefined> {
             .map(
                 (file) => {
                     // with drag-and-drop (unlike input@type=file) the File `path` property is equal to `name`!
-                    // const absolutePath = file.path ? file.path : webUtils.getPathForFile(file);
-                    const absolutePath = webUtils.getPathForFile(file);
+                    // const absolutePath = file.path ? file.path : getFilePath(file);
+                    const absolutePath = getFilePath(file);
                     // console.log("absolutePath 2: " + absolutePath);
                     return {
                         name: file.name,
@@ -100,8 +98,8 @@ export default class App extends React.Component<{}, undefined> {
         if (filez.length === 0) {
             const file = acceptedFiles[0];
             // with drag-and-drop (unlike input@type=file) the File `path` property is equal to `name`!
-            // const absolutePath = file.path ? file.path : webUtils.getPathForFile(file);
-            const absolutePath = webUtils.getPathForFile(file);
+            // const absolutePath = file.path ? file.path : getFilePath(file);
+            const absolutePath = getFilePath(file);
             // console.log("absolutePath 3: " + absolutePath);
 
 
@@ -187,7 +185,7 @@ export default class App extends React.Component<{}, undefined> {
             //       console.log(ev.dataTransfer.files[0]);
             //       console.log(ev.dataTransfer.files[0].name);
             //       console.log(ev.dataTransfer.files[0].path);
-            //       console.log(require("electron").webUtils.getPathForFile(ev.dataTransfer.files[0]));
+            //       console.log(getFilePath(ev.dataTransfer.files[0]));
             //   });`;
             //   if (!document.getElementById("jsdrop")) {
             //   const eljs = document.createElement("script");

--- a/src/renderer/library/components/Wizard.tsx
+++ b/src/renderer/library/components/Wizard.tsx
@@ -33,7 +33,6 @@ import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import * as CheckIcon from "readium-desktop/renderer/assets/icons/singlecheck-icon.svg";
 import * as LinkIcon from "readium-desktop/renderer/assets/icons/link-icon.svg";
-import { shell } from "electron";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
 
 
@@ -171,7 +170,7 @@ export const WizardModal = () => {
                                                     ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                                     const href = "https://www.thoriumreader.com";
                                                     if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                                        await shell.openExternal(href);
+                                                        await window.electronApi.openExternal(href);
                                                     }
                                                 }}>
                                                 🌐 {__("wizard.resources.website", { url: "https://www.thoriumreader.com" })}
@@ -182,7 +181,7 @@ export const WizardModal = () => {
                                                     ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                                     const href = "https://discord.gg/2GnubQbE";
                                                     if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                                        await shell.openExternal(href);
+                                                        await window.electronApi.openExternal(href);
                                                     }
                                                 }}>
                                                 💬 {__("wizard.resources.discord", { url: "https://discord.gg/2GnubQbE" })}

--- a/src/renderer/library/components/catalog/AboutThoriumButton.tsx
+++ b/src/renderer/library/components/catalog/AboutThoriumButton.tsx
@@ -8,7 +8,6 @@
 import * as stylesFooter from "readium-desktop/renderer/assets/styles/components/aboutFooter.scss";
 import * as stylesGlobal from "readium-desktop/renderer/assets/styles/global.scss";
 
-import { shell } from "electron";
 // import * as path from "path";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -87,13 +86,13 @@ class AboutThoriumButton extends React.Component<IProps, IState> {
                                 ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                 this.setState({ versionInfo : false });
                                 if (this.props.newVersionURL && /^https?:\/\//.test(this.props.newVersionURL)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                    await shell.openExternal(this.props.newVersionURL);
+                                    await window.electronApi.openExternal(this.props.newVersionURL);
                                 }
                             }}>{`${this.props.__("app.update.message")}`}</a> <span>(v{this.props.newVersion})</span></p>
                         </div>
                         {/* <button onClick={async () => {
                             this.setState({ versionInfo : false });
-                            await shell.openExternal(this.props.newVersionURL);
+                            await window.electronApi.openExternal(this.props.newVersionURL);
                         }}>
                             {this.props.__("app.session.exit.askBox.button.yes")}
                         </button>
@@ -123,7 +122,7 @@ class AboutThoriumButton extends React.Component<IProps, IState> {
                                 ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                 const href = `https://thorium.edrlab.org/?lang=${locale}&v=${app_version}`;
                                 if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                    await shell.openExternal(href);
+                                    await window.electronApi.openExternal(href);
                                 }
                             }}
                         tabIndex={0}>{__("catalog.about.title", { appName: capitalizedAppName })}</a>

--- a/src/renderer/library/components/dialog/ApiappAddForm.tsx
+++ b/src/renderer/library/components/dialog/ApiappAddForm.tsx
@@ -10,7 +10,6 @@ import * as stylesInputs from "readium-desktop/renderer/assets/styles/components
 import * as stylesModals from "readium-desktop/renderer/assets/styles/components/modals.scss";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
 
-import { shell } from "electron";
 import * as React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import * as QuitIcon from "readium-desktop/renderer/assets/icons/baseline-close-24px.svg";
@@ -117,7 +116,7 @@ export const ApiappHowDoesItWorkInfoBox = () => {
                             ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                             const href = "https://thorium.edrlab.org/";
                             if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                await shell.openExternal(href);
+                                await window.electronApi.openExternal(href);
                             }
                         }}>
                         {__("apiapp.documentation")}

--- a/src/renderer/library/components/dialog/LcpAuthentication.tsx
+++ b/src/renderer/library/components/dialog/LcpAuthentication.tsx
@@ -10,7 +10,6 @@ import * as stylesButtons from "readium-desktop/renderer/assets/styles/component
 import * as stylesModals from "readium-desktop/renderer/assets/styles/components/modals.scss";
 import * as stylesCatalogs from "readium-desktop/renderer/assets/styles/components/catalogs.scss";
 
-import { shell } from "electron";
 import * as React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { connect } from "react-redux";
@@ -147,7 +146,7 @@ export class LCPAuthentication extends React.Component<IProps, IState> {
                                     onClick={async (ev) => {
                                         ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                         if (this.props.urlHint.href && /^https?:\/\//.test(this.props.urlHint.href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                            await shell.openExternal(this.props.urlHint.href);
+                                            await window.electronApi.openExternal(this.props.urlHint.href);
                                         }
                                     }} className={stylesModals.urlHint}>
                                     {this.props.urlHint.title || __("library.lcp.urlHint")}
@@ -169,7 +168,7 @@ export class LCPAuthentication extends React.Component<IProps, IState> {
                                         ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                                         const href = "https://www.edrlab.org/readium-lcp/";
                                         if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                                            await shell.openExternal(href);
+                                            await window.electronApi.openExternal(href);
                                         }
                                     }}>
                                     {__("library.lcp.whatIsLcpInfoDetailsLink")}

--- a/src/renderer/library/components/dialog/OpdsFeedAddForm.tsx
+++ b/src/renderer/library/components/dialog/OpdsFeedAddForm.tsx
@@ -10,7 +10,6 @@ import * as stylesInputs from "readium-desktop/renderer/assets/styles/components
 import * as stylesModals from "readium-desktop/renderer/assets/styles/components/modals.scss";
 import * as stylesCatalogs from "readium-desktop/renderer/assets/styles/components/catalogs.scss";
 
-import { shell } from "electron";
 import * as React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import SVG from "readium-desktop/renderer/common/components/SVG";
@@ -50,7 +49,7 @@ export const OpdsFeedHowDoesItWorksInfoBox = () => {
                         ev.preventDefault(); // necessary because href="", CSS must also ensure hyperlink visited style
                         const href = "https://opds.io/";
                         if (href && /^https?:\/\//.test(href)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                            await shell.openExternal(href);
+                            await window.electronApi.openExternal(href);
                         }
                     }}>
                     {__("opds.documentation")}

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -87,7 +87,6 @@ import { keyboardShortcutsMatch } from "readium-desktop/common/keyboard";
 import {
     ensureKeyboardListenerIsInstalled, registerKeyboardListener, unregisterKeyboardListener,
 } from "readium-desktop/renderer/common/keyboard";
-import { ipcRenderer } from "electron";
 import PublicationCard from "../publication/PublicationCard";
 import classNames from "classnames";
 import * as Popover from "@radix-ui/react-popover";
@@ -161,13 +160,13 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
 
     public componentDidMount() {
 
-        ipcRenderer.on("accessibility-support-changed", this.accessibilitySupportChanged);
+        window.electronApi.ipcOn("accessibility-support-changed", this.accessibilitySupportChanged);
 
         // note that "@r2-navigator-js/electron/main/browser-window-tracker"
         // uses "accessibility-support-changed" instead of "accessibility-support-query",
         // so there is no duplicate event handler.
-        console.log("componentDidMount() ipcRenderer.send - accessibility-support-query");
-        ipcRenderer.send("accessibility-support-query");
+        console.log("componentDidMount() electronApi.ipcSend - accessibility-support-query");
+        window.electronApi.ipcSend("accessibility-support-query");
 
         ensureKeyboardListenerIsInstalled();
         this.registerAllKeyboardListeners();
@@ -200,7 +199,7 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
     }
 
     public componentWillUnmount() {
-        ipcRenderer.off("accessibility-support-changed", this.accessibilitySupportChanged);
+        window.electronApi.ipcOff("accessibility-support-changed", this.accessibilitySupportChanged);
 
         this.unregisterAllKeyboardListeners();
 
@@ -214,8 +213,8 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
         // note that "@r2-navigator-js/electron/main/browser-window-tracker"
         // uses "accessibility-support-changed" instead of "accessibility-support-query",
         // so there is no duplicate event handler.
-        console.log("componentDidUpdate() ipcRenderer.send - accessibility-support-query");
-        ipcRenderer.send("accessibility-support-query");
+        console.log("componentDidUpdate() electronApi.ipcSend - accessibility-support-query");
+        window.electronApi.ipcSend("accessibility-support-query");
 
         if (!keyboardShortcutsMatch(oldProps.keyboardShortcuts, this.props.keyboardShortcuts)) {
             this.unregisterAllKeyboardListeners();
@@ -260,8 +259,8 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
         );
     }
 
-    private accessibilitySupportChanged = (_e: Electron.IpcRendererEvent, accessibilitySupportEnabled: boolean) => {
-        console.log("ALLPUBPAGES.tsx ipcRenderer.on - accessibility-support-changed: ", accessibilitySupportEnabled);
+    private accessibilitySupportChanged = (_e: undefined, accessibilitySupportEnabled: boolean) => {
+        console.log("ALLPUBPAGES.tsx electronApi.ipcOn - accessibility-support-changed: ", accessibilitySupportEnabled);
 
         // prevents infinite loop via componentDidUpdate()
         if (accessibilitySupportEnabled !== this.state.accessibilitySupportEnabled) {

--- a/src/renderer/library/index_library.ts
+++ b/src/renderer/library/index_library.ts
@@ -5,7 +5,6 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { ipcRenderer } from "electron";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { syncIpc, winIpc } from "readium-desktop/common/ipc";
@@ -67,7 +66,7 @@ initGlobalConverters_GENERIC();
 //     }, 5000);
 // }
 
-ipcRenderer.on(winIpc.CHANNEL, (_0: any, data: winIpc.EventPayload) => {
+window.electronApi.ipcOn(winIpc.CHANNEL, (_0: undefined, data: winIpc.EventPayload) => {
     switch (data.type) {
         case winIpc.EventType.IdResponse:
             // Initialize window
@@ -99,7 +98,7 @@ ipcRenderer.on(winIpc.CHANNEL, (_0: any, data: winIpc.EventPayload) => {
 });
 
 // Request main process for a new id
-ipcRenderer.on(syncIpc.CHANNEL, (_0: any, data: syncIpc.EventPayload) => {
+window.electronApi.ipcOn(syncIpc.CHANNEL, (_0: undefined, data: syncIpc.EventPayload) => {
 
     switch (data.type) {
         case syncIpc.EventType.MainAction:
@@ -131,7 +130,7 @@ if (__TH__IS_DEV__) {
     //     throw new Error("Test exception 1 ...");
     // }, 1000);
 
-    ipcRenderer.once("AXE_A11Y", () => {
+    window.electronApi.ipcOnce("AXE_A11Y", () => {
         // https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure
         const config = {
             // rules: [

--- a/src/renderer/library/opds/handleLink.ts
+++ b/src/renderer/library/opds/handleLink.ts
@@ -5,7 +5,6 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { shell } from "electron";
 import { dialogActions } from "readium-desktop/common/redux/actions";
 import { IOpdsLinkView } from "readium-desktop/common/views/opds";
 import { decodeB64 } from "readium-desktop/renderer/common/logics/base64";
@@ -55,7 +54,7 @@ export const dispatchOpdsLink =
                 }, location.state as IRouterLocationState);
             } else {
                 if (ln.url && /^https?:\/\//.test(ln.url)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-                    await shell.openExternal(ln.url);
+                    await window.electronApi.openExternal(ln.url);
                 }
             }
         };

--- a/src/renderer/preload/library.ts
+++ b/src/renderer/preload/library.ts
@@ -1,0 +1,48 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { clipboard, contextBridge, ipcRenderer, shell, webUtils } from "electron";
+
+window.addEventListener("error", (event) => {
+    console.error("[LibraryWindow:error]", event.message, event.filename, event.lineno, event.colno, event.error);
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+    console.error("[LibraryWindow:unhandledrejection]", event.reason);
+});
+
+type TIpcRendererListener = (_event: undefined, ...args: any[]) => void;
+
+const ipcRendererListenerMap = new WeakMap<TIpcRendererListener, (...args: any[]) => void>();
+
+const electronApi = {
+    getPathForFile: (file: File): string => webUtils.getPathForFile(file),
+    openExternal: (url: string): Promise<void> => shell.openExternal(url),
+    clipboardWriteText: (text: string, type?: "selection" | "clipboard"): void => clipboard.writeText(text, type),
+    ipcSend: (channel: string, ...args: any[]): void => ipcRenderer.send(channel, ...args),
+    ipcOn: (channel: string, listener: TIpcRendererListener): void => {
+        const wrappedListener = (_event: Electron.IpcRendererEvent, ...args: any[]) => listener(undefined, ...args);
+        ipcRendererListenerMap.set(listener, wrappedListener);
+        ipcRenderer.on(channel, wrappedListener);
+    },
+    ipcOnce: (channel: string, listener: TIpcRendererListener): void => {
+        ipcRenderer.once(channel, (_event: Electron.IpcRendererEvent, ...args: any[]) => listener(undefined, ...args));
+    },
+    ipcOff: (channel: string, listener: TIpcRendererListener): void => {
+        const wrappedListener = ipcRendererListenerMap.get(listener);
+        if (wrappedListener) {
+            ipcRenderer.off(channel, wrappedListener);
+            ipcRendererListenerMap.delete(listener);
+        }
+    },
+};
+
+if (process.contextIsolated) {
+    contextBridge.exposeInMainWorld("electronApi", electronApi);
+} else {
+    (window as any).electronApi = electronApi;
+}

--- a/src/renderer/preload/library.ts
+++ b/src/renderer/preload/library.ts
@@ -7,6 +7,8 @@
 
 import { clipboard, contextBridge, ipcRenderer, shell, webUtils } from "electron";
 
+declare const __non_webpack_require__: (moduleName: string) => unknown;
+
 window.addEventListener("error", (event) => {
     console.error("[LibraryWindow:error]", event.message, event.filename, event.lineno, event.colno, event.error);
 });
@@ -19,7 +21,16 @@ type TIpcRendererListener = (_event: undefined, ...args: any[]) => void;
 
 const ipcRendererListenerMap = new WeakMap<TIpcRendererListener, (...args: any[]) => void>();
 
+const requireExternal = (moduleName: string) => {
+
+    // no separation between main and renderer process on src/r2-xxx files
+    console.log("[contextBridge.require:call]", moduleName);
+};
+
 const electronApi = {
+    base64Decode: (value: string): string => Buffer.from(value, "base64").toString("utf8"),
+    base64Encode: (value: string): string => Buffer.from(value, "utf8").toString("base64"),
+    cwd: (): string => process.cwd(),
     getPathForFile: (file: File): string => webUtils.getPathForFile(file),
     openExternal: (url: string): Promise<void> => shell.openExternal(url),
     clipboardWriteText: (text: string, type?: "selection" | "clipboard"): void => clipboard.writeText(text, type),
@@ -39,10 +50,13 @@ const electronApi = {
             ipcRendererListenerMap.delete(listener);
         }
     },
+    requireExternal,
 };
 
 if (process.contextIsolated) {
     contextBridge.exposeInMainWorld("electronApi", electronApi);
+    contextBridge.exposeInMainWorld("require", requireExternal);
 } else {
     (window as any).electronApi = electronApi;
+    (window as any).require = requireExternal;
 }

--- a/src/renderer/reader/components/ImageClickManagerViewerOnly.tsx
+++ b/src/renderer/reader/components/ImageClickManagerViewerOnly.tsx
@@ -119,7 +119,7 @@ export const ImageClickManagerImgViewerOnly: React.FC = () => {
                                 <TransformComponent wrapperStyle={{ display: "flex", width: "100%", height: "100%", minHeight: "350px", flex: "1", position: "relative" }} >
                                     <img
                                         style={{ height: "100%", width: "100%", maxHeight: "calc(100vh - 250px)", backgroundColor: "white", color: "black", fill: "currentcolor", stroke: "currentcolor" }}
-                                        src={isSVGFragment ? ("data:image/svg+xml;base64," + Buffer.from(HTMLImgSrc_SVGImageHref_SVGFragmentMarkup).toString("base64")) : HTMLImgSrc_SVGImageHref_SVGFragmentMarkup}
+                                        src={isSVGFragment ? ("data:image/svg+xml;base64," + window.electronApi.base64Encode(HTMLImgSrc_SVGImageHref_SVGFragmentMarkup)) : HTMLImgSrc_SVGImageHref_SVGFragmentMarkup}
                                         alt={altAttributeOf_HTMLImg_SVGImage_SVGFragment}
                                         title={titleAttributeOf_HTMLImg_SVGImage_SVGFragment}
                                         aria-label={ariaLabelAttributeOf_HTMLImg_SVGImage_SVGFragment}

--- a/src/renderer/reader/components/Reader.tsx
+++ b/src/renderer/reader/components/Reader.tsx
@@ -12,7 +12,6 @@ import debug_ from "debug";
 import * as stylesReader from "readium-desktop/renderer/assets/styles/reader-app.scss";
 import * as stylesReaderFooter from "readium-desktop/renderer/assets/styles/components/readerFooter.scss";
 import { fixedLayoutZoomPercent } from "@r2-navigator-js/electron/renderer/dom";
-import { ipcRenderer } from "electron";
 import classNames from "classnames";
 import divinaPlayer from "divina-player-js";
 import * as path from "path";
@@ -135,10 +134,9 @@ interface IWindowHistory extends History {
 const windowHistory = window.history as IWindowHistory;
 
 // see r2-navigator-js src/electron/renderer/location.ts
-ipcRenderer.on(R2_EVENT_LINK, (event: Electron.IpcRendererEvent, payload: IEventPayload_R2_EVENT_LINK) => {
-    console.log("R2_EVENT_LINK (ipcRenderer.on READER.TSX)");
-    // see ipcRenderer.emit(R2_EVENT_LINK...) special case!
-    const pay = (!payload && (event as unknown as IEventPayload_R2_EVENT_LINK).url) ? event as unknown as IEventPayload_R2_EVENT_LINK : payload;
+window.electronApi.ipcOn(R2_EVENT_LINK, (_event: undefined, payload: IEventPayload_R2_EVENT_LINK) => {
+    console.log("R2_EVENT_LINK (electronApi.ipcOn READER.TSX)");
+    const pay = payload;
     console.log(pay.url);
     handleLinkUrl_UpdateHistoryState(pay.url);
 });
@@ -445,13 +443,13 @@ class Reader extends React.Component<IProps, IState> {
     public async componentDidMount() {
         // navigatorTTSVoicesSetter(this.props.ttsVoices);
 
-        ipcRenderer.on("accessibility-support-changed", this.accessibilitySupportChanged);
+        window.electronApi.ipcOn("accessibility-support-changed", this.accessibilitySupportChanged);
 
         // note that "@r2-navigator-js/electron/main/browser-window-tracker"
         // uses "accessibility-support-changed" instead of "accessibility-support-query",
         // so there is no duplicate event handler.
-        console.log("componentDidMount() ipcRenderer.send - accessibility-support-query");
-        ipcRenderer.send("accessibility-support-query");
+        console.log("componentDidMount() electronApi.ipcSend - accessibility-support-query");
+        window.electronApi.ipcSend("accessibility-support-query");
 
         // if (this.mainElRef?.current) {
         //     this.resizeObserver.observe(this.mainElRef.current);
@@ -793,7 +791,7 @@ class Reader extends React.Component<IProps, IState> {
     }
 
     public componentWillUnmount() {
-        ipcRenderer.off("accessibility-support-changed", this.accessibilitySupportChanged);
+        window.electronApi.ipcOff("accessibility-support-changed", this.accessibilitySupportChanged);
 
         // if (this.mainElRef?.current) {
         //     this.resizeObserver.unobserve(this.mainElRef.current); // publication_viewport
@@ -1517,8 +1515,8 @@ class Reader extends React.Component<IProps, IState> {
         r2HandleLinkUrl(url);
     };
 
-    private accessibilitySupportChanged = (_e: Electron.IpcRendererEvent, accessibilitySupportEnabled: boolean) => {
-        console.log("READER.tsx ipcRenderer.on - accessibility-support-changed: ", accessibilitySupportEnabled);
+    private accessibilitySupportChanged = (_e: undefined, accessibilitySupportEnabled: boolean) => {
+        console.log("READER.tsx electronApi.ipcOn - accessibility-support-changed: ", accessibilitySupportEnabled);
 
         // prevents infinite loop via componentDidUpdate()
         if (accessibilitySupportEnabled !== this.state.accessibilitySupportEnabled) {
@@ -2613,7 +2611,7 @@ class Reader extends React.Component<IProps, IState> {
                 } else {
                     // dev/debug mode (with WebPack HMR Hot Module Reload HTTP server)
                     // preloadPath = "file://" + path.normalize(path.join(process.cwd(), "node_modules", preloadPath)).replace(/\\/g, "/");
-                    preloadPath = "file://" + path.normalize(path.join(process.cwd(), "dist", "preload.js")).replace(/\\/g, "/");
+                    preloadPath = "file://" + path.normalize(path.join(window.electronApi.cwd(), "dist", "preload.js")).replace(/\\/g, "/");
                 }
             }
 
@@ -3299,9 +3297,9 @@ const mapStateToProps = (state: IReaderRootState, _props: IBaseProps) => {
     // const manifestUrlR2Protocol = state.reader.info.manifestUrlR2Protocol; // httpsr2:// "CustomScheme"
     const manifestUrlHttp = state.reader.info.manifestUrlHttp.startsWith(READIUM2_ELECTRON_HTTP_PROTOCOL) ? convertCustomSchemeToHttpUrl(state.reader.info.manifestUrlHttp) : state.reader.info.manifestUrlHttp;
     const pubPathBase64 = decodeURIComponent(manifestUrlHttp.replace(/\/manifest.json$/, "").replace(`${URL_PROTOCOL_THORIUMHTTPS}://${URL_HOST_COMMON}/${URL_PATH_PREFIX_PUB}/`, ""));
-    const pubPath = Buffer.from(pubPathBase64, "base64").toString();
+    const pubPath = window.electronApi.base64Decode(pubPathBase64);
 
-    const manifestUrlR2Protocol_pub_id_not_path = convertHttpUrlToCustomScheme(`${URL_PROTOCOL_THORIUMHTTPS}://${URL_HOST_COMMON}/${URL_PATH_PREFIX_PUB}/${encodeURIComponent_RFC3986(Buffer.from(state.reader.info.publicationIdentifier || state.reader.info.publicationView.identifier, "utf8").toString("base64"))}/manifest.json`);
+    const manifestUrlR2Protocol_pub_id_not_path = convertHttpUrlToCustomScheme(`${URL_PROTOCOL_THORIUMHTTPS}://${URL_HOST_COMMON}/${URL_PATH_PREFIX_PUB}/${encodeURIComponent_RFC3986(window.electronApi.base64Encode(state.reader.info.publicationIdentifier || state.reader.info.publicationView.identifier))}/manifest.json`);
 
     debug("manifestUrlR2Protocol_pub_id_not_path", manifestUrlR2Protocol_pub_id_not_path);
     debug("state.reader.info.manifestUrlR2Protocol", state.reader.info.manifestUrlR2Protocol);

--- a/src/renderer/reader/components/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu.tsx
@@ -98,7 +98,6 @@ import { EDrawType, INoteState, noteColorCodeToColorTranslatorKeySet, TDrawType 
 
 import DOMPurify from "dompurify";
 
-import { shell } from "electron";
 import { exportAnnotationSet } from "readium-desktop/renderer/common/redux/sagas/readiumAnnotation/export";
 import { getSaga } from "../createStore";
 import { clone } from "ramda";
@@ -106,7 +105,7 @@ import { marked } from "readium-desktop/renderer/common/marked/marked";
 import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
 import { trimNormaliseWhitespaceAndCollapse } from "readium-desktop/common/string";
 
-(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? shell.openExternal(url) : Promise.resolve(); // needed after markdown marked parsing for sanitizing the external anchor href
+(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? window.electronApi.openExternal(url) : Promise.resolve(); // needed after markdown marked parsing for sanitizing the external anchor href
 
 // console.log(window);
 

--- a/src/renderer/reader/index_reader.ts
+++ b/src/renderer/reader/index_reader.ts
@@ -5,7 +5,6 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { ipcRenderer } from "electron";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { readerIpc } from "readium-desktop/common/ipc";
@@ -46,8 +45,8 @@ initGlobalConverters_GENERIC();
 //     }, 5000);
 // }
 
-ipcRenderer.on(readerIpc.CHANNEL,
-    (_0: any, data: readerIpc.EventPayload) => {
+window.electronApi.ipcOn(readerIpc.CHANNEL,
+    (_0: undefined, data: readerIpc.EventPayload) => {
         switch (data.type) {
             case readerIpc.EventType.request:
                 // Initialize window
@@ -104,7 +103,7 @@ ipcRenderer.on(readerIpc.CHANNEL,
     });
 
 if (__TH__IS_DEV__) {
-    ipcRenderer.once("AXE_A11Y", () => {
+    window.electronApi.ipcOnce("AXE_A11Y", () => {
         const publicationViewport = document.getElementById("publication_viewport");
         let parent: Element | undefined;
         if (publicationViewport) {

--- a/src/renderer/reader/pdf/driver.ts
+++ b/src/renderer/reader/pdf/driver.ts
@@ -5,7 +5,6 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END
 
-import { ipcRenderer } from "electron";
 import * as path from "path";
 import {
     _DIST_RELATIVE_URL, _RENDERER_PDF_WEBVIEW_BASE_URL,
@@ -100,7 +99,7 @@ export function pdfMount(
 
     const pdfData = data;
     const pdfDataString = JSON.stringify(pdfData);
-    const b64EncodedPdfData = Buffer.from(pdfDataString, "utf8").toString("base64");
+    const b64EncodedPdfData = window.electronApi.base64Encode(pdfDataString);
 
     const webview = document.createElement("webview");
 
@@ -111,7 +110,7 @@ export function pdfMount(
 
     //     console.log("will-navigate event:", event.type, event.url);
     //     if (event.url && /^https?:\/\//.test(event.url)) { /* ignores file: mailto: data: thoriumhttps: httpsr2: thorium: opds: etc. */
-    //         await shell.openExternal(event.url);
+    //         await window.electronApi.openExternal(event.url);
     //     }
     // };
     // webview.addEventListener("will-navigate", handleRedirect);
@@ -152,7 +151,7 @@ export function pdfMount(
             // }
         } else {
             // dev/debug mode (with WebPack HMR Hot Module Reload HTTP server)
-            preloadPath = "file://" + path.normalize(path.join(process.cwd(), "dist", PDFPATH));
+            preloadPath = "file://" + path.normalize(path.join(window.electronApi.cwd(), "dist", PDFPATH));
             preloadPath = preloadPath.replace(/\\/g, "/");
         }
     }
@@ -180,6 +179,6 @@ const webviewDomReadyDebugger = (ev: DOMEvent) => {
     webview.clearHistory();
 
     if (__TH__IS_DEV__) {
-        ipcRenderer.send(CONTEXT_MENU_SETUP, webview.getWebContentsId());
+        window.electronApi.ipcSend(CONTEXT_MENU_SETUP, webview.getWebContentsId());
     }
 };

--- a/src/renderer/reader/redux/sagas/customization.ts
+++ b/src/renderer/reader/redux/sagas/customization.ts
@@ -61,8 +61,8 @@ function* profileActivating(id: string): SagaGenerator<void> {
         return ;
     }
 
-    const baseUrl = `${URL_PROTOCOL_THORIUMHTTPS}://${URL_HOST_COMMON}/${URL_PATH_PREFIX_CUSTOMPROFILEZIP}/${encodeURIComponent_RFC3986(Buffer.from(id).toString("base64"))}/`;
-    const manifestURL = baseUrl + encodeURIComponent_RFC3986(Buffer.from("manifest.json").toString("base64"));
+    const baseUrl = `${URL_PROTOCOL_THORIUMHTTPS}://${URL_HOST_COMMON}/${URL_PATH_PREFIX_CUSTOMPROFILEZIP}/${encodeURIComponent_RFC3986(window.electronApi.base64Encode(id))}/`;
+    const manifestURL = baseUrl + encodeURIComponent_RFC3986(window.electronApi.base64Encode("manifest.json"));
     const response = yield* callTyped(() => fetch(manifestURL));
     if (response.status !== 200) {
         debug("ERORR in manifest request", response);

--- a/src/renderer/reader/redux/sagas/ipc.ts
+++ b/src/renderer/reader/redux/sagas/ipc.ts
@@ -6,7 +6,6 @@
 // ==LICENSE-END=
 
 import debug_ from "debug";
-import { ipcRenderer } from "electron";
 import { syncIpc } from "readium-desktop/common/ipc";
 import { ActionWithSender } from "readium-desktop/common/models/sync";
 import { takeSpawnEveryChannel } from "readium-desktop/common/redux/sagas/takeSpawnEvery";
@@ -25,17 +24,17 @@ function getIpcSyncChannel() {
     const channel = eventChannel<syncIpc.EventPayload>(
         (emit) => {
 
-            const handler = (_0: any, data: syncIpc.EventPayload) => {
+            const handler = (_0: undefined, data: syncIpc.EventPayload) => {
 
                 if (data.type === syncIpc.EventType.MainAction) {
                     emit(data);
                 }
             };
 
-            ipcRenderer.on(syncIpc.CHANNEL, handler);
+            window.electronApi.ipcOn(syncIpc.CHANNEL, handler);
 
             return () => {
-                ipcRenderer.removeListener(syncIpc.CHANNEL, handler);
+                window.electronApi.ipcOff(syncIpc.CHANNEL, handler);
             };
         },
         buffers.fixed(10),

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -49,6 +49,18 @@ declare const __TH__IS_CI__: boolean;
 declare const __TH__CUSTOMIZATION_PROFILE_PRIVATE_KEY__: string;
 // declare const __TH__CUSTOMIZATION_PROFILE_PUB_KEY__: string;
 
+interface Window {
+    electronApi: {
+        clipboardWriteText: (text: string, type?: "selection" | "clipboard") => void;
+        getPathForFile: (file: File) => string;
+        ipcOff: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
+        ipcOn: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
+        ipcOnce: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
+        ipcSend: (channel: string, ...args: any[]) => void;
+        openExternal: (url: string) => Promise<void>;
+    };
+}
+
 declare module "bindings";
 declare module "debug/src/node";
 declare module "debug/src/browser";

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -51,13 +51,17 @@ declare const __TH__CUSTOMIZATION_PROFILE_PRIVATE_KEY__: string;
 
 interface Window {
     electronApi: {
+        base64Decode: (value: string) => string;
+        base64Encode: (value: string) => string;
         clipboardWriteText: (text: string, type?: "selection" | "clipboard") => void;
+        cwd: () => string;
         getPathForFile: (file: File) => string;
         ipcOff: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
         ipcOn: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
         ipcOnce: (channel: string, listener: (_event: undefined, ...args: any[]) => void) => void;
         ipcSend: (channel: string, ...args: any[]) => void;
         openExternal: (url: string) => Promise<void>;
+        requireExternal: (moduleName: string) => unknown;
     };
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const libraryConfig = require("./webpack.config.renderer-library");
 const readerConfig = require("./webpack.config.renderer-reader");
 const pdfConfig = require("./webpack.config.renderer-pdf");
 const pdfExtractConfig = require("./webpack.config.renderer-pdf-extract");
+const preloadLibraryConfig = require("./webpack.config.renderer-preload-library");
 const preloadConfig = require("./webpack.config.preload");
 
 // console.log("-------------------- MAIN config:");
@@ -22,4 +23,4 @@ const preloadConfig = require("./webpack.config.preload");
 // console.log("-------------------- PRELOAD config:");
 // console.log(util.inspect(preloadConfig, { colors: true, depth: null, compact: false, customInspect: true }));
 
-module.exports = [mainConfig, libraryConfig, readerConfig, pdfConfig, pdfExtractConfig, preloadConfig];
+module.exports = [mainConfig, libraryConfig, readerConfig, pdfConfig, pdfExtractConfig, preloadLibraryConfig, preloadConfig];

--- a/webpack.config.renderer-preload-library.js
+++ b/webpack.config.renderer-preload-library.js
@@ -48,7 +48,7 @@ if (nodeEnv !== "production") {
         // allowlist: ["marked", "pdf.js", "readium-speech", "@github/paste-markdown", "yargs", "timeout-signal", "nanoid", "normalize-url", "node-fetch", "data-uri-to-buffer", /^fetch-blob/, /^formdata-polyfill/],
         importType: function (moduleName) {
             if (!_externalsCache.has(moduleName)) {
-                console.log(`WEBPACK EXTERNAL (PDF EXTRACT): [${moduleName}]`);
+                console.log(`WEBPACK EXTERNAL (PRELOAD-LIBRARY): [${moduleName}]`);
             }
             _externalsCache.add(moduleName);
             // if (moduleName === "normalize-url") {
@@ -63,7 +63,7 @@ if (nodeEnv !== "production") {
             const isRDesk = request.indexOf("readium-desktop/") === 0;
             if (isRDesk) {
                 if (!_externalsCache.has(request)) {
-                    console.log(`WEBPACK EXTERNAL (PDF EXTRACT): READIUM-DESKTOP [${request}]`);
+                    console.log(`WEBPACK EXTERNAL (PRELOAD-LIBRARY): READIUM-DESKTOP [${request}]`);
                 }
                 _externalsCache.add(request);
 

--- a/webpack.config.renderer-preload-library.js
+++ b/webpack.config.renderer-preload-library.js
@@ -1,0 +1,262 @@
+const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+const StatoscopeWebpackPlugin = require('@statoscope/webpack-plugin').default;
+
+const TerserPlugin = require("terser-webpack-plugin");
+
+const path = require("path");
+const webpack = require("webpack");
+
+const preprocessorDirectives = require("./webpack.config-preprocessor-directives");
+
+const _src = path.resolve(__dirname, "src");
+const aliases = {
+    "readium-desktop": _src,
+
+    "@r2-utils-js": path.join(_src, "r2-xxx-js/r2-utils-js"),
+    "@r2-lcp-js": path.join(_src, "r2-xxx-js/r2-lcp-js"),
+    "@r2-opds-js": path.join(_src, "r2-xxx-js/r2-opds-js"),
+    "@r2-shared-js": path.join(_src, "r2-xxx-js/r2-shared-js"),
+    "@r2-streamer-js": path.join(_src, "r2-xxx-js/r2-streamer-js"),
+    "@r2-navigator-js": path.join(_src, "r2-xxx-js/r2-navigator-js"),
+};
+
+// Get node environment
+const nodeEnv = process.env.NODE_ENV || "development";
+console.log(`PDF EXTRACT nodeEnv: ${nodeEnv}`);
+
+// https://github.com/edrlab/thorium-reader/issues/1097#issuecomment-643406149
+const useLegacyTypeScriptLoader = process.env.USE_LEGACY_TYPESCRIPT_LOADER ? true : false;
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+ForkTsCheckerWebpackPlugin.prototype[require("util").inspect.custom] = (_depth, _options) => {
+    return "ForkTsCheckerWebpackPlugin";
+};
+const checkTypeScriptSkip =
+    nodeEnv !== "production" ? (process.env.SKIP_CHECK_TYPESCRIPT === "1" ? true : false) : false;
+let externals = {
+    bindings: "bindings",
+    "file-uri-to-path": "file-uri-to-path",
+    fsevents: "fsevents",
+    "electron-devtools-installer": "electron-devtools-installer",
+    "remote-redux-devtools": "remote-redux-devtools",
+    electron: "electron",
+    // yargs: "yargs",
+};
+const _externalsCache = new Set();
+if (nodeEnv !== "production") {
+    const nodeExternals = require("webpack-node-externals");
+    const neFunc = nodeExternals({
+        // allowlist: ["marked", "pdf.js", "readium-speech", "@github/paste-markdown", "yargs", "timeout-signal", "nanoid", "normalize-url", "node-fetch", "data-uri-to-buffer", /^fetch-blob/, /^formdata-polyfill/],
+        importType: function (moduleName) {
+            if (!_externalsCache.has(moduleName)) {
+                console.log(`WEBPACK EXTERNAL (PDF EXTRACT): [${moduleName}]`);
+            }
+            _externalsCache.add(moduleName);
+            // if (moduleName === "normalize-url") {
+            //     return "module normalize-url";
+            // }
+            return "commonjs " + moduleName;
+        },
+    });
+    externals = [
+        externals,
+        function ({ context, request, contextInfo, getResolve }, callback) {
+            const isRDesk = request.indexOf("readium-desktop/") === 0;
+            if (isRDesk) {
+                if (!_externalsCache.has(request)) {
+                    console.log(`WEBPACK EXTERNAL (PDF EXTRACT): READIUM-DESKTOP [${request}]`);
+                }
+                _externalsCache.add(request);
+
+                return callback();
+            }
+
+            const isRDeskR2 = request.indexOf("@r2-") === 0;
+            if (isRDeskR2) {
+                if (!_externalsCache.has(request)) {
+                    console.log(`WEBPACK EXTERNAL (MAIN): READIUM-DESKTOP @R2 [${request}]`);
+                }
+                _externalsCache.add(request);
+
+                return callback();
+            }
+
+            let request_ = request;
+            if (aliases) {
+                // const isR2 = /^r2-.+-js/.test(request);
+                // const isR2Alias = /^@r2-.+-js/.test(request);
+
+                const iSlash = request.indexOf("/");
+                const key = request.substr(0, iSlash >= 0 ? iSlash : request.length);
+                if (aliases[key]) {
+                    request_ = request.replace(key, aliases[key]);
+
+                    if (!_externalsCache.has(request)) {
+                        console.log(`WEBPACK EXTERNAL (PDF EXTRACT): ALIAS [${request}] => [${request_}]`);
+                    }
+                    _externalsCache.add(request);
+
+                    return callback(null, "commonjs " + request_);
+                }
+            }
+
+            neFunc(context, request, callback);
+        },
+    ];
+}
+
+console.log("WEBPACK externals (PDF EXTRACT):", "-".repeat(200));
+console.log(JSON.stringify(externals, null, "  "));
+////// EXTERNALS
+////// ================================
+
+let config = Object.assign(
+    {},
+    {
+        entry: "./src/renderer/preload/library.ts",
+        name: "renderer pdf extract webview index",
+        output: {
+            filename: "preload_library.js",
+            path: path.join(__dirname, "dist"),
+            // https://github.com/webpack/webpack/issues/1114
+            libraryTarget: "commonjs2", // commonjs-module
+        },
+        target: "electron-renderer",
+
+        mode: nodeEnv,
+
+        externalsPresets: { node: true },
+        // externals: externals,
+        // externalsType: "commonjs", // module, node-commonjs
+        experiments: {
+            outputModule: false, // module, node-commonjs
+        },
+
+        resolve: {
+            extensions: [".ts", ".tsx", ".js", ".jsx"],
+            alias: aliases,
+        },
+        stats: {
+            // warningsFilter: /export .* was not found in/,
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.tsx$/,
+                    loader: useLegacyTypeScriptLoader ? "awesome-typescript-loader" : "ts-loader",
+                    options: {
+                        transpileOnly: true, // checkTypeScriptSkip
+                        // compiler: "@typescript/native-preview",
+                    },
+                },
+                {
+                    test: /\.ts$/,
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: [],
+                                // sourceMaps: "inline",
+                                plugins: ["macros"],
+                            },
+                        },
+                        {
+                            loader: useLegacyTypeScriptLoader ? "awesome-typescript-loader" : "ts-loader",
+                            options: {
+                                transpileOnly: true, // checkTypeScriptSkip
+                                // compiler: "@typescript/native-preview",
+                            },
+                        },
+                    ],
+                },
+                {
+                    test: /\.(jsx?|tsx?)$/,
+                    use: [
+                        {
+                            loader: path.resolve("./scripts/webpack-loader-scope-checker.js"),
+                            options: {
+                                forbids: ["src/renderer/library", "src/main", "src/renderer/reader/components", "src/renderer/reader/redux", "src/common", "src/resources", "src/typings", "src/renderer/reader/common", "src/renderer/common"],
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+
+        plugins: [
+            preprocessorDirectives.definePlugin,
+        ],
+    },
+);
+
+if (checkTypeScriptSkip) {
+    // const GoTsCheckerWebpackPlugin = require("./scripts/go-ts-checker-webpack-plugin");
+    // config.plugins.push(
+    //     new GoTsCheckerWebpackPlugin({name: "PDF EXTRACT"}),
+    // );
+} else {
+    config.plugins.push(
+        new ForkTsCheckerWebpackPlugin({
+            // measureCompilationTime: true,
+        }),
+    );
+}
+
+if (nodeEnv !== "production") {
+} else {
+    config.optimization = {
+        ...(config.optimization || {}),
+        nodeEnv: false,
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                extractComments: false,
+                exclude: /MathJax/,
+                // parallel: 3,
+                terserOptions: {
+                    // sourceMap: nodeEnv !== "production" ? true : false,
+                    sourceMap: false,
+                    compress: {defaults:false, dead_code:true, booleans: true, passes: 1},
+                    mangle: false,
+                    output: {
+                        comments: false,
+                    },
+                },
+            }),
+        ],
+    };
+    // {
+    //     minimize: false,
+    // };
+
+    config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^devtron$/ }));
+    config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^@axe-core\/react$/ }));
+}
+
+if (process.env.ENABLE_WEBPACK_BUNDLE_STATS)
+config.plugins.push(
+new StatoscopeWebpackPlugin({
+    saveReportTo: './dist/STATOSCOPE_[name].html',
+    // saveStatsTo: './dist/STATOSCOPE_[name].json',
+    saveStatsTo: undefined,
+    normalizeStats: false,
+    saveOnlyStats: false,
+    disableReportCompression: true,
+    statsOptions: {},
+    additionalStats: [],
+    watchMode: false,
+    name: 'renderer-pdf-extract',
+    open: false,
+    compressor: false,
+}),
+new BundleAnalyzerPlugin({
+    analyzerMode: "disabled",
+    defaultSizes: "stat", // "parsed"
+    openAnalyzer: false,
+    generateStatsFile: true,
+    statsFilename: "stats_renderer-pdf-extract.json",
+    statsOptions: null,
+
+    excludeAssets: null,
+}));
+
+module.exports = config;


### PR DESCRIPTION
Fixes #111 



The current `src/r2-xxx` codebase does not have a separation between main and renderer process. Renderer bundles pull modules that require Electron/Node runtime access which makes `contextIsolation` / `nodeIntegration: false` migration strongly difficult !

for example:

```
[LibraryWindow:console-message] {
  "level": 1,
  "message": "[contextBridge.require:call] util",
  "line": 1,
  "sourceId": "C:\\Users\\plero\\Documents\\git\\thorium-reader\\release\\win-unpacked\\resources\\app.asar\\preload_library.js"
}
[LibraryWindow:console-message] {
  "level": 3,
  "message": "Uncaught Error: Uncaught Error: An object could not be cloned.",
  "line": 7,
  "sourceId": "filex://0.0.0.0/C%3A/Users/plero/Documents/git/thorium-reader/release/win-unpacked/resources/app.asar/index_library.js"
}
```

Probably coming from this: https://github.com/edrlab/thorium-reader/blob/585b43a1cbc90457a0109f78b372e2bf518d47e4/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/console-redirect.ts#L53


Let's continue running it as a backlog task.