### PR TITLE
app minimizes to the system tray on Windows

### DIFF
--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -17,6 +17,7 @@ import { takeSpawnEvery } from "readium-desktop/common/redux/sagas/takeSpawnEver
 import { takeSpawnLeading } from "readium-desktop/common/redux/sagas/takeSpawnLeading";
 import { diMainGet, getAllReaderWindowFromDi, getLibraryWindowFromDi, getReaderWindowFromDi } from "readium-desktop/main/di";
 import { error } from "readium-desktop/main/tools/error";
+import { enableSystemTrayIntegration } from "readium-desktop/main/tools/platform";
 import { streamerActions } from "readium-desktop/main/redux/actions";
 import { RootState } from "readium-desktop/main/redux/states";
 // eslint-disable-next-line local-rules/typed-redux-saga-use-typed-effects
@@ -186,7 +187,7 @@ function* readerOpenRequest(action: readerActions.openRequest.TAction) {
         // const readersArray = ObjectValues(readers);
 
         const mode = yield* selectTyped((state: RootState) => state.mode);
-        if (mode === ReaderMode.Attached) {
+        if (enableSystemTrayIntegration || mode === ReaderMode.Attached) {
             try {
                 const libWin = getLibraryWindowFromDi();
                 if (libWin && !libWin.isDestroyed() && !libWin.webContents.isDestroyed()) {

--- a/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
+++ b/src/main/redux/sagas/win/browserWindow/createLibraryWindow.ts
@@ -7,8 +7,11 @@
 
 import debug_ from "debug";
 import { encodeURIComponent_RFC3986 } from "@r2-utils-js/_utils/http/UrlUtils";
-import { BrowserWindow, Event as ElectronEvent, HandlerDetails, shell, WebContentsWillNavigateEventParams } from "electron";
+import { app, BrowserWindow, Event as ElectronEvent, HandlerDetails, Menu, shell, Tray, WebContentsWillNavigateEventParams } from "electron";
 import * as path from "path";
+import { getTranslator } from "readium-desktop/common/services/translator";
+import { enableSystemTrayIntegration } from "readium-desktop/main/tools/platform";
+import { _APP_NAME } from "readium-desktop/preprocessor-directives";
 import { normalizeWinBoundRectangle } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
 import { setMenu } from "readium-desktop/main/menu";
@@ -34,6 +37,7 @@ const ENABLE_DEV_TOOLS = __TH__IS_DEV__ || __TH__IS_CI__;
 // Global reference to the main window,
 // so the garbage collector doesn't close it.
 let libWindow: BrowserWindow = null;
+let tray: Tray | null = null;
 
 // Opens the main window, with a native menu bar.
 export function* createLibraryWindow(_action: winActions.library.openRequest.TAction) {
@@ -42,6 +46,8 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
     let windowBound = yield* selectTyped(
         (state: RootState) => state.win.session.library.windowBound);
     windowBound = normalizeWinBoundRectangle(windowBound);
+
+    const icon_path = path.join(__dirname, "assets/icons/icon.png");
 
     libWindow = new BrowserWindow({
         ...windowBound,
@@ -59,9 +65,26 @@ export function* createLibraryWindow(_action: winActions.library.openRequest.TAc
             webSecurity: true,
             webviewTag: false,
         },
-        icon: path.join(__dirname, "assets/icons/icon.png"),
+        icon: icon_path,
     });
     debug("LibraryWindow new BrowserWindow instancied");
+
+    if (enableSystemTrayIntegration) {
+        const translator = getTranslator();
+        tray = new Tray(icon_path);
+        const contextMenu = Menu.buildFromTemplate([
+            { label: translator.translate("app.window.showLibrary"), click: () => libWindow.show() },
+            { label: translator.translate("app.quit", { appName: _APP_NAME }), click: () => app.quit() },
+        ]);
+        tray.setToolTip(_APP_NAME);
+        tray.setContextMenu(contextMenu);
+
+        libWindow.on("minimize", () => libWindow.hide());
+
+        tray.on("click", () => {
+            libWindow.isVisible() ? libWindow.hide() : libWindow.show();
+        });
+    }
 
     if (ENABLE_DEV_TOOLS) {
         const wc = libWindow.webContents;

--- a/src/main/tools/platform.ts
+++ b/src/main/tools/platform.ts
@@ -1,0 +1,8 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+export const enableSystemTrayIntegration = process.platform === "win32";


### PR DESCRIPTION
This PR is an update from #3558, handling the concerns discussed in that PR. The code is now internationalized (with no new strings needed) and only affect Windows.

Something I'm less sure about is adding a new file to export enableSystemTrayIntegration. I like checking enableSystemTrayIntegration  instead of checking if its Windows directly as that communicates better what is going on, particularly in reader.ts. But I wasn't quite sure where to put the export, there didn't seem to be a place to put things like that. There are checks on process.platform in other parts of the code, one might consider replacing those with new exports that communicate intent.

## Overview

Instead of having the library open as a second window:

<img width="1489" height="217" alt="image" src="https://github.com/user-attachments/assets/d3508d66-69f8-47ce-b056-097effac4b6e" />

It is more convenient for the library to minimize to the system tray:

<img width="553" height="224" alt="image" src="https://github.com/user-attachments/assets/b90bc11f-79c9-405f-81b5-4530f8915328" />

This let's the library window minimize by hiding itself, allowing it to be re-opened from the system tray.   I had an LLM suggest how to implement that in a minimal way for experimentation and discussion.

I also put in a change to hide the library window when the reader opens. This seems like nicer behavior, it might address https://github.com/edrlab/thorium-reader/issues/3505  and https://github.com/edrlab/thorium-reader/issues/2826 because I think the library window would be hidden in their cases.

I thought I remember seeing complaints about the app taking two windows from another user but couldn't find it. I agreed with that issue even if I also hallucinated it.