### PR TITLE
fix(security): annotations/bookmarks/custom-profiles - post-sanitize a@href onclick JS handler string interpolation RCE injection in URL field -- now dispatches to shell.openExternal() automatically by leveraging top-level Electron will-navigate event (or setWindowOpenHandler) in library and reader BrowserWindows

### DIFF
--- a/src/renderer/common/components/customizationProfileDialog.tsx
+++ b/src/renderer/common/components/customizationProfileDialog.tsx
@@ -56,7 +56,7 @@ export const CustomizationProfileDialog: React.FC = () => {
     const welcomeScreenHtmlZipPath = customization.manifest?.links?.find((ln) => ln.rel === "welcome-screen" && (!ln.type || ln.type === "text/html") && ln.language === locale)?.href || customization.manifest?.links?.find((ln) => ln.rel === "welcome-screen" && (!ln.type || ln.type === "text/html") && (ln.language === "en" || !ln.language))?.href;
     const welcomeScreenHtmlHref = customizationBaseUrl && welcomeScreenHtmlZipPath ? customizationBaseUrl + encodeURIComponent_RFC3986(Buffer.from(welcomeScreenHtmlZipPath).toString("base64")) : "";
 
-    const [welcomeScreenHtmlSanitized, setWelcomeScreenHtmlSanitized] = React.useState("");
+    const [dangerousInnerHTML_WelcomeScreenSanitized, setDangerousInnerHTML_WelcomeScreenSanitized] = React.useState("");
 
     // console.log("welcomeScreen HTML zipPath: ", welcomeScreenHtmlZipPath);
     // console.log("welcomeScreen HTML URL: ", welcomeScreenHtmlHref);
@@ -77,30 +77,20 @@ export const CustomizationProfileDialog: React.FC = () => {
                         return;
                     }
 
-                    const regex = new RegExp(/href=\"(.*?)\"/, "gm");
-                    const parsed = DOMPurify.sanitize(rawHtmlContent, { FORBID_TAGS: [/*"style"*/], FORBID_ATTR: [/*"style"*/] /* TODO: handle external https links */ });
-                    const hrefSanitized = parsed.replace(regex, (substring) => {
-
-                        let url = /href=\"(.*?)\"/.exec(substring)[1];
-                        if (!/^https?:\/\//.test(url)) {
-                            url = "http://" + url;
-                        }
-
-                        return `href="" alt="${url}" onclick="return ((e) => {
-                                    window.__shell_openExternal('${url}').then((_v) => undefined).catch((_err) => undefined);
-                                    return false;
-                                 })()"`;
-                    });
-
-                    setWelcomeScreenHtmlSanitized(hrefSanitized);
+                    const htmlSanitized = DOMPurify.sanitize(rawHtmlContent, { FORBID_TAGS: [/*"style"*/], FORBID_ATTR: [/*"style"*/] /* TODO: handle external https links */ });
+                    // console.log(rawHtmlContent, htmlSanitized);
+                    // NOTE that <a href="yyy">xxx</a> is fine, caught by webContents.on("will-navigate", ...) with event.preventDefault() and shell.openExternal(...) on normalized/escaped URL and filtered on HTTP(S)://
+                    // NOTE that the attribute target="_blank" (etc) is automatically removed by DOMPurify but would be caught by webContents.setWindowOpenHandler(...) with { action: "deny" }, although no shell.openExternal(...) in this case
+                    setDangerousInnerHTML_WelcomeScreenSanitized(htmlSanitized);
                 })
                 .catch((e) => {
                     console.error("Error fetching data:", e);
+                    setDangerousInnerHTML_WelcomeScreenSanitized("");
                 });
         } else {
-            setWelcomeScreenHtmlSanitized("");
+            setDangerousInnerHTML_WelcomeScreenSanitized("");
         }
-    }, [welcomeScreenHtmlHref, customizationId, open, setWelcomeScreenHtmlSanitized]);
+    }, [welcomeScreenHtmlHref, customizationId, open, setDangerousInnerHTML_WelcomeScreenSanitized]);
 
 
     return (
@@ -121,16 +111,16 @@ export const CustomizationProfileDialog: React.FC = () => {
                         </AlertDialog.Action>
                         </AlertDialog.Title>
                     <AlertDialog.Description className={stylesModals.modal_dialog_body} style={{ display: "flex", gap: "20px", flexDirection: "row", justifyContent: "normal"}}>
-                        {customization.welcomeScreen.enable && welcomeScreenHtmlSanitized ? <img style={{ maxWidth: "250px", maxHeight: "500px", objectFit: "contain" }} src={welcomeScreenImgHref} /> : <></>}
+                        {customization.welcomeScreen.enable && dangerousInnerHTML_WelcomeScreenSanitized ? <img style={{ maxWidth: "250px", maxHeight: "500px", objectFit: "contain" }} src={welcomeScreenImgHref} /> : <></>}
                         <div style={{position: "relative", width: "100%", height: "100%"}}>
                             {
-                                customization.welcomeScreen.enable && welcomeScreenHtmlSanitized ?
-                                    <div dangerouslySetInnerHTML={{ __html: welcomeScreenHtmlSanitized }} />
+                                customization.welcomeScreen.enable && dangerousInnerHTML_WelcomeScreenSanitized ?
+                                    <div dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_WelcomeScreenSanitized }} />
                                     : customization.welcomeScreen.enable ?
                                         <p>{__("dialog.customization.splashscreen.fallbackWelcomeScreen")}</p> : <></>
                             }
                             {
-                                !(customization.lock.state === "IDLE" || welcomeScreenHtmlSanitized) ?
+                                !(customization.lock.state === "IDLE" || dangerousInnerHTML_WelcomeScreenSanitized) ?
                                 <div style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", flexDirection: "column", justifyContent: "space-between"}}>
                                     <Loader></Loader>
                                     <span>{__("dialog.customization.splashscreen.state", {state: customization.lock.state, id: customization.lock.lockInfo?.id === "" && customization.lock.state === "ACTIVATING" ? "THorium Default Profile" : customization.lock.lockInfo?.id || "undefined"})}</span>

--- a/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/PublicationInfoA11y2.tsx
@@ -81,7 +81,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
     const a11y_certifierCredential = Array.isArray(a11y_certifierCredential_) ? a11y_certifierCredential_ : a11y_certifierCredential_ ? [a11y_certifierCredential_] : [];
 
     // taken from previous a11y implementation src/renderer/common/components/dialog/publicationInfos/publicationInfoA11y.tsx:ln108
-    let accessibilitySummaryStrSanitized = undefined;
+    let dangerousInnerHTML_AccessibilitySummarySanitized = undefined;
     let accessibilitySummaryIsRTL = undefined;
     let accessibilitySummaryLang = undefined;
     if (a11y_accessibilitySummary) {
@@ -94,7 +94,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
         accessibilitySummaryLang = accessibilitySummaryLangStr && accessibilitySummaryLangStr[0] ? accessibilitySummaryLangStr[0].toLowerCase() : "";
         accessibilitySummaryIsRTL = langStringIsRTL(accessibilitySummaryLang);
         const accessibilitySummaryStr = accessibilitySummaryLangStr && accessibilitySummaryLangStr[1] ? accessibilitySummaryLangStr[1] : "";
-        accessibilitySummaryStrSanitized = accessibilitySummaryStr ? DOMPurify.sanitize(accessibilitySummaryStr, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] }).replace(/font-size:/g, "font-sizexx:") : "";
+        dangerousInnerHTML_AccessibilitySummarySanitized = accessibilitySummaryStr ? DOMPurify.sanitize(accessibilitySummaryStr, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] }).replace(/font-size:/g, "font-sizexx:") : "";
 
     }
 
@@ -232,7 +232,7 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
 
     const enableAdditionnals = (page_break_markers || aria || audio_descriptions || braille || full_ruby_annotations || high_contrast_between_foreground_and_background_audio || high_contrast_between_text_and_background || large_print || ruby_annotations || sign_language || tactile_graphic || tactile_object || text_to_speech_hinting);
 
-    const enableSummaryDetail = accessibilitySummaryStrSanitized || enableAdditionnals || enableConformance || enableHazard || enableRichContent;
+    const enableSummaryDetail = dangerousInnerHTML_AccessibilitySummarySanitized || enableAdditionnals || enableConformance || enableHazard || enableRichContent;
 
     // https://www.w3.org/community/reports/publishingcg/CG-FINAL-epub-techniques-20250422#legal-considerations
     // https://github.com/w3c/publ-a11y/issues/350
@@ -561,11 +561,11 @@ export const PublicationInfoA11y2: React.FC<IProps> = ({publicationViewMaybeOpds
                     </>
                     : <></>
                 }
-                {accessibilitySummaryStrSanitized ?
+                {dangerousInnerHTML_AccessibilitySummarySanitized ?
                     <><h5 className="publicationInfoA11y2-title">{__("publ-a11y-display-guide.accessibility-summary.accessibility-summary-title")}</h5><div
                         dir={accessibilitySummaryIsRTL ? "rtl" : undefined}
                         lang={accessibilitySummaryLang ? accessibilitySummaryLang : undefined}
-                        dangerouslySetInnerHTML={{ __html: accessibilitySummaryStrSanitized }}
+                        dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_AccessibilitySummarySanitized }}
                     ></div></>
                     : <></>
                 }

--- a/src/renderer/common/components/dialog/publicationInfos/PublicationInfoDescription.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/PublicationInfoDescription.tsx
@@ -66,8 +66,8 @@ const PublicationInfoDescription: React.FC<IProps> = ({ publicationViewMaybeOpds
     const description = pubDescStr;
     if (!description) return <></>;
 
-    const descriptionSanitized = DOMPurify.sanitize(description).replace(/font-size:/g, "font-sizexx:");
-    if (!descriptionSanitized) return <></>;
+    const dangerousInnerHTML_DescriptionSanitized = DOMPurify.sanitize(description).replace(/font-size:/g, "font-sizexx:");
+    if (!dangerousInnerHTML_DescriptionSanitized) return <></>;
 
     return (
         <>
@@ -88,7 +88,7 @@ const PublicationInfoDescription: React.FC<IProps> = ({ publicationViewMaybeOpds
                         dir={pubDescIsRTL ? "rtl" : undefined}
                         lang={pubDescLang ? pubDescLang : undefined}
                         className={stylesBookDetailsDialog.allowUserSelect}
-                        dangerouslySetInnerHTML={{ __html: descriptionSanitized }}
+                        dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_DescriptionSanitized }}
                     />
                 </div>
                 {needSeeMore &&

--- a/src/renderer/common/components/dialog/publicationInfos/publicationInfoA11y.tsx
+++ b/src/renderer/common/components/dialog/publicationInfos/publicationInfoA11y.tsx
@@ -113,7 +113,7 @@
 //             const accessibilitySummaryLang = accessibilitySummaryLangStr && accessibilitySummaryLangStr[0] ? accessibilitySummaryLangStr[0].toLowerCase() : "";
 //             const accessibilitySummaryIsRTL = langStringIsRTL(accessibilitySummaryLang);
 //             const accessibilitySummaryStr = accessibilitySummaryLangStr && accessibilitySummaryLangStr[1] ? accessibilitySummaryLangStr[1] : "";
-//             const accessibilitySummaryStrSanitized = accessibilitySummaryStr ? DOMPurify.sanitize(accessibilitySummaryStr).replace(/font-size:/g, "font-sizexx:") : "";
+//             const dangerousInnerHTML_AccessibilitySummarySanitized = accessibilitySummaryStr ? DOMPurify.sanitize(accessibilitySummaryStr).replace(/font-size:/g, "font-sizexx:") : "";
 
 //             return accessibilitySummaryStr ?
 //                 <div className={classNames(stylesBlocks.description_see_more)}>
@@ -128,7 +128,7 @@
 //                             ref={this.descriptionRef_a11y}
 //                             className={stylesBookDetailsDialog.allowUserSelect}
 //                             dir={accessibilitySummaryIsRTL ? "rtl" : undefined}
-//                             dangerouslySetInnerHTML={{ __html: accessibilitySummaryStrSanitized }}
+//                             dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_AccessibilitySummarySanitized }}
 //                         >
 //                         </div>
 //                     </div>

--- a/src/renderer/library/components/App.tsx
+++ b/src/renderer/library/components/App.tsx
@@ -43,11 +43,6 @@ import { CustomizationProfileDialog } from "readium-desktop/renderer/common/comp
 // eslintxx-disable-next-line @typescript-eslint/no-unused-expressions
 // globalScssStyle.__LOAD_FILE_SELECTOR_NOT_USED_JUST_TO_TRIGGER_WEBPACK_SCSS_FILE__;
 
-import { shell } from "electron";
-
-// always returns a resolved Promise with value undefined
-(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? shell.openExternal(url).then((_v: void): undefined => undefined).catch((_err: unknown): undefined => undefined) /* .finally(() => {  }) */ : Promise.resolve(undefined); // needed after markdown marked parsing for sanitizing the external anchor href
-
 export default class App extends React.Component<{}, undefined> {
 
     constructor(props: {}) {

--- a/src/renderer/library/components/layout/LibraryHeader.tsx
+++ b/src/renderer/library/components/layout/LibraryHeader.tsx
@@ -173,7 +173,7 @@ const Header = () => {
     }, [customizationManifest, locale]);
     const screenZipObj = React.useMemo(() => screenZipLinks?.map(({ href, title }) => href && customizationBaseUrl ? {url: customizationBaseUrl + encodeURIComponent_RFC3986(Buffer.from(href).toString("base64")), title } : undefined), [screenZipLinks, customizationBaseUrl]);
 
-    const [screenHtmlArray, setScreenHtmlArray] = React.useState<Array<{ html: string, title: string | IStringMap }>>([]);
+    const [screenHtmlArray, setScreenHtmlArray] = React.useState<Array<{ dangerousInnerHTML_CustomProfileScreenSanitized: string, title: string | IStringMap }>>([]);
     const [cancel, setCancel] = React.useState(false);
 
 
@@ -242,22 +242,11 @@ const Header = () => {
                             return ;
                         }
 
-                        const regex = new RegExp(/href=\"(.*?)\"/, "gm");
-                        const parsed = DOMPurify.sanitize(rawHtmlContent, { FORBID_TAGS: [/*"style"*/], FORBID_ATTR: [/*"style"*/] /* TODO: handle external https links */ });
-                        const hrefSanitized = parsed.replace(regex, (substring) => {
-
-                            let url = /href=\"(.*?)\"/.exec(substring)[1];
-                            if (!/^https?:\/\//.test(url)) {
-                                url = "http://" + url;
-                            }
-
-                            return `href="" alt="${url}" onclick="return ((e) => {
-                                        window.__shell_openExternal('${url}').then((_v) => undefined).catch((_err) => undefined);
-                                        return false;
-                                     })()"`;
-                        });
-
-                        setScreenHtmlArray((screenHtmlArray) => [...screenHtmlArray, { html: hrefSanitized, title: screenHref.title }]);
+                        const htmlSanitized = DOMPurify.sanitize(rawHtmlContent, { FORBID_TAGS: [/*"style"*/], FORBID_ATTR: [/*"style"*/] /* TODO: handle external https links */ });
+                        // console.log(rawHtmlContent, htmlSanitized);
+                        // NOTE that <a href="yyy">xxx</a> is fine, caught by webContents.on("will-navigate", ...) with event.preventDefault() and shell.openExternal(...) on normalized/escaped URL and filtered on HTTP(S)://
+                        // NOTE that the attribute target="_blank" (etc) is automatically removed by DOMPurify but would be caught by webContents.setWindowOpenHandler(...) with { action: "deny" }, although no shell.openExternal(...) in this case
+                        setScreenHtmlArray((screenHtmlArray) => [...screenHtmlArray, { dangerousInnerHTML_CustomProfileScreenSanitized: htmlSanitized, title: screenHref.title }]);
                     })
                     .catch((e) => {
                         console.error("Error fetching data:", e);
@@ -359,7 +348,7 @@ const Header = () => {
                         )
                     }
                 {
-                    screenHtmlArray.length ? screenHtmlArray.map(({html: htmlSanitized, title: titleStringOrObject}, index) => {
+                    screenHtmlArray.length ? screenHtmlArray.map(({dangerousInnerHTML_CustomProfileScreenSanitized, title: titleStringOrObject}, index) => {
 
                         const title = convertMultiLangStringToString(titleStringOrObject, locale);
 
@@ -384,8 +373,8 @@ const Header = () => {
                                             }
 
                                             {
-                                                htmlSanitized ?
-                                                    <div className={stylesModals.modal_dialog_body} dangerouslySetInnerHTML={{ __html: htmlSanitized }} /> : <></>
+                                                dangerousInnerHTML_CustomProfileScreenSanitized ?
+                                                    <div className={stylesModals.modal_dialog_body} dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_CustomProfileScreenSanitized }} /> : <></>
                                             }
 
                                         </Dialog.Content>

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -1048,7 +1048,7 @@ const CellTags: React.FC<ITableCellProps_Column & ITableCellProps_GenericCell & 
 const CellDescription: React.FC<ITableCellProps_Column & ITableCellProps_GenericCell & ITableCellProps_StringValue> = (props) => {
 
     const textNeedToBeSanitized = props.value || "";
-    const cellTextSanitized = DOMPurify.sanitize(textNeedToBeSanitized).replace(/font-size:/g, "font-sizexx:");
+    const dangerousInnerHTML_DescriptionSanitized = DOMPurify.sanitize(textNeedToBeSanitized).replace(/font-size:/g, "font-sizexx:");
     const [isOpen, setIsOpen] = React.useState(false);
 
     return (<div
@@ -1067,7 +1067,7 @@ const CellDescription: React.FC<ITableCellProps_Column & ITableCellProps_Generic
             // textAlign: props.displayType === DisplayType.Grid ? "justify" : "start",
             textAlign: "start",
         }}>
-        <p dangerouslySetInnerHTML={{ __html: cellTextSanitized }}></p>
+        <p dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_DescriptionSanitized }}></p>
         {props.value ?
             <Popover.Root onOpenChange={() => setIsOpen(!isOpen)}>
                 <Popover.Trigger style={{maxWidth: "15px"}}>
@@ -1080,7 +1080,7 @@ const CellDescription: React.FC<ITableCellProps_Column & ITableCellProps_Generic
                 <Popover.Portal>
                     <Popover.Content collisionPadding={{top : 280}} avoidCollisions sideOffset={5} align="end" alignOffset={-10} hideWhenDetached>
                         <p className={stylesDropDown.dropdown_description}
-                            dangerouslySetInnerHTML={{ __html: cellTextSanitized }}></p>
+                            dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_DescriptionSanitized }}></p>
                         <Popover.Arrow className={stylesDropDown.PopoverArrow} aria-hidden />
                     </Popover.Content>
                 </Popover.Portal>

--- a/src/renderer/reader/components/ReaderMenu/AnnotationCard.tsx
+++ b/src/renderer/reader/components/ReaderMenu/AnnotationCard.tsx
@@ -61,26 +61,17 @@ export const AnnotationCard: React.FC<{ annotation: INoteState, isEdited: boolea
     const dockedEditAnnotation = isEditing && dockedMode;
     const annotationColor = rgbToHex(annotation.color);
 
-    const [textParsed, setTextParsed] = React.useState<string>();
+    const [dangerousInnerHTML_AnnotationTextSanitized, setDangerousInnerHTML_AnnotationTextSanitized] = React.useState<string>();
     React.useEffect(() => {
         if (textualValue) {
             const htmlPromise = Promise.resolve(marked.parse(textualValue.replace(/^[\u200B\u200C\u200D\u200E\u200F\uFEFF]/, ""), { gfm: true }));
             htmlPromise.then((html) => {
-                const parsed = DOMPurify.sanitize(html, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] });
-                const regex = new RegExp(/href=\"(.*?)\"/, "gm");
-                const hrefSanitized = parsed.replace(regex, (_substring, url) => {
-
-                    if (url && !/^https?:\/\//.test(url)) {
-                        url = "http://" + url;
-                    }
-
-                    return `href="" alt="${url}" onclick="return ((e) => {
-                                window.__shell_openExternal('${url}').then((_v) => undefined).catch((_err) => undefined);
-                                return false;
-                                })()"`;
-                });
-                setTextParsed(hrefSanitized);
-                console.log(parsed, hrefSanitized);
+                // https://github.com/cure53/DOMPurify/wiki/Default-TAGs-ATTRIBUTEs-allow-list-&-blocklist
+                const htmlSanitized = DOMPurify.sanitize(html, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] });
+                // console.log(html, htmlSanitized);
+                // NOTE that <a href="yyy">xxx</a> is fine, caught by webContents.on("will-navigate", ...) with event.preventDefault() and shell.openExternal(...) on normalized/escaped URL and filtered on HTTP(S)://
+                // NOTE that the attribute target="_blank" (etc) is automatically removed by DOMPurify but would be caught by webContents.setWindowOpenHandler(...) with { action: "deny" }, although no shell.openExternal(...) in this case
+                setDangerousInnerHTML_AnnotationTextSanitized(htmlSanitized);
             }).catch((err) => { console.log(err); });
         }
     }, [textualValue]);
@@ -235,7 +226,7 @@ export const AnnotationCard: React.FC<{ annotation: INoteState, isEdited: boolea
                     </FocusLock>
                     :
                     <>
-                        <div className={(stylesMarkdown as any)["markdown-body"]} dangerouslySetInnerHTML={{ __html: textParsed }} />
+                        <div className={(stylesMarkdown as any)["markdown-body"]} dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_AnnotationTextSanitized }} />
                         {/* <HardWrapComment comment={textualValue} /> */}
                         {tagName ? <div className={stylesTags.tags_wrapper} aria-label={__("catalog.tags")}>
                             <div className={stylesTags.tag}>

--- a/src/renderer/reader/components/ReaderMenu/BookmarkCard.tsx
+++ b/src/renderer/reader/components/ReaderMenu/BookmarkCard.tsx
@@ -55,27 +55,17 @@ export const BookmarkCard: React.FC<{ bookmark: INoteState, isEdited: boolean, t
     const tag = Array.isArray(tags) ? tags[0] || "" : "";
     const dockedEditBookmark = isEdited && dockedMode;
 
-    const [textParsed, setTextParsed] = React.useState<string>();
+    const [dangerousInnerHTML_BookmarkTextSanitized, setDangerousInnerHTML_BookmarkTextSanitized] = React.useState<string>();
     React.useEffect(() => {
         if (bookmark.textualValue) {
             const htmlPromise = Promise.resolve(marked.parse(bookmark.textualValue.replace(/^[\u200B\u200C\u200D\u200E\u200F\uFEFF]/, ""), { gfm: true }));
             htmlPromise.then((html) => {
-                const parsed = DOMPurify.sanitize(html, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] });
-                const regex = new RegExp(/href=\"(.*?)\"/, "gm");
-                const hrefSanitized = parsed.replace(regex, (substring) => {
-
-                    let url = /href=\"(.*?)\"/.exec(substring)[1];
-                    if (url && !/^https?:\/\//.test(url)) {
-                        url = "http://" + url;
-                    }
-
-                    return `href="" alt="${url}" onclick="return ((e) => {
-                                window.__shell_openExternal('${url}').then((_v) => undefined).catch((_err) => undefined);
-                                return false;
-                                })()"`;
-                });
-                setTextParsed(hrefSanitized);
-                console.log(parsed, hrefSanitized);
+                // https://github.com/cure53/DOMPurify/wiki/Default-TAGs-ATTRIBUTEs-allow-list-&-blocklist
+                const htmlSanitized = DOMPurify.sanitize(html, { FORBID_TAGS: ["style"], FORBID_ATTR: ["style"] });
+                // console.log(html, htmlSanitized);
+                // NOTE that <a href="yyy">xxx</a> is fine, caught by webContents.on("will-navigate", ...) with event.preventDefault() and shell.openExternal(...) on normalized/escaped URL and filtered on HTTP(S)://
+                // NOTE that the attribute target="_blank" (etc) is automatically removed by DOMPurify but would be caught by webContents.setWindowOpenHandler(...) with { action: "deny" }, although no shell.openExternal(...) in this case
+                setDangerousInnerHTML_BookmarkTextSanitized(htmlSanitized);
             }).catch((err) => { console.log(err); });
         }
     }, [bookmark.textualValue]);
@@ -206,7 +196,7 @@ export const BookmarkCard: React.FC<{ bookmark: INoteState, isEdited: boolean, t
                     :
                     <>
                         {/* <HardWrapComment comment={bookmark.textualValue} /> */}
-                        <div className={(stylesMarkdown as any)["markdown-body"]} dangerouslySetInnerHTML={{ __html: textParsed }} />
+                        <div className={(stylesMarkdown as any)["markdown-body"]} dangerouslySetInnerHTML={{ __html: dangerousInnerHTML_BookmarkTextSanitized }} />
                         {tag ? <div className={stylesTags.tags_wrapper} aria-label={__("catalog.tags")}>
                             <div className={stylesTags.tag}>
                                 <a onClick={() => setTagFilter(tag)}

--- a/src/renderer/reader/components/ReaderMenu/ReaderMenu.tsx
+++ b/src/renderer/reader/components/ReaderMenu/ReaderMenu.tsx
@@ -42,16 +42,12 @@ import { readerLocalActionLocatorHrefChanged } from "../../redux/actions";
 import { useReaderConfig, useSaveReaderConfig } from "readium-desktop/renderer/common/hooks/useReaderConfig";
 import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
 
-import { shell } from "electron";
 import { AnnotationList } from "./AnnotationList";
 import { BookmarkList } from "./BookmarkList";
 import { GoToPageSection } from "./GoToPageSection";
 import { createOrGetPdfEventBus } from "../../pdf/driver";
 import { ModalControlButtons } from "readium-desktop/renderer/reader/components/ModalControlButtons";
 import { DockedHeader } from "readium-desktop/renderer/reader/components/DockedHeader";
-
-// always returns a resolved Promise with value undefined (will never reject)
-(window as any).__shell_openExternal = (url: string) => url && /^https?:\/\//.test(url) ? shell.openExternal(url).then((_v: void): undefined => undefined).catch((_err: unknown): undefined => undefined) /* .finally(() => {  }) */ : Promise.resolve(undefined); // needed after markdown marked parsing for sanitizing the external anchor href
 
 // console.log(window);
 


### PR DESCRIPTION
This PR also harmonizes all usages of React JSX/TSX `dangerouslySetInnerHTML`, so as to flag more explicitly/obviously the variable assignments that affect the potentially-harmful injected HTML markup.