### PR TITLE
fix(tts): speak `<sub>`/`<sup>` content instead of discarding it

### DIFF
--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -312,7 +312,11 @@ export function findTtsQueueItemIndex(
 // tslint:disable-next-line:max-line-length
 const _putInElementStackTagNames = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "th", "td", "caption", "li", "blockquote", "q", "dt", "dd", "figcaption", "div", "pre"];
 // tslint:disable-next-line:max-line-length
-const _doNotProcessDeepChildTagNames = ["svg", "img", "sup", "sub", "audio", "video", "source", "button", "canvas", "del", "dialog", "embed", "form", "head", "iframe", "meter", "noscript", "object", "s", "script", "select", "style", "textarea"]; // "code", "nav", "dl", "figure", "table", "ul", "ol"
+const _doNotProcessDeepChildTagNames = ["svg", "img", "audio", "video", "source", "button", "canvas", "del", "dialog", "embed", "form", "head", "iframe", "meter", "noscript", "object", "s", "script", "select", "style", "textarea"]; // "code", "nav", "dl", "figure", "table", "ul", "ol"
+// note: "sup" and "sub" used to be listed above, which silently discarded their text
+// content (exponents, indices, ion charges, isotopes ... ). They are now processed like
+// any other inline element, with an aria-label/title override - see isSubSup below.
+// Note *references* are handled by the skippability mechanism instead (see _skippables).
 
 // https://www.w3.org/TR/epub-33/#sec-behaviors-skip-escape
 // https://www.w3.org/TR/epub-ssv-11/
@@ -321,6 +325,7 @@ const _skippables = [
     "endnote",
     "pagebreak",
     //
+    "noteref", // the reference marker itself, not just the note body
     "note",
     "rearnote",
     "sidebar",
@@ -660,19 +665,53 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                         }
                     }
 
+                    // sup/sub carry meaning in scientific and mathematical prose (x<sup>2</sup>,
+                    // v<sub>1</sub>, SO<sub>4</sub><sup>2-</sup>), so their text is spoken.
+                    // An aria-label/title on the element overrides it, which lets authors
+                    // supply better phrasing ("squared" rather than "2").
+                    const isSubSup = childTagNameLow === "sup" || childTagNameLow === "sub";
+                    let subSupNeedsDeepDive = isSubSup && !hidden;
+                    if (subSupNeedsDeepDive) {
+                        let altAttr = childElement.getAttribute("aria-label");
+                        if (!altAttr) {
+                            altAttr = childElement.getAttribute("title");
+                        }
+                        if (altAttr) {
+                            const txt = altAttr.trim();
+                            if (txt) {
+                                subSupNeedsDeepDive = false;
+                                const lang = getLanguage(childElement);
+                                const dir: string | undefined = undefined;
+                                ttsQueue.push({
+                                    combinedText: txt,
+                                    combinedTextSentences: undefined,
+                                    combinedTextSentencesRangeBegin: undefined,
+                                    combinedTextSentencesRangeEnd: undefined,
+                                    dir,
+                                    lang,
+                                    parentElement: childElement,
+                                    textNodes: [],
+                                    // isSkippable,
+                                });
+                            }
+                        }
+                    }
+
                     const isMathJax = childTagNameLow && childTagNameLow.startsWith("mjx-");
                     const isMathML = childTagNameLow === "math";
                     const processDeepChild =
                         pageBreakNeedsDeepDive ||
                         linkNeedsDeepDive ||
+                        subSupNeedsDeepDive ||
                         (
                         !isPageBreak &&
                         !isLink &&
+                        !isSubSup &&
                         !isMathJax &&
                         !isMathML &&
                         childTagNameLow && !_doNotProcessDeepChildTagNames.includes(childTagNameLow)
                         // tslint:disable-next-line:max-line-length
-                        // !childElement.matches("svg, img, sup, sub, audio, video, source, button, canvas, del, dialog, embed, form, head, iframe, meter, noscript, object, s, script, select, style, textarea")
+                        // !childElement.matches("svg, img, audio, video, source, button, canvas, del, dialog, embed, form, head, iframe, meter, noscript, object, s, script, select, style, textarea")
                         // code, nav, dl, figure, table, ul, ol
                         )
                     ;
@@ -680,7 +719,7 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     if (processDeepChild) {
                         processElement(childElement);
                     } else if (!hidden) {
-                        if (isPageBreak || isLink) {
+                        if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)
                         } else if (isMathML) {
                             const altAttr = childElement.getAttribute("alttext");

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -16,6 +16,12 @@ import { ReadiumElectronWebviewWindow } from "../webview/state";
 
 const win = global.window as ReadiumElectronWebviewWindow;
 
+// Virtual separator fencing the text of a sup/sub element on both sides when building
+// the utterance. One character, and it must stay one character: readaloud.ts maps
+// utterance offsets back to DOM ranges by accumulating contributed lengths, and assumes
+// a tagged node contributes exactly SUBSUP_SEPARATOR.length * 2 beyond its nodeValue.
+export const SUBSUP_SEPARATOR = " ";
+
 export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): string {
     if (textNodes && textNodes.length) {
         let str = "";
@@ -34,7 +40,28 @@ export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): st
                     txt = " ";
                     str += txt;
                 } else {
+                    // Text inside sup/sub is fenced by a separator on BOTH sides, so it
+                    // fuses with neither what precedes nor what follows it:
+                    //   "10<sup>23</sup>"        must not become "1023"  ("one thousand
+                    //                            twenty-three")
+                    //   "<em>R</em><sub>o</sub>" must not become "Ro"
+                    //   "10<sub>23</sub>45"      must not become "10 2345" ("two thousand
+                    //                            three hundred forty-five")
+                    //   "<sub>theta</sub>x"      must not become "thetax", which speech
+                    //                            engines drop entirely
+                    // The separators exist only in this string, never in the DOM, so they
+                    // cannot affect rendering - but the offset walkers in readaloud.ts
+                    // MUST account for both (see SUBSUP_SEPARATOR there), exactly as they
+                    // already do for __RUBY and for whitespace-only nodes.
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const isSubSup = (textNode as any).__SUBSUP;
+                    if (isSubSup) {
+                        str += SUBSUP_SEPARATOR;
+                    }
                     str += (skipNormalize ? txt : normalizeText(txt));
+                    if (isSubSup) {
+                        str += SUBSUP_SEPARATOR;
+                    }
                 }
             }
         }
@@ -365,6 +392,10 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
     let ttsQueue: ITtsQueueItem[] = [];
     const elementStack: Element[] = [];
 
+    // set just before descending into a sup/sub, consumed by the first text node found
+    // inside it, which then contributes SUBSUP_SEPARATOR ahead of its text
+    let pendingSubSupSeparator = false;
+
     function processTextNode(textNode: Node) {
 
         if (textNode.nodeType !== Node.TEXT_NODE) {
@@ -441,6 +472,16 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                 // isSkippable: undefined,
             };
             ttsQueue.push(current);
+        }
+
+        if (pendingSubSupSeparator) {
+            pendingSubSupSeparator = false;
+            // whitespace-only nodes already contribute a single space, so tagging one
+            // would double-count against the offset walkers
+            if (textNode.nodeValue.trim().length) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (textNode as any).__SUBSUP = true;
+            }
         }
 
         current.textNodes.push(textNode);
@@ -717,7 +758,12 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     ;
 
                     if (processDeepChild) {
+                        if (isSubSup) {
+                            // the first text node inside contributes SUBSUP_SEPARATOR
+                            pendingSubSupSeparator = true;
+                        }
                         processElement(childElement);
+                        pendingSubSupSeparator = false;
                     } else if (!hidden) {
                         if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -392,10 +392,6 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
     let ttsQueue: ITtsQueueItem[] = [];
     const elementStack: Element[] = [];
 
-    // set just before descending into a sup/sub, consumed by the first text node found
-    // inside it, which then contributes SUBSUP_SEPARATOR ahead of its text
-    let pendingSubSupSeparator = false;
-
     function processTextNode(textNode: Node) {
 
         if (textNode.nodeType !== Node.TEXT_NODE) {
@@ -474,14 +470,15 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
             ttsQueue.push(current);
         }
 
-        if (pendingSubSupSeparator) {
-            pendingSubSupSeparator = false;
-            // whitespace-only nodes already contribute a single space, so tagging one
-            // would double-count against the offset walkers
-            if (textNode.nodeValue.trim().length) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (textNode as any).__SUBSUP = true;
-            }
+        // Same idea as the __RUBY tagging above, but closest() rather than a direct
+        // parent-tag test, because inline markup inside a sup/sub is common and the text
+        // still needs fencing: <sup><a href="#fn1">1</a></sup> (footnote markers),
+        // <sup><em>n</em></sup>. With a direct parent test those read as fused again.
+        // Whitespace-only nodes already contribute a single space, so tagging one would
+        // double-count against the offset walkers in readaloud.ts.
+        if (textNode.nodeValue.trim().length && textNode.parentElement?.closest("sup, sub")) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (textNode as any).__SUBSUP = true;
         }
 
         current.textNodes.push(textNode);
@@ -758,12 +755,7 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     ;
 
                     if (processDeepChild) {
-                        if (isSubSup) {
-                            // the first text node inside contributes SUBSUP_SEPARATOR
-                            pendingSubSupSeparator = true;
-                        }
                         processElement(childElement);
-                        pendingSubSupSeparator = false;
                     } else if (!hidden) {
                         if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
@@ -736,29 +736,39 @@ function wrapHighlightWord(
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isRUBY = (txtNode as any).__RUBY;
-        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides.
-        // Those two chars have no DOM counterpart, so they are added to the contributed
-        // length here, and the leading one is subtracted back out (with the result
-        // clamped into the node) when converting an utterance offset to a DOM offset.
+        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides, so
+        // such a node contributes two characters that have no DOM counterpart. Converting
+        // an utterance offset back to a DOM offset subtracts the leading one and clamps
+        // into the node.
+        // No need to exclude isRUBY here: a node can carry both flags (<sup><ruby>...),
+        // but isRUBY is tested first in every cascade below, and combineTextNodes() skips
+        // __RUBY nodes outright, so such a node contributes 0 either way.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
-        const sep = isSUBSUP ? 1 : 0;
+        const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
         const nodeLen = txtNode.nodeValue.length;
 
-        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
+        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
         acc += l;
         if (!rangeStartNode) {
             if (isRUBY && charIndexAdjusted <= acc
                 || charIndexAdjusted < acc) {
                 rangeStartNode = txtNode;
-                rangeStartOffset = isRUBY ? 0 :
-                    Math.min(Math.max(l - (acc - charIndexAdjusted) - sep, 0), nodeLen);
+                rangeStartOffset =
+                    isRUBY ?
+                    0 :
+                    isSUBSUP ?
+                    Math.min(Math.max(l - (acc - charIndexAdjusted) - 1, 0), nodeLen) :
+                    (l - (acc - charIndexAdjusted));
             }
         }
         if (rangeStartNode && charIndexEnd <= acc) {
             rangeEndNode = txtNode;
-            rangeEndOffset = isRUBY ? (nodeLen - 1) :
-                Math.min(Math.max(l - (acc - charIndexEnd) - sep, 0), nodeLen);
+            rangeEndOffset =
+                isRUBY ?
+                (nodeLen - 1) :
+                isSUBSUP ?
+                Math.min(Math.max(l - (acc - charIndexEnd) - 1, 0), nodeLen) :
+                (l - (acc - charIndexEnd));
             break;
         }
     }
@@ -924,24 +934,31 @@ function wrapHighlight(
                 const isRUBY = (txtNode as any).__RUBY;
                 // see the equivalent adjustment in updateTTSInfo() above
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
-                const sep = isSUBSUP ? 1 : 0;
+                const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
                 const nodeLen = txtNode.nodeValue.length;
 
-                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
+                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
                 acc += l;
                 if (!rangeStartNode) {
                     if (isRUBY && sentBegin <= acc
                         || sentBegin < acc) {
                         rangeStartNode = txtNode;
-                        rangeStartOffset = isRUBY ? 0 :
-                            Math.min(Math.max(l - (acc - sentBegin) - sep, 0), nodeLen);
+                        rangeStartOffset =
+                            isRUBY ?
+                            0 :
+                            isSUBSUP ?
+                            Math.min(Math.max(l - (acc - sentBegin) - 1, 0), nodeLen) :
+                            (l - (acc - sentBegin));
                     }
                 }
                 if (rangeStartNode && sentEnd <= acc) {
                     rangeEndNode = txtNode;
-                    rangeEndOffset = isRUBY ? (nodeLen - 1) :
-                        Math.min(Math.max(l - (acc - sentEnd) - sep, 0), nodeLen);
+                    rangeEndOffset =
+                        isRUBY ?
+                        (nodeLen - 1) :
+                        isSUBSUP ?
+                        Math.min(Math.max(l - (acc - sentEnd) - 1, 0), nodeLen) :
+                        (l - (acc - sentEnd));
                     break;
                 }
             }

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
@@ -736,19 +736,29 @@ function wrapHighlightWord(
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isRUBY = (txtNode as any).__RUBY;
+        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides.
+        // Those two chars have no DOM counterpart, so they are added to the contributed
+        // length here, and the leading one is subtracted back out (with the result
+        // clamped into the node) when converting an utterance offset to a DOM offset.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+        const sep = isSUBSUP ? 1 : 0;
+        const nodeLen = txtNode.nodeValue.length;
 
-        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : txtNode.nodeValue.length;
+        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
         acc += l;
         if (!rangeStartNode) {
             if (isRUBY && charIndexAdjusted <= acc
                 || charIndexAdjusted < acc) {
                 rangeStartNode = txtNode;
-                rangeStartOffset = isRUBY ? 0 : l - (acc - charIndexAdjusted);
+                rangeStartOffset = isRUBY ? 0 :
+                    Math.min(Math.max(l - (acc - charIndexAdjusted) - sep, 0), nodeLen);
             }
         }
         if (rangeStartNode && charIndexEnd <= acc) {
             rangeEndNode = txtNode;
-            rangeEndOffset = isRUBY ? (txtNode.nodeValue.length - 1) : l - (acc - charIndexEnd);
+            rangeEndOffset = isRUBY ? (nodeLen - 1) :
+                Math.min(Math.max(l - (acc - charIndexEnd) - sep, 0), nodeLen);
             break;
         }
     }
@@ -912,19 +922,26 @@ function wrapHighlight(
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const isRUBY = (txtNode as any).__RUBY;
+                // see the equivalent adjustment in updateTTSInfo() above
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+                const sep = isSUBSUP ? 1 : 0;
+                const nodeLen = txtNode.nodeValue.length;
 
-                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : txtNode.nodeValue.length;
+                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
                 acc += l;
                 if (!rangeStartNode) {
                     if (isRUBY && sentBegin <= acc
                         || sentBegin < acc) {
                         rangeStartNode = txtNode;
-                        rangeStartOffset = isRUBY ? 0 : l - (acc - sentBegin);
+                        rangeStartOffset = isRUBY ? 0 :
+                            Math.min(Math.max(l - (acc - sentBegin) - sep, 0), nodeLen);
                     }
                 }
                 if (rangeStartNode && sentEnd <= acc) {
                     rangeEndNode = txtNode;
-                    rangeEndOffset = isRUBY ? (txtNode.nodeValue.length - 1) : l - (acc - sentEnd);
+                    rangeEndOffset = isRUBY ? (nodeLen - 1) :
+                        Math.min(Math.max(l - (acc - sentEnd) - sep, 0), nodeLen);
                     break;
                 }
             }


### PR DESCRIPTION
Fixes #<!-- ISSUE -->

Part 1 of 2. #<!-- PR2 --> is stacked on this branch and adds a `ttsSubSupEnabled`
preference (default on) as an opt-out for the behaviour change noted at the bottom.
This PR stands alone if you would rather not take the preference.

## What

`<sub>` and `<sup>` text was never spoken by read-aloud. In scientific prose this
does not merely sound awkward, it changes the statement: `πr<sup>2</sup>` was read
as "pi r", `v<sub>1</sub>` as "v", `SO<sub>4</sub><sup>2-</sup>` as "SO".

Three changes in
`src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts`:

1. **`"sup"`/`"sub"` removed from `_doNotProcessDeepChildTagNames`**, with
   `!isSubSup` added to the deep-dive condition. The elements are now descended
   into like any other inline element, which keeps their text in the *surrounding*
   utterance — `v<sub>1</sub>` reads as one phrase, and the `textNodes` array stays
   populated so word-level highlighting keeps working. (Pushing a separate queue
   item, as `img` does, would have fragmented every sentence containing an index.)

2. **An `aria-label` / `title` override**, following the existing
   `linkNeedsDeepDive` idiom, so authors can supply better phrasing:
   `<sup aria-label="squared">2</sup>`. Consistent with the `math` branch a few
   lines below, which prefers `alttext` and falls back to `textContent`.

3. **`"noteref"` added to `_skippables`.** This is what makes (1) safe: footnote
   *reference* markers were previously suppressed only as a side effect of the tag
   blacklist. `_skippables` listed note *bodies* (`footnote`, `endnote`, `note`,
   `rearnote`) but never the reference. `computeEpubTypes` already resolves
   `epub:type="noteref"` and normalises `role="doc-noteref"` → `noteref`, so only
   the list entry was missing. Correctly-marked references stay silent, now via the
   mechanism intended for it and under the user's existing skippability control.

## Why not just add an alt-text fallback and leave the blacklist alone

That would have left every existing book silent, since the fallback only fires when
the attribute is present — the fix would have required every publisher to re-mark
their content. The `math` branch already establishes the better pattern in this same
function: attribute if provided, content otherwise.

## Verification

Confirmed by ear in a running build (this branch on `develop`), on a real EPUB, for
both fusion classes:

| passage | before | after |
|---|---|---|
| `…two atoms of oxygen (written O<sub>2</sub>), we have 6.0214076 * 10<sup>23</sup>…` | "written O … times 10" | "written O 2 … times 10 23" |
| `…relative sizes of r, R<sub>o</sub>, and R<sub>i</sub>… R<sub>o</sub> = 0.05 m, R<sub>i</sub> = 0.04 m` | "r, R and R … R = 0.05 m, R = 0.04 m" | "r, R o, and R i … R o = 0.05, R i = 0.04" |

A small test EPUB covering all seventeen cases is linked from #<!-- ISSUE --> (with the
script that generates it). Running `generateTtsQueue()` over that file from `develop`
and from this branch gives:

| test | develop | this branch |
|---|---|---|
| 1 `v₁ v₂` | "v and v" | "v 1 and v 2" |
| 2 `R_o R_i` | "R and R" | "R o and R i" |
| 3 `t_o` | "t" | "t o" |
| 4 `10²³` | "10" | "10 23" |
| 6 `H₂O` | "HO" | "H 2O" |
| 7 `x₁²` | "x" | "x 1 2" |
| 8 `aria-label="squared"` | "x" | "x" + "squared" |
| 10 `epub:type="noteref"` | silent | **silent** |
| 11 `role="doc-noteref"` | silent | **silent** |
| 12 bare `<sup>` marker | silent | "3" |
| 13 `display:none` | silent | **silent** |
| 14 plain prose | unchanged | **unchanged** |

Tests 10, 11, 13 and 14 are the regression cases and are unaffected. Test 12 is the
single behaviour change, covered by the preference in #<!-- PR2 -->.

Plus:

- `tsc --noEmit -p tsconfig.json` — exit 0, zero diagnostics
- `eslint` on the changed file — clean, identical to baseline
- Behavioural diff: `generateTtsQueue()` bundled from this branch and from
  `develop`, run against jsdom fixtures, comparing `combinedText`. At the default
  setting (skippability on):

| fixture | before | after |
|---|---|---|
| `&#x3C0;<em>r</em><sup>2</sup>` | `"the area is πr exactly"` | `"the area is πr2 exactly"` |
| `<em>v</em><sub>1</sub> … <sub>2</sub>` | `"compare v with v"` | `"compare v1 with v2"` |
| `SO<sub>4</sub><sup>2-</sup>` | `"the SO ion"` | `"the SO42- ion"` |
| `&#x3BC;<sub>s</sub>` | `"use μ for static"` | `"use μs for static"` |
| `<sup aria-label="squared">2</sup>` | `"the area is r here"` | `"the area is r"`, `"squared"`, `"here"` |
| `<sup><a epub:type="noteref">1</a></sup>` | `"as shown earlier"` | unchanged |
| `<sup><a role="doc-noteref">1</a></sup>` | `"as shown earlier"` | unchanged |
| `<sup><a href="#fn1">1</a></sup>` | `"as shown earlier"` | `"as shown1 earlier"` |
| `<sup style="display:none">9</sup>` | `"visible text"` | unchanged |

I can contribute the fixture harness as a jest test if you want it in-tree; it
needs `jest-environment-jsdom`, which isn't currently a devDependency, so I left it
out of this PR rather than expand the dependency set unasked.

## Why removing the tags from the list is not sufficient on its own (commit 3)

`combineTextNodes()` joins raw `nodeValue`s with no separator, so a base and its
sub/superscript reach the speech engine as **one token**:

| markup | on `develop` | naively spoken | with commit 3 |
|---|---|---|---|
| `10<sup>23</sup>` | "ten" | "one thousand twenty-three" | "ten, twenty-three" |
| `<em>R</em><sub>o</sub>` | "R" | "Ro" (one syllable) | "R o" |
| `<em>t</em><sub>o</sub>` | "t" | "to" (the word) | "t o" |
| `<em>x</em><sup>2</sup>` | "x" | "x 2" ✔ | "x 2" ✔ |

Measured on a 12-chapter physics textbook: of 172 prose `sub`/`sup` sites, **8 fused
into a false number and 40 into a false word**. That is 28% of sites producing
confidently wrong output — which is very likely *why* `sup`/`sub` were put on
`_doNotProcessDeepChildTagNames` to begin with.

**This is not platform-specific.** Measured on all three desktop platforms, each
through the Web Speech API so it is that platform's real engine — macOS Samantha,
espeak-ng via speech-dispatcher on Linux, SAPI `Speech_OneCore` under Chrome on Windows:

| utterance | macOS | espeak-ng | SAPI |
|---|---|---|---|
| `we have 1023 atoms` | 2.198s | 2.514s | 3.298s |
| `we have one thousand twenty three atoms` | 2.310s | 2.546s | 3.087s |
| `we have 10 23 atoms` | 1.860s | 2.108s | 2.677s |
| `compare Ro with Ri` / `compare R o with R i` | 1.303s / 1.689s | 1.458s / 1.809s | 2.086s / 2.216s |
| `the time to matters` / `the time t o matters` | 1.306s / 1.540s | 1.404s / 1.596s | 1.996s / 2.266s |

On every engine `1023` matches the spelled-out number rather than the split digits, and
the fused letters run shorter than the separated ones — the digits are parsed as one
number and the letters as one syllable everywhere, so the separator is needed on all
three. It reads as a blunt guard against
garbage rather than an oversight, so this PR would not be defensible without
addressing it.

So text inside `sup`/`sub` now contributes a leading `SUBSUP_SEPARATOR` when the
utterance string is assembled. **The separator exists only in that string, never in
the DOM**, so rendering, CFIs and locators are untouched.

### Why a plain space, and not a zero-width character

U+FEFF is the obvious alternative, and on macOS it works exactly as well — timing
synthesised speech, `10<FEFF>23` and `10 23` come out within 4 ms of each other in
every case I tried. I still went with a space, for two reasons.

It cannot be discarded. U+FEFF is `Default_Ignorable_Code_Point`, so an engine that
strips it before tokenising is doing what the character's definition invites, not
misbehaving. Were an engine to do that, this fix would silently do nothing there and
the failure would look exactly like the bug it was meant to fix. A space has no such
licence anywhere in the chain.

And the separator is visible to the user in a place where visibility helps. The
utterance string is what the read-aloud panel displays, and that panel shows what is
about to be *spoken*, not what the book looks like — the sub/sup distinction is already
gone from it. `H 2 O` truthfully shows the separation being applied; `H2O` would render
identically whether the subscript were separated, fused, or dropped altogether, which is
precisely the ambiguity that made this bug hard to notice in the first place.

This follows the existing `__RUBY` convention exactly: tag the text node, and have
`combineTextNodes()` and the two offset walkers in `readaloud.ts` agree on the length
that node contributes. The walkers subtract the separator back out when converting an
utterance offset into a DOM offset, so word- and sentence-level highlighting stay
aligned. I verified that by replicating the walker and mapping **every** utterance
offset back to its DOM character across fusion, non-fusion and nested-element
fixtures — 0 mismatches.

Note this makes the utterance say "ten, twenty-three" rather than "ten to the
twenty-third". Correct pronunciation of an exponent needs semantics, which is what
the `aria-label` override in commit 2 is for; the separator's job is only to stop the
reader inventing a different number.

## Behaviour change / release note

Note references marked up as a bare `<sup>` with no `epub:type` or `role` will now
have their marker spoken. Correctly-marked references are unaffected at the default
setting, since `"noteref"` is now in `_skippables` and skippability defaults to on
(`mediaOverlaysEnableSkippability: true` drives `ttsSkippabilityEnable`).

#<!-- PR2 --> adds a `ttsSubSupEnabled` preference (default on) as an explicit
opt-out for that case; switching it off reproduces current `develop` output
byte-for-byte on every fixture above.

The `aria-label` override emits its own queue item, so it splits the sentence into
three utterances — the same as the existing `img`/link/pagebreak overrides, but more
audible inline. Change 2 can be dropped independently of 1 and 3 if you would
rather not have that.