### PR TITLE
remove modal attribut from menu add bottom collision padding

### DIFF
--- a/src/renderer/common/components/menu/Menu.tsx
+++ b/src/renderer/common/components/menu/Menu.tsx
@@ -21,11 +21,11 @@ const Menu = (props: React.PropsWithChildren<IBaseProps>) => {
 
     const [triggerOpen, setTriggerOpen] = React.useState(false);
 
-    const collisionValue = location.hash === "#/home" ? 10 : 280;
-    const collision: Partial<Record<"top", number>> = props.noCollisionPadding ? undefined : {top : collisionValue};
+    const collisionValueTop = location.hash === "#/home" ? 10 : 280;
+    const collision: Partial<Record<"top" | "bottom", number>> = props.noCollisionPadding ? undefined : {top : collisionValueTop, bottom: 80};
 
     return (
-        <Popover.Root modal onOpenChange={() => setTriggerOpen(!triggerOpen)}>
+        <Popover.Root onOpenChange={() => setTriggerOpen(!triggerOpen)}>
             <Popover.Trigger asChild>
                 <button className={classNames(stylesDropDown.dropdown_trigger, triggerOpen ? "popover_open" : "")}>
                     {props.button}

--- a/src/renderer/library/components/searchResult/AllPublicationPage.tsx
+++ b/src/renderer/library/components/searchResult/AllPublicationPage.tsx
@@ -1460,7 +1460,7 @@ const CellActions: React.FC<ITableCellProps_Column & ITableCellProps_GenericCell
     return (
         <div className={stylesPublication.cell_wrapper}
         >
-            <Menu noCollisionPadding={true}
+            <Menu
                 button={(
                     <SVG title={`${props.__("publication.actions")} (${label})`} svg={MenuIcon} />
                 )}


### PR DESCRIPTION
The modal attribut in the Menu component was causing a bug: 
- When opening the publication infos from the popover and closing it via "escape" key, their appeared to be a misbehavior regarding the overlay causing an impossibility to click on anything unless refreshing the app. 
