### PR TITLE
handling of CFI selectors during annotation import/export

### DIFF
--- a/scripts/convert-annotation-state-311-to-annotation-file.mjs
+++ b/scripts/convert-annotation-state-311-to-annotation-file.mjs
@@ -83,7 +83,7 @@ export function convertAnnotationStateToReadiumAnnotation(note/*: INoteState*/)/
             } : undefined,
             selector: [
                 {
-                    type: "CfiSelector",
+                    type: "EPUBCFISelector",
                     value: locatorExtended?.selectionInfo?.rangeInfo?.cfi
                         || locatorExtended?.locator?.locations?.rangeInfo?.cfi
                         || locatorExtended?.locator?.locations?.cfi

--- a/src/common/readium/annotation/annotationModel.type.ts
+++ b/src/common/readium/annotation/annotationModel.type.ts
@@ -113,11 +113,21 @@ export function isCssSelector(a: any): a is ICssSelector<undefined> {
     && typeof a.value === "string";
 }
 
-export interface ICfiSelector<T extends ISelector = any> extends ISelector<T> {
+export interface IEPUBCFISelector<T extends ISelector = any> extends ISelector<T> {
+    type: "EPUBCFISelector";
+    value: string;
+}
+
+interface ILegacyCfiSelector<T extends ISelector = any> extends ISelector<T> {
     type: "CfiSelector";
     value: string;
 }
-export function isCfiSelector(a: any): a is ICfiSelector<undefined> {
+export function isEPUBCFISelector(a: any): a is IEPUBCFISelector<undefined> {
+    return typeof a === "object" && a.type === "EPUBCFISelector"
+    && typeof a.value === "string";
+}
+// Thorium exported this non-standard type before EPUBCFISelector was adopted.
+export function isLegacyCfiSelector(a: any): a is ILegacyCfiSelector<undefined> {
     return typeof a === "object" && a.type === "CfiSelector"
     && typeof a.value === "string";
 }

--- a/src/common/readium/annotation/converter.ts
+++ b/src/common/readium/annotation/converter.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 
-import { ICssSelector, IReadiumAnnotation, IReadiumAnnotationSet, isCFIFragmentSelector, isCfiSelector, isCssSelector, isProgressionSelector, isTextPositionSelector, isTextQuoteSelector, ITextPositionSelector, ITextQuoteSelector } from "./annotationModel.type";
+import { ICssSelector, IReadiumAnnotation, IReadiumAnnotationSet, isCFIFragmentSelector, isCssSelector, isEPUBCFISelector, isLegacyCfiSelector, isProgressionSelector, isTextPositionSelector, isTextQuoteSelector, ITextPositionSelector, ITextQuoteSelector } from "./annotationModel.type";
 import { uuidv4 } from "readium-desktop/utils/uuid";
 import { _APP_NAME, _APP_VERSION } from "readium-desktop/preprocessor-directives";
 import { PublicationView } from "readium-desktop/common/views/publication";
@@ -37,7 +37,7 @@ export async function convertSelectorTargetToLocatorExtended(target: IReadiumAnn
 
     const root = xmlDom.body;
 
-    const cfiSelector = target.selector.find(isCfiSelector);
+    const cfiSelector = target.selector.find(isEPUBCFISelector) || target.selector.find(isLegacyCfiSelector);
     const cfiFragmentSelector = target.selector.find(isCFIFragmentSelector);
     const textQuoteSelector = target.selector.find(isTextQuoteSelector);
     const textPositionSelector = target.selector.find(isTextPositionSelector);

--- a/src/main/redux/sagas/note.ts
+++ b/src/main/redux/sagas/note.ts
@@ -16,7 +16,7 @@ import { SagaGenerator } from "typed-redux-saga";
 import { call as callTyped, put as putTyped, take as takeTyped, delay as delayTyped, all as allTyped } from "typed-redux-saga/macro";
 import { hexToRgb } from "readium-desktop/common/rgb";
 import { isNil } from "readium-desktop/utils/nil";
-import { __READIUM_ANNOTATION_AJV_ERRORS, isCFIFragmentSelector, isCfiSelector, isCssSelector, isFragmentSelector, isIReadiumAnnotationSet, isTextPositionSelector, isTextQuoteSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
+import { __READIUM_ANNOTATION_AJV_ERRORS, isCFIFragmentSelector, isCssSelector, isEPUBCFISelector, isFragmentSelector, isIReadiumAnnotationSet, isLegacyCfiSelector, isTextPositionSelector, isTextQuoteSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
 import path from "path";
 import { getPublication } from "./api/publication/getPublication";
 import { Publication as R2Publication } from "@r2-shared-js/models/publication";
@@ -238,7 +238,7 @@ function* importAnnotationSet(action: annotationActions.importAnnotationSet.TAct
                 debug(`for ${uuid} a CFI selector is available (${JSON.stringify(textPositionSelector, null, 4)})`);
             }
 
-            const cfiSelector = incommingAnnotation.target.selector.find(isCfiSelector);
+            const cfiSelector = incommingAnnotation.target.selector.find(isEPUBCFISelector) || incommingAnnotation.target.selector.find(isLegacyCfiSelector);
             if (cfiSelector) {
                 debug(`for ${uuid} a CFI selector is available (${JSON.stringify(cfiSelector, null, 4)})`);
             }

--- a/src/renderer/reader/redux/sagas/readiumAnnotation/selector.ts
+++ b/src/renderer/reader/redux/sagas/readiumAnnotation/selector.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 
-import { ICFIFragmentSelector, ICssSelector, IEPUBCFISelector, IProgressionSelector, ISelector, ITextPositionSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
+import { ICssSelector, IEPUBCFISelector, IProgressionSelector, ISelector, ITextPositionSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
 import { uniqueCssSelector } from "@r2-navigator-js/electron/renderer/common/cssselector3";
 import { INoteState } from "readium-desktop/common/redux/states/renderer/note";
 import {  describeTextPosition, describeTextQuote } from "readium-desktop/third_party/apache-annotator/dom";
@@ -18,9 +18,6 @@ import { SagaGenerator } from "typed-redux-saga";
 import { EpubCfiUtils } from "@r2-navigator-js/electron/common/colibrio-cfi/EpubCfiUtils";
 import { EpubCfiBuilderHelper } from "@r2-navigator-js/electron/common/colibrio-cfi/builder/EpubCfiBuilderHelper";
 import { EpubCfiStringifier } from "@r2-navigator-js/electron/common/colibrio-cfi/stringifier/EpubCfiStringifier";
-import { IReaderRootState } from "readium-desktop/common/redux/states/renderer/readerRootState";
-
-import { select as selectTyped } from "typed-redux-saga/macro";
 
 // Logger
 const debug = debug_("readium-desktop:renderer:reader:redux:sagas:readiumAnnotation:selector");
@@ -49,7 +46,7 @@ const describeCssSelectorWithTextPosition = async (range: Range, document: Docum
     };
 };
 
-export function* readiumAnnotationSelectorFromNote(note: INoteState, isLcp: boolean, sourceHref: string, xmlDom: Document): SagaGenerator<ISelector[]> {
+export function* readiumAnnotationSelectorFromNote(note: INoteState, isLcp: boolean, _sourceHref: string, xmlDom: Document): SagaGenerator<ISelector[]> {
 
     const { locatorExtended } = note;
     if (!locatorExtended) {
@@ -116,25 +113,12 @@ export function* readiumAnnotationSelectorFromNote(note: INoteState, isLcp: bool
         debug("ProgressionSelector SKIP : ", progression);
     }
 
-    const { r2Publication } = yield* selectTyped((state: IReaderRootState) => state.reader.info);
-    const opfSpineItemIndex = r2Publication.Spine.findIndex((link) => link.Href === sourceHref);
-    const opfSpineItemCFIPath = opfSpineItemIndex > -1 ? `/6/${(opfSpineItemIndex*2+2)}` : "/6/0"; // TODO Fallback !?
-
     const rootNode = EpubCfiUtils.createEmptyRootNode();
     EpubCfiBuilderHelper.appendTerminalDomRange(range, rootNode);
     let cfi = EpubCfiStringifier.stringifyRootNode(rootNode);
-    let cfi_ = cfi;
     if (cfi) {
         cfi = cfi.replace(/^epubcfi\(/, "").replace(/\)$/, "");
-        cfi_ = `epubcfi(${opfSpineItemCFIPath}!${cfi})`;
     }
-
-    const cfiFragmentSelector: ICFIFragmentSelector = {
-        type: "FragmentSelector",
-        conformsTo: "http://www.idpf.org/epub/linking/cfi/epub-cfi.html",
-        value: cfi_,
-    };
-    selector.push(cfiFragmentSelector);
 
     const cfiSelector: IEPUBCFISelector = {
         type: "EPUBCFISelector",

--- a/src/renderer/reader/redux/sagas/readiumAnnotation/selector.ts
+++ b/src/renderer/reader/redux/sagas/readiumAnnotation/selector.ts
@@ -7,7 +7,7 @@
 
 import debug_ from "debug";
 
-import { ICFIFragmentSelector, ICfiSelector, ICssSelector, IProgressionSelector, ISelector, ITextPositionSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
+import { ICFIFragmentSelector, ICssSelector, IEPUBCFISelector, IProgressionSelector, ISelector, ITextPositionSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
 import { uniqueCssSelector } from "@r2-navigator-js/electron/renderer/common/cssselector3";
 import { INoteState } from "readium-desktop/common/redux/states/renderer/note";
 import {  describeTextPosition, describeTextQuote } from "readium-desktop/third_party/apache-annotator/dom";
@@ -136,8 +136,8 @@ export function* readiumAnnotationSelectorFromNote(note: INoteState, isLcp: bool
     };
     selector.push(cfiFragmentSelector);
 
-    const cfiSelector: ICfiSelector = {
-        type: "CfiSelector",
+    const cfiSelector: IEPUBCFISelector = {
+        type: "EPUBCFISelector",
         value: cfi,
     };
     selector.push(cfiSelector);

--- a/test/common/readium/annotation/converter.test.ts
+++ b/test/common/readium/annotation/converter.test.ts
@@ -4,7 +4,7 @@ import {
     convertAnnotationStateArrayToReadiumAnnotationSet,
     convertAnnotationStateToReadiumAnnotation,
 } from "readium-desktop/common/readium/annotation/converter";
-import type { ITextQuoteSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
+import type { IEPUBCFISelector, ITextQuoteSelector } from "readium-desktop/common/readium/annotation/annotationModel.type";
 import { EDrawType, INoteState } from "readium-desktop/common/redux/states/renderer/note";
 import { PublicationView } from "readium-desktop/common/views/publication";
 
@@ -24,6 +24,11 @@ const textQuoteSelector: ITextQuoteSelector = {
     exact: "selected text",
     prefix: "",
     suffix: "",
+};
+
+const epubCfiSelector: IEPUBCFISelector = {
+    type: "EPUBCFISelector",
+    value: "/4/2,/1:0,/1:13",
 };
 
 function createNote(overrides: Partial<INoteState> = {}): INoteState {
@@ -113,4 +118,16 @@ test("Readium annotation set export filters PDF annotations and preserves EPUB a
     expect(annotationSet.items).toHaveLength(1);
     expect(annotationSet.items[0].id).toBe("urn:uuid:epub-note");
     expect(annotationSet.items[0].target.source).toBe("chapter.xhtml");
+});
+
+test("Readium annotation export preserves EPUB CFI selector vocabulary", () => {
+    const annotation = convertAnnotationStateToReadiumAnnotation(createNote({
+        readiumAnnotation: {
+            export: {
+                selector: [epubCfiSelector],
+            },
+        },
+    }));
+
+    expect(annotation?.target.selector).toContainEqual(epubCfiSelector);
 });


### PR DESCRIPTION
This PR updates the handling of CFI selectors during annotation import/export.

    On import, both the legacy CfiSelector and the standard EPUBCFISelector are supported.
    On export, only EPUBCFISelector, which is compliant with the specification, is generated.
    Removed the legacy Readium annotation export of FragmentSelector with the CFI conformsTo value.

Ref: from this commit https://github.com/readium/annotations/commit/f52c729e78e77aadf675fe0daf5ba99eae20a858 

