### PR TITLE
Omit display of "No information about prerecorded audio is available"

### DIFF
--- a/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
@@ -293,21 +293,19 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
                             {__("publ-a11y-display-guide.ways-of-reading.ways-of-reading-nonvisual-reading-alt-text.compact")}
                         </li>
                         : <></>}
-                    <li className="publicationInfoA11y2-icon" title={synchronised_pre_recorded_audio
-                        ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-synchronized.descriptive")
-                        : all_content_audio
-                            ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-only.descriptive")
-                            : audio_content
-                                ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-complementary.descriptive")
-                                : __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-no-metadata.descriptive")}>
-                        {synchronised_pre_recorded_audio
-                            ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-synchronized.compact")
+                    {(synchronised_pre_recorded_audio || all_content_audio || audio_content) ?
+                        <li className="publicationInfoA11y2-icon" title={synchronised_pre_recorded_audio
+                            ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-synchronized.descriptive")
                             : all_content_audio
-                                ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-only.compact")
-                                : audio_content
-                                    ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-complementary.compact")
-                                    : __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-no-metadata.compact")}
-                    </li>
+                                ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-only.descriptive")
+                                : __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-complementary.descriptive")}>
+                            {synchronised_pre_recorded_audio
+                                ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-synchronized.compact")
+                                : all_content_audio
+                                    ? __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-only.compact")
+                                    : __("publ-a11y-display-guide.ways-of-reading.ways-of-reading-prerecorded-audio-complementary.compact")}
+                        </li>
+                        : <></>}
                 </ul></>
             : <></>}
         {enableNavigation


### PR DESCRIPTION
Replace #3564 to add fix for #3563. Authored with help of GitHub Copilot and tested with several publications.