### PR TITLE
Fix AllPublication persistence

### DIFF
--- a/src/common/redux/actions/settings/index.ts
+++ b/src/common/redux/actions/settings/index.ts
@@ -6,12 +6,14 @@
 // ==LICENSE-END==
 
 import * as enableAPIAPP from "./enableAPIAPP";
+import * as libraryView from "./libraryView";
 import * as lcpAutoDeleteExpiredPublications from "./lcpAutoDeleteExpiredPublications";
 import * as lcpAutoDeleteExpiredPublicationsForced from "./lcpAutoDeleteExpiredPublicationsForced";
 import * as minimizeLibraryToTray from "./minimizeLibraryToTray";
 
 export {
     enableAPIAPP,
+    libraryView,
     lcpAutoDeleteExpiredPublications,
     lcpAutoDeleteExpiredPublicationsForced,
     minimizeLibraryToTray,

--- a/src/common/redux/actions/settings/libraryView.ts
+++ b/src/common/redux/actions/settings/libraryView.ts
@@ -1,0 +1,28 @@
+// ==LICENSE-BEGIN==
+// Copyright 2017 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+// ==LICENSE-END==
+
+import { Action } from "readium-desktop/common/models/redux";
+import { ILibraryViewSettingsState } from "../../states/settings";
+
+export const ID = "SETTINGS_LIBRARY_VIEW";
+
+export interface Payload {
+    libraryView: Partial<ILibraryViewSettingsState>;
+}
+
+export function build(libraryView: Partial<ILibraryViewSettingsState>):
+    Action<typeof ID, Payload> {
+
+    return {
+        type: ID,
+        payload: {
+            libraryView,
+        },
+    };
+}
+build.toString = () => ID; // Redux StringableActionCreator
+export type TAction = ReturnType<typeof build>;

--- a/src/common/redux/reducers/settings.ts
+++ b/src/common/redux/reducers/settings.ts
@@ -38,7 +38,7 @@ function settingsReducer_(
                 ...initialState,
                 ...state,
                 minimizeLibraryToTray: action.payload.minimizeLibraryToTray,
-            }
+            };
         case settingsActions.libraryView.ID:
             return {
                 ...initialState,

--- a/src/common/redux/reducers/settings.ts
+++ b/src/common/redux/reducers/settings.ts
@@ -22,6 +22,7 @@ function settingsReducer_(
     action:
         settingsActions.enableAPIAPP.TAction |
         settingsActions.minimizeLibraryToTray.TAction |
+        settingsActions.libraryView.TAction |
         settingsActions.lcpAutoDeleteExpiredPublications.TAction |
         settingsActions.lcpAutoDeleteExpiredPublicationsForced.TAction,
 ):  ISettingsState {
@@ -37,6 +38,15 @@ function settingsReducer_(
                 ...initialState,
                 ...state,
                 minimizeLibraryToTray: action.payload.minimizeLibraryToTray,
+            }
+        case settingsActions.libraryView.ID:
+            return {
+                ...initialState,
+                ...state,
+                libraryView: {
+                    ...(state.libraryView || {}),
+                    ...action.payload.libraryView,
+                },
             };
         case settingsActions.lcpAutoDeleteExpiredPublications.ID:
             return {

--- a/src/common/redux/states/settings.ts
+++ b/src/common/redux/states/settings.ts
@@ -11,6 +11,20 @@ export interface ISettingsState {
     lcpAutoDeleteExpiredPublications: boolean; // false by default
     // Runtime-only command-line override. It is intentionally excluded from persisted state.
     lcpAutoDeleteExpiredPublicationsForced: boolean; // false by default
+    libraryView?: ILibraryViewSettingsState;
+}
+
+export type TLibraryViewDisplayType = "grid" | "list";
+
+export interface ILibraryViewSortBy {
+    id: string;
+    desc?: boolean;
+}
+
+export interface ILibraryViewSettingsState {
+    displayType?: TLibraryViewDisplayType;
+    sortBy?: ILibraryViewSortBy[];
+    hiddenColumns?: string[];
 }
 
 export const settingsMinimizeLibraryToTrayIsEnabled = (settings?: Partial<ISettingsState>) =>

--- a/src/main/redux/middleware/sync.ts
+++ b/src/main/redux/middleware/sync.ts
@@ -84,6 +84,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
     creatorActions.set.ID,
 
     settingsActions.minimizeLibraryToTray.ID,
+    settingsActions.libraryView.ID,
     settingsActions.lcpAutoDeleteExpiredPublications.ID,
     settingsActions.lcpAutoDeleteExpiredPublicationsForced.ID,
 

--- a/src/renderer/library/components/catalog/Header.tsx
+++ b/src/renderer/library/components/catalog/Header.tsx
@@ -22,7 +22,9 @@ import {
 import SVG from "readium-desktop/renderer/common/components/SVG";
 import SecondaryHeader from "readium-desktop/renderer/library/components/SecondaryHeader";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
+import { settingsActions } from "readium-desktop/common/redux/actions";
 import { DisplayType, IRouterLocationState } from "readium-desktop/renderer/library/routing";
+import { TDispatch } from "readium-desktop/typings/redux";
 
 import PublicationAddButton from "./PublicationAddButton";
 
@@ -36,8 +38,11 @@ interface IBaseProps extends TranslatorProps {
 // ReturnType<typeof mapStateToProps>
 // ReturnType<typeof mapDispatchToProps>
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface IProps extends IBaseProps, ReturnType<typeof mapStateToProps> {
+interface IProps extends IBaseProps, ReturnType<typeof mapStateToProps>, ReturnType<typeof mapDispatchToProps> {
 }
+
+const normalizeDisplayType = (displayType: string | undefined) =>
+    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
 
 class Header extends React.Component<IProps, undefined> {
 
@@ -48,7 +53,8 @@ class Header extends React.Component<IProps, undefined> {
     public render(): React.ReactElement<{}> {
         const { __, location } = this.props;
 
-        const displayType = (location?.state && (location.state as IRouterLocationState).displayType) || DisplayType.Grid;
+        const locationDisplayType = location?.state && (location.state as IRouterLocationState).displayType;
+        const displayType = normalizeDisplayType(locationDisplayType || this.props.libraryView?.displayType);
 
         return (
             <SecondaryHeader>
@@ -67,6 +73,7 @@ class Header extends React.Component<IProps, undefined> {
                             aria-pressed={displayType === DisplayType.Grid}
                             role={"button"}
                             onClick={(e) => {
+                                this.props.setLibraryViewSettings({ displayType: DisplayType.Grid });
                                 if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
                                     e.preventDefault();
                                     e.currentTarget.click();
@@ -107,6 +114,7 @@ class Header extends React.Component<IProps, undefined> {
                             aria-pressed={displayType === DisplayType.List}
                             role={"button"}
                             onClick={(e) => {
+                                this.props.setLibraryViewSettings({ displayType: DisplayType.List });
                                 if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
                                     e.preventDefault();
                                     e.currentTarget.click();
@@ -174,6 +182,13 @@ class Header extends React.Component<IProps, undefined> {
 const mapStateToProps = (state: ILibraryRootState) => ({
     location: state.router.location,
     locale: state.i18n.locale, // refresh
+    libraryView: state.settings.libraryView,
 });
 
-export default connect(mapStateToProps)(withTranslator(Header));
+const mapDispatchToProps = (dispatch: TDispatch) => ({
+    setLibraryViewSettings: (libraryView: Parameters<typeof settingsActions.libraryView.build>[0]) => {
+        dispatch(settingsActions.libraryView.build(libraryView));
+    },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslator(Header));

--- a/src/renderer/library/components/catalog/Header.tsx
+++ b/src/renderer/library/components/catalog/Header.tsx
@@ -23,7 +23,7 @@ import SVG from "readium-desktop/renderer/common/components/SVG";
 import SecondaryHeader from "readium-desktop/renderer/library/components/SecondaryHeader";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import { settingsActions } from "readium-desktop/common/redux/actions";
-import { DisplayType, IRouterLocationState } from "readium-desktop/renderer/library/routing";
+import { DisplayType, resolveDisplayType } from "readium-desktop/renderer/library/routing";
 import { TDispatch } from "readium-desktop/typings/redux";
 
 import PublicationAddButton from "./PublicationAddButton";
@@ -41,9 +41,6 @@ interface IBaseProps extends TranslatorProps {
 interface IProps extends IBaseProps, ReturnType<typeof mapStateToProps>, ReturnType<typeof mapDispatchToProps> {
 }
 
-const normalizeDisplayType = (displayType: string | undefined) =>
-    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
-
 class Header extends React.Component<IProps, undefined> {
 
     constructor(props: IProps) {
@@ -53,8 +50,7 @@ class Header extends React.Component<IProps, undefined> {
     public render(): React.ReactElement<{}> {
         const { __, location } = this.props;
 
-        const locationDisplayType = location?.state && (location.state as IRouterLocationState).displayType;
-        const displayType = normalizeDisplayType(locationDisplayType || this.props.libraryView?.displayType);
+        const displayType = resolveDisplayType(location?.state, this.props.libraryView?.displayType);
 
         return (
             <SecondaryHeader>

--- a/src/renderer/library/components/layout/BreadCrumb.tsx
+++ b/src/renderer/library/components/layout/BreadCrumb.tsx
@@ -15,7 +15,7 @@ import * as ChevronRight from "readium-desktop/renderer/assets/icons/chevron-rig
 import SVG from "readium-desktop/renderer/common/components/SVG";
 import { IBreadCrumbItem } from "readium-desktop/common/redux/states/renderer/breadcrumbItem";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
-import { DisplayType, IRouterLocationState } from "../../routing";
+import { resolveDisplayType } from "../../routing";
 import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import useResizeObserver from "@react-hook/resize-observer";
 import debounce from "debounce";
@@ -50,13 +50,14 @@ function useSize<T extends Element>(target: React.RefObject<T>) {
 const LinkItemBreadcrumb = ({item: {name, path}/*, isTheFirstOne*/}: {item: IBreadCrumbItem, isTheFirstOne?: boolean}) => {
 
     const location = useSelector((state: ILibraryRootState) => state.router.location);
+    const savedDisplayType = useSelector((state: ILibraryRootState) => state.settings.libraryView?.displayType);
 
     return (<Link
         to={{
             ...location,
             pathname: path,
         }}
-        state={{ displayType: (location.state && (location.state as IRouterLocationState).displayType) ? (location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+        state={{ displayType: resolveDisplayType(location.state, savedDisplayType) }}
         title={name}
         className={stylesButtons.button_transparency}
         onClick={(e) => {

--- a/src/renderer/library/components/layout/LibraryHeader.tsx
+++ b/src/renderer/library/components/layout/LibraryHeader.tsx
@@ -16,7 +16,7 @@ import classNames from "classnames";
 import * as React from "react";
 import SkipLink from "readium-desktop/renderer/common/components/SkipLink";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
-import { DisplayType, IRouterLocationState } from "../../routing";
+import { resolveDisplayType } from "../../routing";
 import * as HomeIcon from "readium-desktop/renderer/assets/icons/home-icon.svg";
 import * as GlobeIcon from "readium-desktop/renderer/assets/icons/globe-icon.svg";
 import * as CatalogsIcon from "readium-desktop/renderer/assets/icons/catalogs-icon.svg";
@@ -45,9 +45,6 @@ export interface NavigationHeader {
     svg: any;
 }
 
-const normalizeDisplayType = (displayType: string | undefined) =>
-    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
-
 const Header = () => {
 
 
@@ -56,7 +53,6 @@ const Header = () => {
     const locale = useSelector((state: ILibraryRootState) => state.i18n.locale);
     const customizationManifest = useSelector((state: ILibraryRootState) => state.customization.manifest);
     const savedDisplayTypeSetting = useSelector((state: ILibraryRootState) => state.settings.libraryView?.displayType);
-    const savedDisplayType = normalizeDisplayType(savedDisplayTypeSetting);
     const [__] = useTranslator();
 
     const buildNavItem = React.useCallback((item: NavigationHeader, index: number, active: boolean) => {
@@ -90,7 +86,7 @@ const Header = () => {
             <li className={classNames(...styleClasses, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")} key={index} style={{ height: "inherit" }}>
                 <Link
                     to={nextLocation}
-                    state={{ displayType: (nextLocation.state && (nextLocation.state as IRouterLocationState).displayType) ? (nextLocation.state as IRouterLocationState).displayType : savedDisplayType }}
+                    state={{ displayType: resolveDisplayType(nextLocation.state, savedDisplayTypeSetting) }}
                     replace={true}
                     aria-pressed={active}
                     role={"button"}
@@ -125,7 +121,7 @@ const Header = () => {
                 </Link>
             </li>
         );
-    }, [history, location, savedDisplayType]);
+    }, [history, location, savedDisplayTypeSetting]);
 
     const headerNav: NavigationHeader[] = [
         {

--- a/src/renderer/library/components/layout/LibraryHeader.tsx
+++ b/src/renderer/library/components/layout/LibraryHeader.tsx
@@ -45,6 +45,9 @@ export interface NavigationHeader {
     svg: any;
 }
 
+const normalizeDisplayType = (displayType: string | undefined) =>
+    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
+
 const Header = () => {
 
 
@@ -52,6 +55,8 @@ const Header = () => {
     const history = useSelector((state: ILibraryRootState) => state.history);
     const locale = useSelector((state: ILibraryRootState) => state.i18n.locale);
     const customizationManifest = useSelector((state: ILibraryRootState) => state.customization.manifest);
+    const savedDisplayTypeSetting = useSelector((state: ILibraryRootState) => state.settings.libraryView?.displayType);
+    const savedDisplayType = normalizeDisplayType(savedDisplayTypeSetting);
     const [__] = useTranslator();
 
     const buildNavItem = React.useCallback((item: NavigationHeader, index: number, active: boolean) => {
@@ -85,7 +90,7 @@ const Header = () => {
             <li className={classNames(...styleClasses, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")} key={index} style={{ height: "inherit" }}>
                 <Link
                     to={nextLocation}
-                    state={{ displayType: (nextLocation.state && (nextLocation.state as IRouterLocationState).displayType) ? (nextLocation.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                    state={{ displayType: (nextLocation.state && (nextLocation.state as IRouterLocationState).displayType) ? (nextLocation.state as IRouterLocationState).displayType : savedDisplayType }}
                     replace={true}
                     aria-pressed={active}
                     role={"button"}
@@ -120,7 +125,7 @@ const Header = () => {
                 </Link>
             </li>
         );
-    }, [history, location]);
+    }, [history, location, savedDisplayType]);
 
     const headerNav: NavigationHeader[] = [
         {

--- a/src/renderer/library/components/layout/LibraryLayout.tsx
+++ b/src/renderer/library/components/layout/LibraryLayout.tsx
@@ -199,7 +199,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
         }
     };
 
-    private displayTypeState = () => ({
+    private linkState = () => ({
         displayType: resolveDisplayType(this.props.location.state, this.props.libraryView?.displayType),
     });
 
@@ -232,7 +232,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         pathname: route,
                     }}
                     style={{ width: "20px", height: "20px"}}
-                    state={this.displayTypeState()}
+                    state={this.linkState()}
                     className={stylesButtons.button_secondary_blue}
                     onClick={(e) => {
                         if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -295,7 +295,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         pathname: route,
                     }}
                     style={{ width: "20px", height: "20px" }}
-                    state={this.displayTypeState()}
+                    state={this.linkState()}
                     className={stylesButtons.button_secondary_blue}
                     onClick={(e) => {
                         if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -361,7 +361,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                             pathname: route,
                         }}
                         style={{ height: "unset" }}
-                        state={this.displayTypeState()}
+                        state={this.linkState()}
                         className={classNames(stylesButtons.button_refresh, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")}
                         onClick={(e) => {
                             if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -397,7 +397,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         to={{
                             ...this.props.location,
                         }}
-                        state={this.displayTypeState()}
+                        state={this.linkState()}
                         className={classNames(stylesButtons.button_refresh, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")}
                         onClick={(e) => {
                             if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {

--- a/src/renderer/library/components/layout/LibraryLayout.tsx
+++ b/src/renderer/library/components/layout/LibraryLayout.tsx
@@ -31,7 +31,7 @@ import * as RefreshIcon from "readium-desktop/renderer/assets/icons/refresh-icon
 import * as HomeIcon from "readium-desktop/renderer/assets/icons/home-icon.svg";
 import * as AvatarIcon from "readium-desktop/renderer/assets/icons/person-fill.svg";
 import { buildOpdsBrowserRoute } from "readium-desktop/renderer/library/opds/route";
-import { DisplayType, IOpdsBrowse, IRouterLocationState, routes } from "readium-desktop/renderer/library/routing";
+import { IOpdsBrowse, resolveDisplayType, routes } from "readium-desktop/renderer/library/routing";
 import { Link, matchPath } from "react-router-dom";
 import SVG from "readium-desktop/renderer/common/components/SVG";
 
@@ -199,6 +199,10 @@ class LibraryLayout extends React.Component<IProps, undefined> {
         }
     };
 
+    private displayTypeState = () => ({
+        displayType: resolveDisplayType(this.props.location.state, this.props.libraryView?.displayType),
+    });
+
     private bookshelf = () => {
         const { bookshelf } = this.props.headerLinks;
 
@@ -228,7 +232,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         pathname: route,
                     }}
                     style={{ width: "20px", height: "20px"}}
-                    state = {{displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid}}
+                    state={this.displayTypeState()}
                     className={stylesButtons.button_secondary_blue}
                     onClick={(e) => {
                         if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -291,7 +295,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         pathname: route,
                     }}
                     style={{ width: "20px", height: "20px" }}
-                    state={{ displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                    state={this.displayTypeState()}
                     className={stylesButtons.button_secondary_blue}
                     onClick={(e) => {
                         if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -357,7 +361,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                             pathname: route,
                         }}
                         style={{ height: "unset" }}
-                        state={{ displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                        state={this.displayTypeState()}
                         className={classNames(stylesButtons.button_refresh, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")}
                         onClick={(e) => {
                             if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -393,7 +397,7 @@ class LibraryLayout extends React.Component<IProps, undefined> {
                         to={{
                             ...this.props.location,
                         }}
-                        state={{ displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                        state={this.displayTypeState()}
                         className={classNames(stylesButtons.button_refresh, "R2_CSS_CLASS__FORCE_NO_FOCUS_OUTLINE")}
                         onClick={(e) => {
                             if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -435,6 +439,7 @@ const mapStateToProps = (state: ILibraryRootState, _props: IBaseProps) => ({
     headerLinks: state.opds.browser.header,
     breadcrumb: state.opds.browser.breadcrumb,
     locale: state.i18n.locale, // refresh
+    libraryView: state.settings.libraryView,
 });
 
 export default connect(mapStateToProps)(withTranslator(LibraryLayout));

--- a/src/renderer/library/components/opds/CatalogHeader.tsx
+++ b/src/renderer/library/components/opds/CatalogHeader.tsx
@@ -11,13 +11,17 @@ import { popBreadcrumb } from "../../redux/actions/opds";
 import * as ChevronRight from "readium-desktop/renderer/assets/icons/chevron-right.svg";
 import SVG from "readium-desktop/renderer/common/components/SVG";
 import { Link } from "react-router-dom";
-import { DisplayType } from "readium-desktop/renderer/library/routing";
+import { resolveDisplayType } from "readium-desktop/renderer/library/routing";
 import { IBreadCrumbItem } from "readium-desktop/common/redux/states/renderer/breadcrumbItem";
+import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
+import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 
 export const CatalogHeader: React.FC<React.PropsWithChildren<{ currentLocation: IBreadCrumbItem, previousLocation: IBreadCrumbItem}>> = (props) => {
 
     const { currentLocation, previousLocation } = props;
     const dispatch = useDispatch();
+    const location = useSelector((state: ILibraryRootState) => state.router.location);
+    const savedDisplayType = useSelector((state: ILibraryRootState) => state.settings.libraryView?.displayType);
 
     return (
         <div style={{display: "flex", alignItems: "center", gap: "20px"}}>
@@ -27,7 +31,7 @@ export const CatalogHeader: React.FC<React.PropsWithChildren<{ currentLocation: 
                 to={{
                     pathname: previousLocation?.path,
                 }}
-                state={{ displayType: DisplayType.Grid }}
+                state={{ displayType: resolveDisplayType(location.state, savedDisplayType) }}
                 onClick={(e) => {
                     if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
                         e.preventDefault();

--- a/src/renderer/library/components/opds/Entry.tsx
+++ b/src/renderer/library/components/opds/Entry.tsx
@@ -15,7 +15,7 @@ import { IOpdsNavigationLinkView } from "readium-desktop/common/views/opds";
 
 import { buildOpdsBrowserRoute } from "readium-desktop/renderer/library/opds/route";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
-import { DisplayType, IOpdsBrowse, IRouterLocationState, routes } from "readium-desktop/renderer/library/routing";
+import { IOpdsBrowse, resolveDisplayType, routes } from "readium-desktop/renderer/library/routing";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IBaseProps {
@@ -60,7 +60,7 @@ class Entry extends React.Component<IProps, undefined> {
                     ...this.props.location,
                     pathname: route,
                 }}
-                state={{ displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                state={{ displayType: resolveDisplayType(this.props.location.state, this.props.libraryView?.displayType) }}
                 onClick={(e) => {
                     if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
                         e.preventDefault();
@@ -110,6 +110,7 @@ class Entry extends React.Component<IProps, undefined> {
 
 const mapStateToProps = (state: ILibraryRootState) => ({
     location: state.router.location,
+    libraryView: state.settings.libraryView,
 });
 
 export default connect(mapStateToProps)(Entry);

--- a/src/renderer/library/components/opds/FeedList.tsx
+++ b/src/renderer/library/components/opds/FeedList.tsx
@@ -30,7 +30,7 @@ import { buildOpdsBrowserRoute } from "readium-desktop/renderer/library/opds/rou
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import { TDispatch } from "readium-desktop/typings/redux";
 import { Unsubscribe } from "redux";
-import { DisplayType, IRouterLocationState } from "../../routing";
+import { resolveDisplayType } from "../../routing";
 import DeleteOpdsFeedConfirm from "../dialog/DeleteOpdsFeedConfirm";
 import OpdsFeedUpdateForm from "../dialog/OpdsFeedUpdateForm";
 import * as Popover from "@radix-ui/react-popover";
@@ -111,7 +111,7 @@ class FeedList extends React.Component<IProps, IState> {
                                             item.url,
                                         ),
                                     }}
-                                    state={{ displayType: (this.props.location.state && (this.props.location.state as IRouterLocationState).displayType) ? (this.props.location.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                                    state={{ displayType: resolveDisplayType(this.props.location.state, this.props.libraryView?.displayType) }}
                                     className={stylesCatalogs.catalog_content}
                                     onClick={(e) => {
                                         if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
@@ -285,6 +285,7 @@ const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
 const mapStateToProps = (state: ILibraryRootState) => ({
     location: state.router.location,
     locale: state.i18n.locale, // refresh
+    libraryView: state.settings.libraryView,
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withTranslator(FeedList));

--- a/src/renderer/library/components/opds/OpdsAddForm.tsx
+++ b/src/renderer/library/components/opds/OpdsAddForm.tsx
@@ -12,7 +12,7 @@ import { OpdsFeedAddFormDialog } from "../dialog/OpdsFeedAddForm";
 import { ApiappAddFormDialog } from "../dialog/ApiappAddForm";
 import * as stylesButtons from "readium-desktop/renderer/assets/styles/components/buttons.scss";
 import SVG from "readium-desktop/renderer/common/components/SVG";
-import { DisplayType, IRouterLocationState } from "../../routing";
+import { resolveDisplayType } from "../../routing";
 import { Link } from "react-router-dom";
 // import * as CatalogsIcon from "readium-desktop/renderer/assets/icons/catalogs-icon.svg";
 import * as EyeGlassesIcon from "readium-desktop/renderer/assets/icons/eyeglasses-icon.svg";
@@ -29,6 +29,7 @@ interface IProps {
 const OpdsAddForm: React.FC<IProps> = ({feedsResult}) => {
     const historyState = useSelector((state: ILibraryRootState) => state.history);
     const location = useSelector((state: ILibraryRootState) => state.router.location);
+    const savedDisplayType = useSelector((state: ILibraryRootState) => state.settings.libraryView?.displayType);
     const [__] = useTranslator();
 
     const item: NavigationHeader =   {
@@ -93,7 +94,7 @@ const OpdsAddForm: React.FC<IProps> = ({feedsResult}) => {
             nextLocation ?
             <Link
                 to={nextLocation}
-                state={{ displayType: (nextLocation.state && (nextLocation.state as IRouterLocationState).displayType) ? (nextLocation.state as IRouterLocationState).displayType : DisplayType.Grid }}
+                state={{ displayType: resolveDisplayType(nextLocation.state, savedDisplayType) }}
                 replace={true}
                 role={"button"}
                 className={stylesButtons.button_nav_primary}

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -79,6 +79,7 @@ import { apiAction } from "readium-desktop/renderer/library/apiAction";
 import { apiSubscribe } from "readium-desktop/renderer/library/apiSubscribe";
 import LibraryLayout from "readium-desktop/renderer/library/components/layout/LibraryLayout";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
+import { ILibraryViewSettingsState } from "readium-desktop/common/redux/states/settings";
 import { Unsubscribe } from "redux";
 
 import Header from "../catalog/Header";
@@ -113,6 +114,7 @@ import { useSelector } from "readium-desktop/renderer/common/hooks/useSelector";
 import { ICommonRootState } from "readium-desktop/common/redux/states/commonRootState";
 import { useTranslator } from "readium-desktop/renderer/common/hooks/useTranslator";
 import { HoverEvent } from "@react-types/shared";
+import { settingsActions } from "readium-desktop/common/redux/actions";
 
 
 // import GridTagButton from "../catalog/GridTagButton";
@@ -142,6 +144,27 @@ interface IState {
     accessibilitySupportEnabled: boolean;
     tags: string[];
 }
+
+const nonEditableColumnIds = ["colCover", "colActions", "colAuthors", "colTitle"];
+
+const normalizeDisplayType = (displayType: string | undefined) =>
+    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
+
+const stringArrayEquals = (a: string[] | undefined, b: string[] | undefined) => {
+    const aa = a || [];
+    const bb = b || [];
+    return aa.length === bb.length && aa.every((value, index) => value === bb[index]);
+};
+
+const sortByEquals = (
+    a: ILibraryViewSettingsState["sortBy"] | undefined,
+    b: ILibraryViewSettingsState["sortBy"] | undefined,
+) => {
+    const aa = a || [];
+    const bb = b || [];
+    return aa.length === bb.length &&
+        aa.every((value, index) => value.id === bb[index].id && (value.desc === true) === (bb[index].desc === true));
+};
 
 export class AllPublicationPage extends React.Component<IProps, IState> {
     private unsubscribe: Unsubscribe;
@@ -225,7 +248,8 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
     }
 
     public render(): React.ReactElement<{}> {
-        const displayType = (this.props.location?.state && (this.props.location.state as IRouterLocationState).displayType) || DisplayType.Grid;
+        const locationDisplayType = this.props.location?.state && (this.props.location.state as IRouterLocationState).displayType;
+        const displayType = normalizeDisplayType(locationDisplayType || this.props.libraryView?.displayType);
 
         const { __, location, tags, openReader, displayPublicationInfo } = this.props;
 
@@ -244,6 +268,8 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
                             accessibilitySupportEnabled={this.state.accessibilitySupportEnabled}
                             location={location}
                             displayType={displayType}
+                            libraryView={this.props.libraryView}
+                            setLibraryViewSettings={this.props.setLibraryViewSettings}
                             __={__}
                             publicationViews={this.state.publicationViews}
                             displayPublicationInfo={displayPublicationInfo}
@@ -339,6 +365,7 @@ const mapStateToProps = (state: ILibraryRootState) => ({
     keyboardShortcuts: state.keyboard.shortcuts,
     tags: state.publication.tag,
     locale: state.i18n.locale, // refresh
+    libraryView: state.settings.libraryView,
 });
 
 const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
@@ -352,6 +379,9 @@ const mapDispatchToProps = (dispatch: TDispatch, _props: IBaseProps) => {
         },
         openReader: (publicationViewIdentifier: string) => {
             dispatch(readerActions.openRequest.build(publicationViewIdentifier));
+        },
+        setLibraryViewSettings: (libraryView: Partial<ILibraryViewSettingsState>) => {
+            dispatch(settingsActions.libraryView.build(libraryView));
         },
     };
 };
@@ -1516,6 +1546,8 @@ interface ITableCellProps_TableView {
     location: Location;
     accessibilitySupportEnabled: boolean;
     tags: string[];
+    libraryView?: ILibraryViewSettingsState;
+    setLibraryViewSettings: (libraryView: Partial<ILibraryViewSettingsState>) => void;
 }
 
 // 1. Définissez une interface pour vos props
@@ -1539,7 +1571,18 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
 
     const scrollToViewRef = React.useRef(null);
 
-    const { openReader, displayPublicationInfo, displayType, __, focusInputRef, publicationViews, accessibilitySupportEnabled, tags } = props;
+    const {
+        openReader,
+        displayPublicationInfo,
+        displayType,
+        __,
+        focusInputRef,
+        publicationViews,
+        accessibilitySupportEnabled,
+        tags,
+        libraryView,
+        setLibraryViewSettings,
+    } = props;
 
     const locale = useSelector((state: ICommonRootState) => state.i18n.locale);
     const [activeFiltersArray, setActiveFiltersArray] = React.useState<IActiveFilter[]>([]);
@@ -2063,6 +2106,30 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [__, locale]);
 
+    const tableColumnIds = React.useMemo(() => {
+        const ids: string[] = [];
+        for (const column of tableColumns) {
+            if (typeof column.accessor === "string") {
+                ids.push(column.accessor);
+            }
+        }
+        return new Set<string>(ids);
+    }, [tableColumns]);
+
+    const initialSortBy = React.useMemo(() =>
+        (libraryView?.sortBy || [])
+            .filter((sort) => tableColumnIds.has(sort.id))
+            .map((sort) => ({
+                id: sort.id,
+                desc: sort.desc === true,
+            })),
+    [libraryView?.sortBy, tableColumnIds]);
+
+    const initialHiddenColumns = React.useMemo(() =>
+        (libraryView?.hiddenColumns || [])
+            .filter((columnId) => tableColumnIds.has(columnId) && !nonEditableColumnIds.includes(columnId)),
+    [libraryView?.hiddenColumns, tableColumnIds]);
+
     const defaultColumn = React.useMemo(
         () => ({
             Cell: TableCell,
@@ -2121,9 +2188,11 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
 
     const PAGESIZE = 50;
 
-    const initialState: UsePaginationState<IColumns> & TableState<IColumns> = {
+    const initialState: UsePaginationState<IColumns> & UseSortByState<IColumns> & TableState<IColumns> = {
         pageSize: PAGESIZE, // displayType === DisplayType.List ? 20 : 10;
         pageIndex: 0,
+        sortBy: initialSortBy,
+        hiddenColumns: initialHiddenColumns,
         // hiddenColumns: displayType === DisplayType.Grid ? ["colLanguages", "colPublishers", "colPublishedDate", "colLCP", "colDuration", "colDescription", "col_a11y_accessibilitySummary"] : [],
     };
     const opts:
@@ -2144,6 +2213,43 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
     };
     const tableInstance =
         useTable<IColumns>(opts, useFilters, useGlobalFilter, useSortBy, usePagination) as MyTableInstance<IColumns>;
+
+    const skipInitialTableStatePersistenceRef = React.useRef(true);
+    React.useEffect(() => {
+        if (skipInitialTableStatePersistenceRef.current) {
+            skipInitialTableStatePersistenceRef.current = false;
+            return;
+        }
+
+        const sortBy = (tableInstance.state.sortBy || [])
+            .filter((sort) => tableColumnIds.has(sort.id))
+            .map((sort) => ({
+                id: sort.id,
+                desc: sort.desc === true,
+            }));
+
+        const hiddenColumns = ((tableInstance.state.hiddenColumns as string[] | undefined) || [])
+            .filter((columnId) => tableColumnIds.has(columnId) && !nonEditableColumnIds.includes(columnId));
+
+        if (
+            sortByEquals(libraryView?.sortBy, sortBy) &&
+            stringArrayEquals(libraryView?.hiddenColumns, hiddenColumns)
+        ) {
+            return;
+        }
+
+        setLibraryViewSettings({
+            sortBy,
+            hiddenColumns,
+        });
+    }, [
+        tableInstance.state.sortBy,
+        tableInstance.state.hiddenColumns,
+        tableColumnIds,
+        libraryView?.sortBy,
+        libraryView?.hiddenColumns,
+        setLibraryViewSettings,
+    ]);
 
     const keyboardShortcuts = useSelector((state: ILibraryRootState) => state.keyboard.shortcuts);
 
@@ -2444,8 +2550,6 @@ export const TableView: React.FC<ITableCellProps_TableView & ITableCellProps_Com
         "colReadingState": setSelectedReadingState,
         "colTags": setSelectedTag,
     };
-
-    const nonEditableColumnIds = ["colCover", "colActions", "colAuthors", "colTitle"];
 
     const editableColumnsArray = tableInstance.allColumns.filter(
         (col) => !nonEditableColumnIds.includes(col.id),

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -84,7 +84,7 @@ import { Unsubscribe } from "redux";
 
 import Header from "../catalog/Header";
 
-import { DisplayType, IRouterLocationState } from "readium-desktop/renderer/library/routing";
+import { DisplayType, resolveDisplayType } from "readium-desktop/renderer/library/routing";
 import { keyboardShortcutsMatch } from "readium-desktop/common/keyboard";
 import {
     ensureKeyboardListenerIsInstalled, registerKeyboardListener, unregisterKeyboardListener,
@@ -115,6 +115,7 @@ import { ICommonRootState } from "readium-desktop/common/redux/states/commonRoot
 import { useTranslator } from "readium-desktop/renderer/common/hooks/useTranslator";
 import { HoverEvent } from "@react-types/shared";
 import { settingsActions } from "readium-desktop/common/redux/actions";
+import { equals } from "ramda";
 
 
 // import GridTagButton from "../catalog/GridTagButton";
@@ -147,24 +148,19 @@ interface IState {
 
 const nonEditableColumnIds = ["colCover", "colActions", "colAuthors", "colTitle"];
 
-const normalizeDisplayType = (displayType: string | undefined) =>
-    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
+const stringArrayEquals = (a: string[] | undefined, b: string[] | undefined) =>
+    equals(a || [], b || []);
 
-const stringArrayEquals = (a: string[] | undefined, b: string[] | undefined) => {
-    const aa = a || [];
-    const bb = b || [];
-    return aa.length === bb.length && aa.every((value, index) => value === bb[index]);
-};
+const normalizeSortBy = (sortBy: ILibraryViewSettingsState["sortBy"] | undefined) =>
+    (sortBy || []).map(({ id, desc }) => ({
+        id,
+        desc: desc === true,
+    }));
 
 const sortByEquals = (
     a: ILibraryViewSettingsState["sortBy"] | undefined,
     b: ILibraryViewSettingsState["sortBy"] | undefined,
-) => {
-    const aa = a || [];
-    const bb = b || [];
-    return aa.length === bb.length &&
-        aa.every((value, index) => value.id === bb[index].id && (value.desc === true) === (bb[index].desc === true));
-};
+) => equals(normalizeSortBy(a), normalizeSortBy(b));
 
 export class AllPublicationPage extends React.Component<IProps, IState> {
     private unsubscribe: Unsubscribe;
@@ -248,8 +244,7 @@ export class AllPublicationPage extends React.Component<IProps, IState> {
     }
 
     public render(): React.ReactElement<{}> {
-        const locationDisplayType = this.props.location?.state && (this.props.location.state as IRouterLocationState).displayType;
-        const displayType = normalizeDisplayType(locationDisplayType || this.props.libraryView?.displayType);
+        const displayType = resolveDisplayType(this.props.location?.state, this.props.libraryView?.displayType);
 
         const { __, location, tags, openReader, displayPublicationInfo } = this.props;
 

--- a/src/renderer/library/redux/middleware/sync.ts
+++ b/src/renderer/library/redux/middleware/sync.ts
@@ -71,6 +71,7 @@ const SYNCHRONIZABLE_ACTIONS: string[] = [
 
     settingsActions.enableAPIAPP.ID,
     settingsActions.minimizeLibraryToTray.ID,
+    settingsActions.libraryView.ID,
     settingsActions.lcpAutoDeleteExpiredPublications.ID,
     settingsActions.lcpAutoDeleteExpiredPublicationsForced.ID,
 

--- a/src/renderer/library/routing.ts
+++ b/src/renderer/library/routing.ts
@@ -41,6 +41,19 @@ export interface IRouterLocationState {
     displayType: DisplayType;
 }
 
+export const normalizeDisplayType = (displayType: unknown): DisplayType =>
+    displayType === DisplayType.List ? DisplayType.List : DisplayType.Grid;
+
+export const resolveDisplayType = (locationState: unknown, savedDisplayType?: unknown): DisplayType => {
+    const locationDisplayType = (locationState as Partial<IRouterLocationState> | undefined)?.displayType;
+
+    if (locationDisplayType === DisplayType.Grid || locationDisplayType === DisplayType.List) {
+        return locationDisplayType;
+    }
+
+    return normalizeDisplayType(savedDisplayType);
+};
+
 const _routes = {
     "/opds": {
         path: "/opds",


### PR DESCRIPTION
Fix #3639

- Persist the selected Library display mode between grid and list views.
- Save and restore table preferences for the Library list view, including sort order and hidden columns.