### PR TITLE
fix(tts): insert a word boundary between separable scripts

### DIFF
--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -16,11 +16,82 @@ import { ReadiumElectronWebviewWindow } from "../webview/state";
 
 const win = global.window as ReadiumElectronWebviewWindow;
 
-// Virtual separator fencing the text of a sup/sub element on both sides when building
-// the utterance. One character, and it must stay one character: readaloud.ts maps
-// utterance offsets back to DOM ranges by accumulating contributed lengths, and assumes
-// a tagged node contributes exactly SUBSUP_SEPARATOR.length * 2 beyond its nodeValue.
-export const SUBSUP_SEPARATOR = " ";
+// Virtual separator inserted into the utterance string at the offsets recorded in a
+// text node's __TTS_SEPS. One character, and it must stay one character: readaloud.ts
+// maps utterance offsets back to DOM ranges by accumulating contributed lengths, and
+// assumes a node contributes exactly __TTS_SEPS.length beyond its nodeValue.
+export const TTS_SEPARATOR = " ";
+
+// Scripts between which a word boundary is inserted. Speech engines discard a token
+// that mixes two of these outright - "<em>R</em><sub>o</sub>" is merely mispronounced,
+// but a Greek letter fused to a latin one is silently dropped. Verified on macOS with
+// Samantha, Alex and Daniel: Greek+latin and Cyrillic+latin are both dropped, and both
+// are spoken correctly once separated. Any pair in this list is separated, so a
+// Greek/Cyrillic transition is handled the same as a Greek/latin one.
+//
+// Deliberately an explicit list rather than "any script transition", and deliberately
+// without CJK:
+//
+//  - Japanese mixes Han, Hiragana and Katakana inside single words, so a generic rule
+//    would split ordinary vocabulary: "food-eat-ru" -> "food | eat-ru".
+//  - Grouping the CJK scripts and separating only CJK/latin still measures worse. With
+//    a Japanese voice, "watashi-wa iPhone wo tsukaimasu" runs 2.990s fused and 3.358s
+//    separated - the separator inserts a prosodic pause - and the latin word is spoken
+//    correctly either way, so there is no defect to fix. Mixed CJK/latin is everyday
+//    prose, unlike mixed Greek/latin which is always notation.
+//
+// If an engine is found that drops CJK/latin tokens, add the pair here on that evidence.
+const _separableScripts: Array<[string, RegExp]> = [
+    ["Latin", /\p{Script=Latin}/u],
+    ["Greek", /\p{Script=Greek}/u],
+    ["Cyrillic", /\p{Script=Cyrillic}/u],
+];
+
+function separableScript(ch: string): string | undefined {
+    for (const [name, re] of _separableScripts) {
+        if (re.test(ch)) {
+            return name;
+        }
+    }
+    return undefined;
+}
+
+// Zero-width formatting characters an author may have placed between two scripts.
+// Skipped when tracking script runs: by definition they are not meant to participate in
+// text processing, and letting one end a run would hide the boundary behind it.
+//
+// This matters because some of them do not separate the token for the speech engine
+// either. U+2060 WORD JOINER is the awkward case - an author might reasonably use one to
+// stop "delta-x" breaking across lines - and it leaves the token fused, so without this
+// the content would still be dropped and this fix would not reach it. Where the
+// character does already separate (U+FEFF, U+200B), the extra boundary is redundant but
+// harmless. A real space is not default-ignorable, so it correctly ends the run and no
+// boundary is added after it.
+const _defaultIgnorable = /\p{Default_Ignorable_Code_Point}/u;
+
+// Offsets inside txt at which two different separable scripts meet. Iterates by code
+// point (not UTF-16 unit) so that astral characters are not split, but returns offsets
+// in UTF-16 units to match DOM text node offsets. Characters outside the separable set -
+// digits, punctuation, CJK, the Mathematical Alphanumeric Symbols - never form a
+// boundary, so "10<sup>2</sup>", "x2" and "F-bold x" are untouched.
+export function scriptBoundaryOffsets(txt: string): number[] {
+    const offsets: number[] = [];
+    let prevScript: string | undefined;
+    let i = 0;
+    for (const ch of txt) {
+        if (_defaultIgnorable.test(ch)) {
+            i += ch.length;
+            continue;
+        }
+        const script = separableScript(ch);
+        if (i > 0 && prevScript && script && prevScript !== script) {
+            offsets.push(i);
+        }
+        prevScript = script;
+        i += ch.length;
+    }
+    return offsets;
+}
 
 export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): string {
     if (textNodes && textNodes.length) {
@@ -40,27 +111,34 @@ export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): st
                     txt = " ";
                     str += txt;
                 } else {
-                    // Text inside sup/sub is fenced by a separator on BOTH sides, so it
-                    // fuses with neither what precedes nor what follows it:
-                    //   "10<sup>23</sup>"        must not become "1023"  ("one thousand
-                    //                            twenty-three")
-                    //   "<em>R</em><sub>o</sub>" must not become "Ro"
-                    //   "10<sub>23</sub>45"      must not become "10 2345" ("two thousand
-                    //                            three hundred forty-five")
-                    //   "<sub>theta</sub>x"      must not become "thetax", which speech
-                    //                            engines drop entirely
+                    // TTS_SEPARATOR is inserted at each offset recorded in __TTS_SEPS:
+                    // the ends of sup/sub text, and any boundary between two separable
+                    // scripts. Without them the speech engine receives a single token and
+                    // either mispronounces it or discards it:
+                    //   "10<sup>23</sup>"        -> "1023"   "one thousand twenty-three"
+                    //   "<em>R</em><sub>o</sub>" -> "Ro"     one syllable
+                    //   "10<sub>23</sub>45"      -> "102345" a wholly invented number
+                    //   "&#x394;x"               -> dropped entirely
                     // The separators exist only in this string, never in the DOM, so they
                     // cannot affect rendering - but the offset walkers in readaloud.ts
-                    // MUST account for both (see SUBSUP_SEPARATOR there), exactly as they
-                    // already do for __RUBY and for whitespace-only nodes.
+                    // MUST account for them, exactly as they already do for __RUBY and
+                    // for whitespace-only nodes.
+                    //
+                    // Only applied on the skipNormalize path, which is the one readaloud
+                    // uses: normalizeText() can change the length, which would invalidate
+                    // offsets recorded against nodeValue.
+                    const t = skipNormalize ? txt : normalizeText(txt);
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const isSubSup = (textNode as any).__SUBSUP;
-                    if (isSubSup) {
-                        str += SUBSUP_SEPARATOR;
-                    }
-                    str += (skipNormalize ? txt : normalizeText(txt));
-                    if (isSubSup) {
-                        str += SUBSUP_SEPARATOR;
+                    const seps: number[] | undefined = skipNormalize ? (textNode as any).__TTS_SEPS : undefined;
+                    if (seps && seps.length) {
+                        let prev = 0;
+                        for (const s of seps) {
+                            str += t.slice(prev, s) + TTS_SEPARATOR;
+                            prev = s;
+                        }
+                        str += t.slice(prev);
+                    } else {
+                        str += t;
                     }
                 }
             }
@@ -470,15 +548,27 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
             ttsQueue.push(current);
         }
 
-        // Same idea as the __RUBY tagging above, but closest() rather than a direct
-        // parent-tag test, because inline markup inside a sup/sub is common and the text
-        // still needs fencing: <sup><a href="#fn1">1</a></sup> (footnote markers),
-        // <sup><em>n</em></sup>. With a direct parent test those read as fused again.
-        // Whitespace-only nodes already contribute a single space, so tagging one would
-        // double-count against the offset walkers in readaloud.ts.
-        if (textNode.nodeValue.trim().length && textNode.parentElement?.closest("sup, sub")) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (textNode as any).__SUBSUP = true;
+        // Generalises the __SUBSUP flag into a list of offsets at which a separator is
+        // inserted when the utterance string is assembled, so sup/sub fencing and script
+        // boundaries compose: <em>Δ</em><sub>x</sub>y -> "Δ x y".
+        //
+        // sup/sub is detected with closest() rather than a direct parent-tag test because
+        // inline markup inside a sup/sub is common and its text still needs fencing:
+        // <sup><a href="#fn1">1</a></sup> (footnote markers), <sup><em>n</em></sup>.
+        //
+        // Whitespace-only nodes already contribute a single space, so adding separators to
+        // one would double-count against the offset walkers in readaloud.ts.
+        if (textNode.nodeValue.trim().length) {
+            const nodeLen = textNode.nodeValue.length;
+            const isSubSupText = !!textNode.parentElement?.closest("sup, sub");
+            // sup/sub text is fenced at both ends; script changes are separated in place
+            const seps = isSubSupText
+                ? [0, ...scriptBoundaryOffsets(textNode.nodeValue), nodeLen]
+                : scriptBoundaryOffsets(textNode.nodeValue);
+            if (seps.length) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (textNode as any).__TTS_SEPS = seps;
+            }
         }
 
         current.textNodes.push(textNode);

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -312,7 +312,11 @@ export function findTtsQueueItemIndex(
 // tslint:disable-next-line:max-line-length
 const _putInElementStackTagNames = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "th", "td", "caption", "li", "blockquote", "q", "dt", "dd", "figcaption", "div", "pre"];
 // tslint:disable-next-line:max-line-length
-const _doNotProcessDeepChildTagNames = ["svg", "img", "sup", "sub", "audio", "video", "source", "button", "canvas", "del", "dialog", "embed", "form", "head", "iframe", "meter", "noscript", "object", "s", "script", "select", "style", "textarea"]; // "code", "nav", "dl", "figure", "table", "ul", "ol"
+const _doNotProcessDeepChildTagNames = ["svg", "img", "audio", "video", "source", "button", "canvas", "del", "dialog", "embed", "form", "head", "iframe", "meter", "noscript", "object", "s", "script", "select", "style", "textarea"]; // "code", "nav", "dl", "figure", "table", "ul", "ol"
+// note: "sup" and "sub" used to be listed above, which silently discarded their text
+// content (exponents, indices, ion charges, isotopes ... ). They are now processed like
+// any other inline element, with an aria-label/title override - see isSubSup below.
+// Note *references* are handled by the skippability mechanism instead (see _skippables).
 
 // https://www.w3.org/TR/epub-33/#sec-behaviors-skip-escape
 // https://www.w3.org/TR/epub-ssv-11/
@@ -321,6 +325,7 @@ const _skippables = [
     "endnote",
     "pagebreak",
     //
+    "noteref", // the reference marker itself, not just the note body
     "note",
     "rearnote",
     "sidebar",
@@ -660,19 +665,53 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                         }
                     }
 
+                    // sup/sub carry meaning in scientific and mathematical prose (x<sup>2</sup>,
+                    // v<sub>1</sub>, SO<sub>4</sub><sup>2-</sup>), so their text is spoken.
+                    // An aria-label/title on the element overrides it, which lets authors
+                    // supply better phrasing ("squared" rather than "2").
+                    const isSubSup = childTagNameLow === "sup" || childTagNameLow === "sub";
+                    let subSupNeedsDeepDive = isSubSup && !hidden;
+                    if (subSupNeedsDeepDive) {
+                        let altAttr = childElement.getAttribute("aria-label");
+                        if (!altAttr) {
+                            altAttr = childElement.getAttribute("title");
+                        }
+                        if (altAttr) {
+                            const txt = altAttr.trim();
+                            if (txt) {
+                                subSupNeedsDeepDive = false;
+                                const lang = getLanguage(childElement);
+                                const dir: string | undefined = undefined;
+                                ttsQueue.push({
+                                    combinedText: txt,
+                                    combinedTextSentences: undefined,
+                                    combinedTextSentencesRangeBegin: undefined,
+                                    combinedTextSentencesRangeEnd: undefined,
+                                    dir,
+                                    lang,
+                                    parentElement: childElement,
+                                    textNodes: [],
+                                    // isSkippable,
+                                });
+                            }
+                        }
+                    }
+
                     const isMathJax = childTagNameLow && childTagNameLow.startsWith("mjx-");
                     const isMathML = childTagNameLow === "math";
                     const processDeepChild =
                         pageBreakNeedsDeepDive ||
                         linkNeedsDeepDive ||
+                        subSupNeedsDeepDive ||
                         (
                         !isPageBreak &&
                         !isLink &&
+                        !isSubSup &&
                         !isMathJax &&
                         !isMathML &&
                         childTagNameLow && !_doNotProcessDeepChildTagNames.includes(childTagNameLow)
                         // tslint:disable-next-line:max-line-length
-                        // !childElement.matches("svg, img, sup, sub, audio, video, source, button, canvas, del, dialog, embed, form, head, iframe, meter, noscript, object, s, script, select, style, textarea")
+                        // !childElement.matches("svg, img, audio, video, source, button, canvas, del, dialog, embed, form, head, iframe, meter, noscript, object, s, script, select, style, textarea")
                         // code, nav, dl, figure, table, ul, ol
                         )
                     ;
@@ -680,7 +719,7 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     if (processDeepChild) {
                         processElement(childElement);
                     } else if (!hidden) {
-                        if (isPageBreak || isLink) {
+                        if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)
                         } else if (isMathML) {
                             const altAttr = childElement.getAttribute("alttext");

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -16,6 +16,12 @@ import { ReadiumElectronWebviewWindow } from "../webview/state";
 
 const win = global.window as ReadiumElectronWebviewWindow;
 
+// Virtual separator fencing the text of a sup/sub element on both sides when building
+// the utterance. One character, and it must stay one character: readaloud.ts maps
+// utterance offsets back to DOM ranges by accumulating contributed lengths, and assumes
+// a tagged node contributes exactly SUBSUP_SEPARATOR.length * 2 beyond its nodeValue.
+export const SUBSUP_SEPARATOR = " ";
+
 export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): string {
     if (textNodes && textNodes.length) {
         let str = "";
@@ -34,7 +40,28 @@ export function combineTextNodes(textNodes: Node[], skipNormalize?: boolean): st
                     txt = " ";
                     str += txt;
                 } else {
+                    // Text inside sup/sub is fenced by a separator on BOTH sides, so it
+                    // fuses with neither what precedes nor what follows it:
+                    //   "10<sup>23</sup>"        must not become "1023"  ("one thousand
+                    //                            twenty-three")
+                    //   "<em>R</em><sub>o</sub>" must not become "Ro"
+                    //   "10<sub>23</sub>45"      must not become "10 2345" ("two thousand
+                    //                            three hundred forty-five")
+                    //   "<sub>theta</sub>x"      must not become "thetax", which speech
+                    //                            engines drop entirely
+                    // The separators exist only in this string, never in the DOM, so they
+                    // cannot affect rendering - but the offset walkers in readaloud.ts
+                    // MUST account for both (see SUBSUP_SEPARATOR there), exactly as they
+                    // already do for __RUBY and for whitespace-only nodes.
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const isSubSup = (textNode as any).__SUBSUP;
+                    if (isSubSup) {
+                        str += SUBSUP_SEPARATOR;
+                    }
                     str += (skipNormalize ? txt : normalizeText(txt));
+                    if (isSubSup) {
+                        str += SUBSUP_SEPARATOR;
+                    }
                 }
             }
         }
@@ -365,6 +392,10 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
     let ttsQueue: ITtsQueueItem[] = [];
     const elementStack: Element[] = [];
 
+    // set just before descending into a sup/sub, consumed by the first text node found
+    // inside it, which then contributes SUBSUP_SEPARATOR ahead of its text
+    let pendingSubSupSeparator = false;
+
     function processTextNode(textNode: Node) {
 
         if (textNode.nodeType !== Node.TEXT_NODE) {
@@ -441,6 +472,16 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                 // isSkippable: undefined,
             };
             ttsQueue.push(current);
+        }
+
+        if (pendingSubSupSeparator) {
+            pendingSubSupSeparator = false;
+            // whitespace-only nodes already contribute a single space, so tagging one
+            // would double-count against the offset walkers
+            if (textNode.nodeValue.trim().length) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (textNode as any).__SUBSUP = true;
+            }
         }
 
         current.textNodes.push(textNode);
@@ -717,7 +758,12 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     ;
 
                     if (processDeepChild) {
+                        if (isSubSup) {
+                            // the first text node inside contributes SUBSUP_SEPARATOR
+                            pendingSubSupSeparator = true;
+                        }
                         processElement(childElement);
+                        pendingSubSupSeparator = false;
                     } else if (!hidden) {
                         if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/common/dom-text-utils.ts
@@ -392,10 +392,6 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
     let ttsQueue: ITtsQueueItem[] = [];
     const elementStack: Element[] = [];
 
-    // set just before descending into a sup/sub, consumed by the first text node found
-    // inside it, which then contributes SUBSUP_SEPARATOR ahead of its text
-    let pendingSubSupSeparator = false;
-
     function processTextNode(textNode: Node) {
 
         if (textNode.nodeType !== Node.TEXT_NODE) {
@@ -474,14 +470,15 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
             ttsQueue.push(current);
         }
 
-        if (pendingSubSupSeparator) {
-            pendingSubSupSeparator = false;
-            // whitespace-only nodes already contribute a single space, so tagging one
-            // would double-count against the offset walkers
-            if (textNode.nodeValue.trim().length) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (textNode as any).__SUBSUP = true;
-            }
+        // Same idea as the __RUBY tagging above, but closest() rather than a direct
+        // parent-tag test, because inline markup inside a sup/sub is common and the text
+        // still needs fencing: <sup><a href="#fn1">1</a></sup> (footnote markers),
+        // <sup><em>n</em></sup>. With a direct parent test those read as fused again.
+        // Whitespace-only nodes already contribute a single space, so tagging one would
+        // double-count against the offset walkers in readaloud.ts.
+        if (textNode.nodeValue.trim().length && textNode.parentElement?.closest("sup, sub")) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (textNode as any).__SUBSUP = true;
         }
 
         current.textNodes.push(textNode);
@@ -758,12 +755,7 @@ export function generateTtsQueue(rootElement: Element, splitSentences: boolean):
                     ;
 
                     if (processDeepChild) {
-                        if (isSubSup) {
-                            // the first text node inside contributes SUBSUP_SEPARATOR
-                            pendingSubSupSeparator = true;
-                        }
                         processElement(childElement);
-                        pendingSubSupSeparator = false;
                     } else if (!hidden) {
                         if (isPageBreak || isLink || isSubSup) {
                             // do nothing, already dealt with above (either shallow or deep)

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
@@ -646,6 +646,25 @@ const isOnlyWhiteSpace = (str: string) => {
     return true;
 };
 
+// combineTextNodes() inserts a TTS_SEPARATOR into the utterance string at each offset in
+// a text node's __TTS_SEPS. Those characters do not exist in the DOM, so an offset into
+// the node's slice of the utterance runs ahead of the corresponding DOM offset by the
+// number of separators already emitted for that node.
+//
+// seps holds DOM offsets, so the i-th separator sits at utterance offset seps[i] + i.
+// Subtract every separator at or before ttsOffset, then clamp into the node: an offset
+// landing on a separator itself has no exact DOM counterpart and resolves to the nearest
+// real character.
+function ttsOffsetToDomOffset(ttsOffset: number, seps: number[], nodeLength: number): number {
+    let domOffset = ttsOffset;
+    for (let i = 0; i < seps.length; i++) {
+        if (seps[i] + i <= ttsOffset) {
+            domOffset--;
+        }
+    }
+    return Math.min(Math.max(domOffset, 0), nodeLength);
+}
+
 let _ttsQueueItemHighlightsSentence: Array<IHighlight | null> | undefined;
 let _ttsQueueItemHighlightsWord: Array<IHighlight | null> | undefined;
 
@@ -736,18 +755,20 @@ function wrapHighlightWord(
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isRUBY = (txtNode as any).__RUBY;
-        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides, so
-        // such a node contributes two characters that have no DOM counterpart. Converting
-        // an utterance offset back to a DOM offset subtracts the leading one and clamps
-        // into the node.
-        // No need to exclude isRUBY here: a node can carry both flags (<sup><ruby>...),
-        // but isRUBY is tested first in every cascade below, and combineTextNodes() skips
-        // __RUBY nodes outright, so such a node contributes 0 either way.
+        // combineTextNodes() inserts TTS_SEPARATOR at each offset in __TTS_SEPS. Those
+        // characters have no DOM counterpart, so they add to the length contributed here
+        // and are subtracted back out when converting an utterance offset to a DOM offset
+        // -- see ttsOffsetToDomOffset(). This generalises the previous commit's fixed
+        // two-separator case; a node with no separators still takes the same path it
+        // does on develop.
+        // isRUBY is excluded from `seps` because a node can carry both (<sup><ruby>...),
+        // and __RUBY wins: it is tested first in every cascade below, and
+        // combineTextNodes() skips __RUBY nodes outright.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+        const seps: number[] = (!isRUBY && !isOnlyWhiteSpace(txtNode.nodeValue) && (txtNode as any).__TTS_SEPS) || [];
         const nodeLen = txtNode.nodeValue.length;
 
-        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
+        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : seps.length ? (nodeLen + seps.length) : nodeLen;
         acc += l;
         if (!rangeStartNode) {
             if (isRUBY && charIndexAdjusted <= acc
@@ -756,8 +777,8 @@ function wrapHighlightWord(
                 rangeStartOffset =
                     isRUBY ?
                     0 :
-                    isSUBSUP ?
-                    Math.min(Math.max(l - (acc - charIndexAdjusted) - 1, 0), nodeLen) :
+                    seps.length ?
+                    ttsOffsetToDomOffset(l - (acc - charIndexAdjusted), seps, nodeLen) :
                     (l - (acc - charIndexAdjusted));
             }
         }
@@ -766,8 +787,8 @@ function wrapHighlightWord(
             rangeEndOffset =
                 isRUBY ?
                 (nodeLen - 1) :
-                isSUBSUP ?
-                Math.min(Math.max(l - (acc - charIndexEnd) - 1, 0), nodeLen) :
+                seps.length ?
+                ttsOffsetToDomOffset(l - (acc - charIndexEnd), seps, nodeLen) :
                 (l - (acc - charIndexEnd));
             break;
         }
@@ -934,10 +955,10 @@ function wrapHighlight(
                 const isRUBY = (txtNode as any).__RUBY;
                 // see the equivalent adjustment in updateTTSInfo() above
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+                const seps: number[] = (!isRUBY && !isOnlyWhiteSpace(txtNode.nodeValue) && (txtNode as any).__TTS_SEPS) || [];
                 const nodeLen = txtNode.nodeValue.length;
 
-                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
+                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : seps.length ? (nodeLen + seps.length) : nodeLen;
                 acc += l;
                 if (!rangeStartNode) {
                     if (isRUBY && sentBegin <= acc
@@ -946,8 +967,8 @@ function wrapHighlight(
                         rangeStartOffset =
                             isRUBY ?
                             0 :
-                            isSUBSUP ?
-                            Math.min(Math.max(l - (acc - sentBegin) - 1, 0), nodeLen) :
+                            seps.length ?
+                            ttsOffsetToDomOffset(l - (acc - sentBegin), seps, nodeLen) :
                             (l - (acc - sentBegin));
                     }
                 }
@@ -956,8 +977,8 @@ function wrapHighlight(
                     rangeEndOffset =
                         isRUBY ?
                         (nodeLen - 1) :
-                        isSUBSUP ?
-                        Math.min(Math.max(l - (acc - sentEnd) - 1, 0), nodeLen) :
+                        seps.length ?
+                        ttsOffsetToDomOffset(l - (acc - sentEnd), seps, nodeLen) :
                         (l - (acc - sentEnd));
                     break;
                 }

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
@@ -736,29 +736,39 @@ function wrapHighlightWord(
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isRUBY = (txtNode as any).__RUBY;
-        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides.
-        // Those two chars have no DOM counterpart, so they are added to the contributed
-        // length here, and the leading one is subtracted back out (with the result
-        // clamped into the node) when converting an utterance offset to a DOM offset.
+        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides, so
+        // such a node contributes two characters that have no DOM counterpart. Converting
+        // an utterance offset back to a DOM offset subtracts the leading one and clamps
+        // into the node.
+        // No need to exclude isRUBY here: a node can carry both flags (<sup><ruby>...),
+        // but isRUBY is tested first in every cascade below, and combineTextNodes() skips
+        // __RUBY nodes outright, so such a node contributes 0 either way.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
-        const sep = isSUBSUP ? 1 : 0;
+        const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
         const nodeLen = txtNode.nodeValue.length;
 
-        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
+        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
         acc += l;
         if (!rangeStartNode) {
             if (isRUBY && charIndexAdjusted <= acc
                 || charIndexAdjusted < acc) {
                 rangeStartNode = txtNode;
-                rangeStartOffset = isRUBY ? 0 :
-                    Math.min(Math.max(l - (acc - charIndexAdjusted) - sep, 0), nodeLen);
+                rangeStartOffset =
+                    isRUBY ?
+                    0 :
+                    isSUBSUP ?
+                    Math.min(Math.max(l - (acc - charIndexAdjusted) - 1, 0), nodeLen) :
+                    (l - (acc - charIndexAdjusted));
             }
         }
         if (rangeStartNode && charIndexEnd <= acc) {
             rangeEndNode = txtNode;
-            rangeEndOffset = isRUBY ? (nodeLen - 1) :
-                Math.min(Math.max(l - (acc - charIndexEnd) - sep, 0), nodeLen);
+            rangeEndOffset =
+                isRUBY ?
+                (nodeLen - 1) :
+                isSUBSUP ?
+                Math.min(Math.max(l - (acc - charIndexEnd) - 1, 0), nodeLen) :
+                (l - (acc - charIndexEnd));
             break;
         }
     }
@@ -924,24 +934,31 @@ function wrapHighlight(
                 const isRUBY = (txtNode as any).__RUBY;
                 // see the equivalent adjustment in updateTTSInfo() above
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
-                const sep = isSUBSUP ? 1 : 0;
+                const isSUBSUP = (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
                 const nodeLen = txtNode.nodeValue.length;
 
-                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
+                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : isSUBSUP ? (nodeLen + 2) : nodeLen;
                 acc += l;
                 if (!rangeStartNode) {
                     if (isRUBY && sentBegin <= acc
                         || sentBegin < acc) {
                         rangeStartNode = txtNode;
-                        rangeStartOffset = isRUBY ? 0 :
-                            Math.min(Math.max(l - (acc - sentBegin) - sep, 0), nodeLen);
+                        rangeStartOffset =
+                            isRUBY ?
+                            0 :
+                            isSUBSUP ?
+                            Math.min(Math.max(l - (acc - sentBegin) - 1, 0), nodeLen) :
+                            (l - (acc - sentBegin));
                     }
                 }
                 if (rangeStartNode && sentEnd <= acc) {
                     rangeEndNode = txtNode;
-                    rangeEndOffset = isRUBY ? (nodeLen - 1) :
-                        Math.min(Math.max(l - (acc - sentEnd) - sep, 0), nodeLen);
+                    rangeEndOffset =
+                        isRUBY ?
+                        (nodeLen - 1) :
+                        isSUBSUP ?
+                        Math.min(Math.max(l - (acc - sentEnd) - 1, 0), nodeLen) :
+                        (l - (acc - sentEnd));
                     break;
                 }
             }

--- a/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
+++ b/src/r2-xxx-js/r2-navigator-js/electron/renderer/webview/readaloud.ts
@@ -736,19 +736,29 @@ function wrapHighlightWord(
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isRUBY = (txtNode as any).__RUBY;
+        // combineTextNodes() fences sup/sub text with SUBSUP_SEPARATOR on both sides.
+        // Those two chars have no DOM counterpart, so they are added to the contributed
+        // length here, and the leading one is subtracted back out (with the result
+        // clamped into the node) when converting an utterance offset to a DOM offset.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+        const sep = isSUBSUP ? 1 : 0;
+        const nodeLen = txtNode.nodeValue.length;
 
-        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : txtNode.nodeValue.length;
+        const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
         acc += l;
         if (!rangeStartNode) {
             if (isRUBY && charIndexAdjusted <= acc
                 || charIndexAdjusted < acc) {
                 rangeStartNode = txtNode;
-                rangeStartOffset = isRUBY ? 0 : l - (acc - charIndexAdjusted);
+                rangeStartOffset = isRUBY ? 0 :
+                    Math.min(Math.max(l - (acc - charIndexAdjusted) - sep, 0), nodeLen);
             }
         }
         if (rangeStartNode && charIndexEnd <= acc) {
             rangeEndNode = txtNode;
-            rangeEndOffset = isRUBY ? (txtNode.nodeValue.length - 1) : l - (acc - charIndexEnd);
+            rangeEndOffset = isRUBY ? (nodeLen - 1) :
+                Math.min(Math.max(l - (acc - charIndexEnd) - sep, 0), nodeLen);
             break;
         }
     }
@@ -912,19 +922,26 @@ function wrapHighlight(
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const isRUBY = (txtNode as any).__RUBY;
+                // see the equivalent adjustment in updateTTSInfo() above
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const isSUBSUP = !isRUBY && (txtNode as any).__SUBSUP && !isOnlyWhiteSpace(txtNode.nodeValue);
+                const sep = isSUBSUP ? 1 : 0;
+                const nodeLen = txtNode.nodeValue.length;
 
-                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : txtNode.nodeValue.length;
+                const l = isRUBY ? 0 : isOnlyWhiteSpace(txtNode.nodeValue) ? 1 : (sep * 2) + nodeLen;
                 acc += l;
                 if (!rangeStartNode) {
                     if (isRUBY && sentBegin <= acc
                         || sentBegin < acc) {
                         rangeStartNode = txtNode;
-                        rangeStartOffset = isRUBY ? 0 : l - (acc - sentBegin);
+                        rangeStartOffset = isRUBY ? 0 :
+                            Math.min(Math.max(l - (acc - sentBegin) - sep, 0), nodeLen);
                     }
                 }
                 if (rangeStartNode && sentEnd <= acc) {
                     rangeEndNode = txtNode;
-                    rangeEndOffset = isRUBY ? (txtNode.nodeValue.length - 1) : l - (acc - sentEnd);
+                    rangeEndOffset = isRUBY ? (nodeLen - 1) :
+                        Math.min(Math.max(l - (acc - sentEnd) - sep, 0), nodeLen);
                     break;
                 }
             }


### PR DESCRIPTION
Fixes #3782. Depends on #3779 — stacked on that branch, since it generalises the
separator mechanism introduced there. Independent of #3781.

## The problem

Speech engines **discard** a token that mixes two alphabetic scripts. This is not
mispronunciation, it is silent omission:

> "the change Δx is small"  →  *"the change is small"*

Any book that writes Greek variables inline is affected, which in mathematical and
scientific prose is most of them. As with `sub`/`sup`, the listener gets no cue that
anything was dropped — the sentence is simply, quietly wrong.

## Evidence

Synthesised speech timed on macOS with Samantha, Alex and Daniel (identical results
across all three):

| utterance | duration |
|---|---|
| `we call it here` (nothing at all) | 1.070s |
| `we call it Δx here` | **1.163s** — the token is not spoken |
| `we call it Δ x here` | 2.173s |
| `we call it дx here` (Cyrillic) | **1.163s** — identical behaviour |
| `we call it д x here` | 2.173s |

Cyrillic behaving exactly like Greek is what makes this a *script-boundary* effect
rather than a Greek quirk, and inserting a word boundary at script transitions is the
established remedy for it.

## What is and isn't separated

Only **Latin, Greek and Cyrillic**, and the rule is symmetric between them — a
Greek/Cyrillic transition is separated just as a Greek/latin one is. It is a script-pair
rule, not a latin-centric one.

### Why this is not, and should not be, script-agnostic

The obvious generalisation is "insert a boundary at every script transition". That
destroys Japanese, which mixes Han, Hiragana and Katakana **inside single words**:

| text | script-agnostic rule would produce |
|---|---|
| `食べる` (one verb) | `食 べる` |
| `東京タワー` | `東京 タワー` |
| `私はiPhoneを使います` | `私 は iPhone を 使 います` |

So the separable set has to be an explicit list, and CJK cannot be in it.

### Why CJK/latin is excluded even as a special case

Grouping Han/Hiragana/Katakana together and separating only that group from latin is
more tempting, but measurement says no. With a Japanese voice (Eddy, ja_JP):

| utterance | duration |
|---|---|
| `私はiPhoneを使います` | 2.990s |
| `私は iPhone を使います` | **3.358s** |
| `私はそれを使います` (no latin at all) | 1.966s |

Two conclusions. The latin word is **not dropped** when fused — 2.990s against 1.966s
for the same sentence without it — so there is no defect to fix here. And the spaced
variant is 12% longer, which is an inserted prosodic pause: the separator is *not* free.

That is the opposite trade from Greek and Cyrillic. Mixed Greek/latin runs are rare and
are always notation, so a boundary costs nothing and rescues content that is otherwise
lost outright. Mixed CJK/latin runs are ordinary prose that CJK readers encounter
constantly, and a boundary there would degrade everyday reading to hedge against a
defect not observed on this platform.

If another engine does drop CJK/latin tokens, the fix is to add the pair to
`_separableScripts` on that evidence — the list is a one-line extension point. Scripts
with no measurements are left alone rather than guessed at.

Same-script text is untouched by construction, so these are all unaffected — verified,
not assumed:

| specimen | why unchanged |
|---|---|
| `caféx` | accented latin is still latin |
| `Δθ` | one script; already spoken correctly |
| `Δ2` | digits are not a separable script |
| `(ρ)` | punctuation, not a script boundary |
| `𝐅x` | Mathematical Alphanumeric Symbols are script Common |
| `漢x` | excluded, see above |

### Zero-width formatting characters between the scripts

Skipped when tracking script runs, rather than being allowed to end one. If a character
sits between the two scripts it would otherwise hide the boundary behind it — and that
matters, because not all of them separate the token for the engine:

| between `Δ` and `x` | engine speaks it? | boundary found? |
|---|---|---|
| nothing | ✗ dropped | ✓ added |
| U+2060 WORD JOINER | ✗ **still dropped** | ✓ added — this is the case that needs it |
| U+FEFF, U+200B | ✓ already separated | ✓ added, redundant but harmless |
| a real space | ✓ | ✗ correctly none — a space is not default-ignorable |

WORD JOINER is the awkward one: an author might use it precisely to stop `Δx` breaking
across a line, and it leaves the token fused, so without this the content stays dropped
and the fix never reaches it.

Where a separator is already present the doubled boundary is acoustically identical —
`Δ x`, `Δ<FEFF>x` and `Δ<FEFF> x` all measure 2.197s.

## Note on #3779's review

@danielweck has left review comments on #3779 proposing that the offset walker keep its
existing cascading-ternary shape with an `isSUBSUP ? (length + 2) : length` branch, and
that the `pendingSubSupSeparator` module state be replaced by a direct parent-tag test.
Both are good simplifications for #3779 taken alone.

They do partly conflict with this PR, which is why I am flagging it rather than letting it
be discovered: a fixed `+2` assumes exactly one separator at each end, and script
boundaries need a variable number at arbitrary offsets, hence the `__TTS_SEPS` array here.
The parent-tag suggestion applies cleanly either way and I will adopt it.

**I will rebase this onto whatever shape #3779 lands in**, and I am happy for that to mean
reworking the mechanism below, or dropping this PR entirely if you would rather not carry
a per-platform speech workaround. #3779 does not depend on this one.

## Implementation

Generalises the mechanism from #3779. Instead of a boolean meaning "fence both
ends", a text node carries `__TTS_SEPS` — the offsets at which `TTS_SEPARATOR` is
inserted when the utterance string is assembled. `sup`/`sub` contributes `[0, length]`,
script changes contribute their own offsets, and the two compose:
`<em>Δ</em><sub>x</sub>y` → `"Δ x y"`.

The separators exist only in the utterance string, **never in the DOM**, so rendering,
CFIs and locators are untouched.

Both offset walkers in `readaloud.ts` now share `ttsOffsetToDomOffset()`, which
subtracts the separators preceding an offset and clamps into the node. The `i`-th
separator sits at utterance offset `seps[i] + i`, which is what makes the subtraction a
simple count.

## Verification

- `tsc --noEmit` exit 0, `eslint` clean
- Every utterance offset mapped back to its DOM character across script boundaries,
  `sup`/`sub`, both combined, and all the excluded cases — **0 mismatches**, so word-
  and sentence-level highlighting stay aligned
- A test EPUB is attached (`tts-script-boundary-testcase.epub.zip`, with its build
  script). Eleven cases: four that change, seven that must not. Running
  `generateTtsQueue()` over it from `develop` and from this branch:

| test | develop | this branch |
|---|---|---|
| 1 `Δx` | "Δx" | "Δ x" |
| 2 `dθ` | "dθ" | "d θ" |
| 3 `дx` | "дx" | "д x" |
| 4 in a sentence | "the change Δx is small" | "the change Δ x is small" |
| 5–11 the excluded cases | unchanged | **unchanged** |

## Platform scope — please read before merging

**The defect is macOS-only.** I measured all three desktop platforms afterwards and it
does not reproduce on either of the other two. Timings are of the Web Speech API, the
same path Thorium uses, so each column is that platform's real engine — macOS Samantha,
espeak-ng via speech-dispatcher on Linux, SAPI `Speech_OneCore` under Chrome 150 on
Windows:

| utterance | macOS | Linux / espeak-ng | Windows / SAPI |
|---|---|---|---|
| baseline, no symbol | 1.070s | 1.297s | 1.746s |
| `we call it θx here` | **1.163s — dropped** | 1.810s — spoken | 2.296s — spoken |
| `we call it θ x here` | 2.173s | 1.927s | 2.358s |
| `we call it дx here` | **1.163s — dropped** | 1.778s — spoken | 2.048s — spoken |
| `we call it д x here` | 2.173s | 1.788s | 2.057s |

On Linux and Windows the fused and separated forms are within noise of each other and
both well clear of baseline — the token is spoken either way, so this change buys
nothing there. What it costs there is also close to nothing: a slightly different
cadence at the boundary, no content changed, nothing dropped or mispronounced.

**This PR applies the boundary on all platforms**, deliberately. The alternative is
`process.platform === "darwin"`, which I decided against: it makes the spoken output
differ by platform for the same book, which is harder to reason about and to reproduce
in a bug report than a uniform rule whose worst case elsewhere is a marginally different
cadence. Platform-conditional text processing seemed the larger price.

That said, macOS is the only platform where it changes anything, so gating is a
defensible read of the same data — **say the word and I will push the gate.** The full
set of options:

1. **Ship it unconditionally** (what this PR does). Uniform behaviour everywhere;
   effective on macOS, near-free elsewhere.
2. **Gate on `darwin`.** No effect where there is no defect, at the cost of
   platform-specific text processing and platform-dependent output.
3. **Decline it.** Content is silently lost on macOS, but authors can work around it in
   the EPUB with a zero-width separator, and that is what I have done for my own book.

I would rather state the platform scope plainly than have it discovered in review.

Note also this is a workaround for a speech-synthesis defect, not a bug in the
navigator. That is exactly why it is a separate PR: #3779 fixes content that
Thorium itself discards, is justified on **both** platforms, and does not depend on
accepting the premise here.