### PR TITLE
fix(PDF): TOC links navigate one page early when the PDF has no page labels

### DIFF
--- a/src/renderer/reader/pdf/webview/toc.ts
+++ b/src/renderer/reader/pdf/webview/toc.ts
@@ -59,7 +59,10 @@ export async function tocOutlineItemToLink(outline: IOutline, pdf: PDFDocumentPr
 
         if (destForPageIndex) {
             const page = await pdf.getPageIndex(destForPageIndex);
-            const label = pageLabels?.[page] || String(page);
+            // getPageIndex() is zero-based, whereas Href is consumed by PDFLinkService.goToPage(),
+            // which falls back to interpreting the string as a one-based page number
+            // when it does not match any page label.
+            const label = pageLabels?.[page] || String(page + 1);
             // console.log("PDF PAGE LABEL LiNK HREF", label, pageLabels, page, destForPageIndex?.num, destForPageIndex?.gen)
             link.Href = label;
         }


### PR DESCRIPTION
Commit 549ff9b8a fixed an issue where a graceful degradation was added for resolving PDF Table of Content destinations where the page label is null. It fell back to the page number as a safe alternative.

```ts
const page = await pdf.getPageIndex(destForPageIndex);
const label = pageLabels?.[page] || String(page);
// console.log("PDF PAGE LABEL LiNK HREF", label, pageLabels, page, destForPageIndex?.num, destForPageIndex?.gen)
link.Href = label;
```

As a result:

* `getPageIndex()` resolves a destination to a zero-based page index and assigns the result to `link.Href`. 
* This value is passed to `PDF.js PDFLinkService.goToPage()` later, and this treats string inputs that match no page label as a one-based page number.
* Every TOC entry navigates one page early, and an entry targeting the first page yielded "0", which goToPage() rejects as an invalid page, so the link does nothing at all. 

This PR is a simple change the logic to correct the off-by-one error in this scenario.