### PR TITLE
Fix publication delete storage cleanup

### DIFF
--- a/src/main/redux/sagas/api/publication/delete.ts
+++ b/src/main/redux/sagas/api/publication/delete.ts
@@ -6,9 +6,8 @@
 // ==LICENSE-END==
 
 import { diMainGet } from "readium-desktop/main/di";
-import { publicationActions } from "readium-desktop/main/redux/actions";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
-import { call, delay, put } from "redux-saga/effects";
+import { call, delay } from "redux-saga/effects";
 import { SagaGenerator, call as callTyped } from "typed-redux-saga";
 import debug_ from "debug";
 import { RequesetToCloseAllReadersWithTheSamePubId } from "../../reader";
@@ -20,26 +19,20 @@ export function* deletePublication(publicationIdentifier: string/*, preservePubl
     // yield put(readerActions.closeRequest.build(publicationIdentifier));
     yield* callTyped(RequesetToCloseAllReadersWithTheSamePubId, publicationIdentifier);
 
-    // dispatch action to update publication/lastReadingQueue reducer
-    yield put(publicationActions.deletePublication.build(publicationIdentifier));
-
     // delete publication from reader registry
     // yield put(winActions.registry.unregisterReaderPublication.build(identifier));
 
     // allow extra completion time to ensure the filesystem ZIP streams are closed
     yield delay(300);
 
-    const publicationRepository = diMainGet("publication-repository");
-    // Remove from database
-    yield call(() => publicationRepository.delete(publicationIdentifier));
+    const publicationStorage = diMainGet("publication-storage");
+    // Remove publication files before deleting the persisted publication record.
+    // If this throws, the API layer reports the error and the database remains unchanged.
+    yield call(() => publicationStorage.removePublication(publicationIdentifier /*, preservePublicationOnFileSystem*/));
 
-    try {
-        const publicationStorage = diMainGet("publication-storage");
-        // Remove from storage
-        yield call(() => publicationStorage.removePublication(publicationIdentifier /*, preservePublicationOnFileSystem*/));
-    } catch (e) {
-        debug(`${e}`);
-    }
+    const publicationRepository = diMainGet("publication-repository");
+    // Remove from database only after successful publication storage deletion.
+    yield call(() => publicationRepository.delete(publicationIdentifier));
 
     try {
         const publicationData = diMainGet("publication-data");

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -496,29 +496,35 @@ export class PublicationStorage {
         // }
 
         await this.ready();
-        const defaultPublicationDirectoryPath = path.join(this.defaultDirectory, identifier);
-        try {
-            const stat = await fs.promises.stat(defaultPublicationDirectoryPath);
-            if (stat.isDirectory()) {
-                await rmrf(defaultPublicationDirectoryPath);
-            }
-        } catch {
-            // ignore
-        }
 
+        let removedAtLeastOne = false;
+        let accessError: Error | undefined;
 
-        // TODO: rm or unlink?
-        if (this.userDirectory) {
-            const userPublicationDirectoryPath = path.join(this.userDirectory, identifier);
+        // Safe cleanup: once the publications has been removed, failed publication access to another directory will not block the deletion.
+        for (const directoryPath of this.getPublicationDirectoriesFromCurrentState()) {
+            const publicationPath = path.join(directoryPath, identifier);
+
             try {
-                const stat = await fs.promises.stat(userPublicationDirectoryPath);
-                if (stat.isDirectory()) {
-                    await rmrf(userPublicationDirectoryPath);
+                await fs.promises.stat(publicationPath);
+            } catch (e: any) {
+                if (e?.code !== "ENOENT") {
+                    accessError = new Error(`Failed to access publication storage at ${publicationPath}: ${e.message || e}`);
                 }
-            } catch {
-                // ignore
+                continue;
+            }
+
+            try {
+                await rmrf(publicationPath);
+                removedAtLeastOne = true;
+            } catch (e: any) {
+                throw new Error(`Failed to remove publication storage at ${publicationPath}: ${e.message || e}`);
             }
         }
+
+        if (!removedAtLeastOne && accessError) {
+            throw accessError;
+        }
+
     }
 
     public async getPublicationFilename(publicationView: PublicationView) {

--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -500,7 +500,7 @@ export class PublicationStorage {
         let removedAtLeastOne = false;
         let accessError: Error | undefined;
 
-        // Safe cleanup: once the publications has been removed, failed publication access to another directory will not block the deletion.
+        // Safe cleanup: once the publication has been removed, failed publication access to another directory
         for (const directoryPath of this.getPublicationDirectoriesFromCurrentState()) {
             const publicationPath = path.join(directoryPath, identifier);
 


### PR DESCRIPTION
Fixes #3542 

Fix publication deletion so the database record is removed only after publication storage cleanup succeeds.

- Move `publicationStorage.removePublication()` before `publicationRepository.delete()` in the publication delete saga.
- Remove the early `deletePublication` Redux dispatch from the delete API flow.
- Update publication storage cleanup to check both default and configured user storage directories.
- Treat missing publication folders as already removed.
- Preserve DB records when actual publication file removal fails.
- Allow DB deletion to continue when a secondary/user storage directory has an access issue after the publication was already removed from another storage root.
