### PR TITLE
[PARKED FOR NOW] System tray

### DIFF
--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -7,7 +7,6 @@
 
 import debug_ from "debug";
 import { clipboard } from "electron";
-import { ReaderMode } from "readium-desktop/common/models/reader";
 import { Action } from "readium-desktop/common/models/redux";
 import { ActionWithDestination, ActionWithSender, SenderType } from "readium-desktop/common/models/sync";
 import { ToastType } from "readium-desktop/common/models/toast";
@@ -185,8 +184,8 @@ function* readerOpenRequest(action: readerActions.openRequest.TAction) {
         // );
         // const readersArray = ObjectValues(readers);
 
-        const mode = yield* selectTyped((state: RootState) => state.mode);
-        if (mode === ReaderMode.Attached) {
+        //const mode = yield* selectTyped((state: RootState) => state.mode);
+        //if (mode === ReaderMode.Attached) {
             try {
                 const libWin = getLibraryWindowFromDi();
                 if (libWin && !libWin.isDestroyed() && !libWin.webContents.isDestroyed()) {
@@ -195,7 +194,7 @@ function* readerOpenRequest(action: readerActions.openRequest.TAction) {
             } catch (_err) {
                 debug("library can't be loaded from di");
             }
-        }
+        //}
 
         const windowIdentifier = uuidv4();
         yield* callTyped(createReaderWindow,

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 import { encodeURIComponent_RFC3986 } from "@r2-utils-js/_utils/http/UrlUtils";
-import { BrowserWindow, Event as ElectronEvent, HandlerDetails, shell, WebContentsWillNavigateEventParams } from "electron";
+import { BrowserWindow, Event as ElectronEvent, HandlerDetails, Menu, shell, Tray, WebContentsWillNavigateEventParams } from "electron";
 import * as path from "path";
 import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
@@ -43,6 +43,8 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
         (state: RootState) => state.win.session.library.windowBound);
     windowBound = normalizeWinBoundRectangle(windowBound);
 
+    const icon_path = path.join(__dirname, "assets/icons/icon.png");
+
     libWindow = new BrowserWindow({
         ...windowBound,
         minWidth: WINDOW_MIN_WIDTH,
@@ -59,9 +61,27 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
             webSecurity: true,
             webviewTag: false,
         },
-        icon: path.join(__dirname, "assets/icons/icon.png"),
+        icon: icon_path,
     });
     debug("LibraryWindow new BrowserWindow instancied");
+
+      // Initialize Tray with an icon
+    const tray = new Tray(icon_path);
+    const contextMenu = Menu.buildFromTemplate([
+        { label: 'Show Library', click: () => libWindow.show() },
+        { label: 'Quit', click: () => /*??*/null }
+    ]);
+  
+    //tray.setToolTip('My Redux App');
+    tray.setContextMenu(contextMenu);
+
+    libWindow.on('minimize', () => {
+        libWindow.hide();
+    })
+
+    tray.on('click', () => {
+        libWindow.isVisible() ? libWindow.hide() : libWindow.show()
+    })
 
     if (ENABLE_DEV_TOOLS) {
         const wc = libWindow.webContents;


### PR DESCRIPTION
Instead of having the library open as a second window:

<img width="1489" height="217" alt="image" src="https://github.com/user-attachments/assets/d3508d66-69f8-47ce-b056-097effac4b6e" />

It might be more convenient for the library to minimize to the system tray:

<img width="553" height="224" alt="image" src="https://github.com/user-attachments/assets/b90bc11f-79c9-405f-81b5-4530f8915328" />

This let's the library window minimize by hiding itself, allowing it to be re-opened from the system tray.   I had an LLM suggest how to implement that in a minimal way for experimentation and discussion.

I also put in a change to hide the library window when the reader opens. This seems like nicer behavior, it might address https://github.com/edrlab/thorium-reader/issues/3505  and https://github.com/edrlab/thorium-reader/issues/2826 because I think the library window would be hidden in their cases.

I thought I remember seeing complaints about the app taking two windows from another user but couldn't find it. I agreed with that issue even if I also hallucinated it.