### PR TITLE
feat: support the icon defined by the thorium-reader-website badge catalog generator

### DIFF
--- a/src/common/models/opds.ts
+++ b/src/common/models/opds.ts
@@ -40,6 +40,11 @@ export const getOpdsFeedColor = (value: unknown): TOpdsFeedColor =>
     isOpdsFeedColor(value) ? value : OPDS_FEED_DEFAULT_COLOR;
 
 export const OPDS_FEED_ICON_DATA_URL_PREFIX = "data:image/png;base64,";
+export const OPDS_FEED_ICON_SVG_DATA_URL_PREFIX = "data:image/svg+xml;base64,";
+const OPDS_FEED_ICON_DATA_URL_PREFIXES = [
+    OPDS_FEED_ICON_DATA_URL_PREFIX,
+    OPDS_FEED_ICON_SVG_DATA_URL_PREFIX,
+];
 
 export const isOpdsFeedIconUrl = (value: unknown): value is string => {
     if (typeof value !== "string" || !value.trim()) {
@@ -58,11 +63,16 @@ export const getOpdsFeedIconUrl = (value: unknown): string | undefined =>
     isOpdsFeedIconUrl(value) ? value : undefined;
 
 export const isOpdsFeedIconDataUrl = (value: unknown): value is string => {
-    if (typeof value !== "string" || !value.startsWith(OPDS_FEED_ICON_DATA_URL_PREFIX)) {
+    if (typeof value !== "string") {
         return false;
     }
 
-    const data = value.slice(OPDS_FEED_ICON_DATA_URL_PREFIX.length);
+    const prefix = OPDS_FEED_ICON_DATA_URL_PREFIXES.find((p) => value.startsWith(p));
+    if (!prefix) {
+        return false;
+    }
+
+    const data = value.slice(prefix.length);
     return !!data && /^[A-Za-z0-9+/]+={0,2}$/.test(data);
 };
 

--- a/src/common/models/opds.ts
+++ b/src/common/models/opds.ts
@@ -39,6 +39,36 @@ export const isOpdsFeedColor = (value: unknown): value is TOpdsFeedColor =>
 export const getOpdsFeedColor = (value: unknown): TOpdsFeedColor =>
     isOpdsFeedColor(value) ? value : OPDS_FEED_DEFAULT_COLOR;
 
+export const OPDS_FEED_ICON_DATA_URL_PREFIX = "data:image/png;base64,";
+
+export const isOpdsFeedIconUrl = (value: unknown): value is string => {
+    if (typeof value !== "string" || !value.trim()) {
+        return false;
+    }
+
+    try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+        return false;
+    }
+};
+
+export const getOpdsFeedIconUrl = (value: unknown): string | undefined =>
+    isOpdsFeedIconUrl(value) ? value : undefined;
+
+export const isOpdsFeedIconDataUrl = (value: unknown): value is string => {
+    if (typeof value !== "string" || !value.startsWith(OPDS_FEED_ICON_DATA_URL_PREFIX)) {
+        return false;
+    }
+
+    const data = value.slice(OPDS_FEED_ICON_DATA_URL_PREFIX.length);
+    return !!data && /^[A-Za-z0-9+/]+={0,2}$/.test(data);
+};
+
+export const getOpdsFeedIcon = (value: unknown): string | undefined =>
+    isOpdsFeedIconDataUrl(value) ? value : undefined;
+
 export interface OpdsFeed {
     identifier?: string;
     title: string;
@@ -46,4 +76,5 @@ export interface OpdsFeed {
     authenticationUrl?: string;
     favorite?: boolean;
     color?: TOpdsFeedColor;
+    icon?: string;
 }

--- a/src/common/views/opds.ts
+++ b/src/common/views/opds.ts
@@ -24,6 +24,7 @@ export interface IOpdsFeedView extends Identifiable {
     authenticationUrl?: string;
     favorite?: boolean;
     color: TOpdsFeedColor;
+    icon?: string;
 }
 
 export interface IOpdsCoverView {

--- a/src/main/converter/opds.ts
+++ b/src/main/converter/opds.ts
@@ -14,7 +14,7 @@ import {
     IOpdsPublicationView, IOpdsResultView, IOpdsTagView,
 } from "readium-desktop/common/views/opds";
 import { convertMultiLangStringToString } from "readium-desktop/common/language-string";
-import { getOpdsFeedColor } from "readium-desktop/common/models/opds";
+import { getOpdsFeedColor, getOpdsFeedIcon } from "readium-desktop/common/models/opds";
 import { OpdsFeedDocument } from "readium-desktop/main/db/document/opds";
 import { ContentType } from "readium-desktop/utils/contentType";
 
@@ -178,6 +178,7 @@ export class OpdsFeedViewConverter {
             authenticationUrl: document.authenticationUrl,
             favorite: document.favorite || false,
             color: getOpdsFeedColor(document.color),
+            icon: getOpdsFeedIcon(document.icon),
             // feedHasAuthentication: authentified || await feedHasAuthenticationFunction(),
         };
     }

--- a/src/main/db/document/opds.ts
+++ b/src/main/db/document/opds.ts
@@ -32,4 +32,5 @@ export interface OpdsFeedDocument extends Identifiable, Timestampable {
     authenticationUrl?: string;
     favorite?: boolean;
     color?: TOpdsFeedColor;
+    icon?: string;
 }

--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -8,12 +8,14 @@
 import debug_ from "debug";
 import {
     OPDS_FEED_ICON_DATA_URL_PREFIX,
+    OPDS_FEED_ICON_SVG_DATA_URL_PREFIX,
     OPDS_FEED_DEFAULT_COLOR,
     getOpdsFeedColor,
     getOpdsFeedIconUrl,
     isOpdsFeedColor,
     type TOpdsFeedColor,
 } from "readium-desktop/common/models/opds";
+import { imageSize } from "image-size";
 import { customizationActions, historyActions, readerActions, toastActions } from "readium-desktop/common/redux/actions";
 import { IOpdsLinkView } from "readium-desktop/common/views/opds";
 import { PublicationView } from "readium-desktop/common/views/publication";
@@ -79,23 +81,27 @@ const isSvgImage = (buffer: Buffer, contentType: string | undefined): boolean =>
         Math.min(buffer.length, 4096),
     ).toLowerCase().includes("<svg"));
 
-const isOpdsFeedIconContentLengthValid = (contentLength: string | undefined, iconUrl: string): boolean => {
-    if (!contentLength) {
-        return true;
+const getOpdsFeedIconImageSize = (iconBuffer: Buffer, iconUrl: string): { width: number; height: number } | undefined => {
+    try {
+        return imageSize(iconBuffer);
+    } catch (e) {
+        debug("OPDS feed icon size parsing failed", iconUrl, e);
+        return undefined;
+    }
+};
+
+const getOpdsFeedSvgIconDataUrl = (iconBuffer: Buffer, iconUrl: string): string | undefined => {
+    const size = getOpdsFeedIconImageSize(iconBuffer, iconUrl);
+    if (!size?.width || !size.height) {
+        debug("OPDS feed SVG icon has invalid dimensions", iconUrl, size);
+        return undefined;
+    }
+    if (size.width !== size.height) {
+        debug("OPDS feed SVG icon is not square", iconUrl, size);
+        return undefined;
     }
 
-    if (!/^\d+$/.test(contentLength)) {
-        debug("OPDS feed icon invalid content-length", iconUrl, contentLength);
-        return false;
-    }
-
-    const length = Number.parseInt(contentLength, 10);
-    if (length > OPDS_FEED_ICON_MAX_BYTES) {
-        debug("OPDS feed icon content-length too large", iconUrl, length);
-        return false;
-    }
-
-    return true;
+    return `${OPDS_FEED_ICON_SVG_DATA_URL_PREFIX}${iconBuffer.toString("base64")}`;
 };
 
 const normalizeOpdsFeedIcon = (iconImage: Electron.NativeImage, iconUrl: string): string | undefined => {
@@ -136,13 +142,11 @@ const downloadOpdsFeedIcon = async (iconUrl: string | undefined): Promise<string
             headers: {
                 accept: "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.1",
             },
+            size: OPDS_FEED_ICON_MAX_BYTES,
             timeout: OPDS_FEED_ICON_REQUEST_TIMEOUT,
         });
         if (!response.isSuccess || !response.response?.buffer) {
             debug("OPDS feed icon download failed", iconUrl, response.statusCode, response.statusMessage);
-            return undefined;
-        }
-        if (!isOpdsFeedIconContentLengthValid(response.response.headers?.get("content-length"), iconUrl)) {
             return undefined;
         }
 
@@ -152,12 +156,13 @@ const downloadOpdsFeedIcon = async (iconUrl: string | undefined): Promise<string
             return undefined;
         }
 
-        let iconImage = nativeImage.createFromBuffer(iconBuffer);
-        if (iconImage.isEmpty() && isSvgImage(iconBuffer, response.contentType)) {
-            iconImage = nativeImage.createFromDataURL(
-                `data:image/svg+xml;base64,${iconBuffer.toString("base64")}`,
-            );
+        if (isSvgImage(iconBuffer, response.contentType)) {
+            // https://www.electronjs.org/docs/latest/api/native-image#nativeimagecreatefromdataurldataurl
+            // SVG cannot be converted to PNG
+            return getOpdsFeedSvgIconDataUrl(iconBuffer, iconUrl);
         }
+
+        const iconImage = nativeImage.createFromBuffer(iconBuffer);
         if (iconImage.isEmpty()) {
             debug("OPDS feed icon could not be decoded", iconUrl);
             return undefined;

--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -7,8 +7,10 @@
 
 import debug_ from "debug";
 import {
+    OPDS_FEED_ICON_DATA_URL_PREFIX,
     OPDS_FEED_DEFAULT_COLOR,
     getOpdsFeedColor,
+    getOpdsFeedIconUrl,
     isOpdsFeedColor,
     type TOpdsFeedColor,
 } from "readium-desktop/common/models/opds";
@@ -45,6 +47,8 @@ import { FORCE_PROD_DB_IN_DEV, USER_DATA_FOLDER } from "readium-desktop/common/c
 import { ToastType } from "readium-desktop/common/models/toast";
 import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 import { TCatalogAddAnalyticsOrigin } from "src/common/analytics/catalog";
+import { nativeImage } from "electron";
+import { httpGetWithAuth } from "readium-desktop/main/network/http";
 
 // Logger
 const debug = debug_("readium-desktop:main:saga:event");
@@ -60,9 +64,110 @@ const appLogs = path.join(
     folderPath,
     PROCESS_LOGS,
 );
+const OPDS_FEED_ICON_REQUEST_TIMEOUT = 2000;
+const OPDS_FEED_ICON_MAX_BYTES = 1024 * 1024;
+const OPDS_FEED_ICON_SIZE = 128;
 
 if (!fs.existsSync(folderPath)) {
     fs.mkdirSync(folderPath);
+};
+
+const isSvgImage = (buffer: Buffer, contentType: string | undefined): boolean =>
+    (contentType?.toLowerCase().includes("image/svg+xml") || buffer.toString(
+        "utf8",
+        0,
+        Math.min(buffer.length, 4096),
+    ).toLowerCase().includes("<svg"));
+
+const isOpdsFeedIconContentLengthValid = (contentLength: string | undefined, iconUrl: string): boolean => {
+    if (!contentLength) {
+        return true;
+    }
+
+    if (!/^\d+$/.test(contentLength)) {
+        debug("OPDS feed icon invalid content-length", iconUrl, contentLength);
+        return false;
+    }
+
+    const length = Number.parseInt(contentLength, 10);
+    if (length > OPDS_FEED_ICON_MAX_BYTES) {
+        debug("OPDS feed icon content-length too large", iconUrl, length);
+        return false;
+    }
+
+    return true;
+};
+
+const normalizeOpdsFeedIcon = (iconImage: Electron.NativeImage, iconUrl: string): string | undefined => {
+    const size = iconImage.getSize();
+    if (!size.width || !size.height) {
+        debug("OPDS feed icon has invalid dimensions", iconUrl, size);
+    } else if (size.width !== size.height) {
+        debug("OPDS feed icon is not square, resizing to common square size", iconUrl, size);
+    }
+
+    const resizedImage = iconImage.resize({
+        height: OPDS_FEED_ICON_SIZE,
+        quality: "best",
+        width: OPDS_FEED_ICON_SIZE,
+    });
+    const resizedSize = resizedImage.getSize();
+    if (resizedImage.isEmpty() || resizedSize.width !== OPDS_FEED_ICON_SIZE || resizedSize.height !== OPDS_FEED_ICON_SIZE) {
+        debug("OPDS feed icon resize failed", iconUrl, resizedSize);
+        return undefined;
+    }
+
+    const iconDataUrl = resizedImage.toDataURL({ scaleFactor: 1 });
+    if (!iconDataUrl.startsWith(OPDS_FEED_ICON_DATA_URL_PREFIX)) {
+        debug("OPDS feed icon PNG data URL conversion failed", iconUrl);
+        return undefined;
+    }
+
+    return iconDataUrl;
+};
+
+const downloadOpdsFeedIcon = async (iconUrl: string | undefined): Promise<string | undefined> => {
+    if (!iconUrl) {
+        return undefined;
+    }
+
+    try {
+        const response = await httpGetWithAuth(false)(iconUrl, {
+            headers: {
+                accept: "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.1",
+            },
+            timeout: OPDS_FEED_ICON_REQUEST_TIMEOUT,
+        });
+        if (!response.isSuccess || !response.response?.buffer) {
+            debug("OPDS feed icon download failed", iconUrl, response.statusCode, response.statusMessage);
+            return undefined;
+        }
+        if (!isOpdsFeedIconContentLengthValid(response.response.headers?.get("content-length"), iconUrl)) {
+            return undefined;
+        }
+
+        const iconBuffer = await response.response.buffer();
+        if (!iconBuffer.length || iconBuffer.length > OPDS_FEED_ICON_MAX_BYTES) {
+            debug("OPDS feed icon invalid size", iconUrl, iconBuffer.length);
+            return undefined;
+        }
+
+        let iconImage = nativeImage.createFromBuffer(iconBuffer);
+        if (iconImage.isEmpty() && isSvgImage(iconBuffer, response.contentType)) {
+            iconImage = nativeImage.createFromDataURL(
+                `data:image/svg+xml;base64,${iconBuffer.toString("base64")}`,
+            );
+        }
+        if (iconImage.isEmpty()) {
+            debug("OPDS feed icon could not be decoded", iconUrl);
+            return undefined;
+        }
+
+        return normalizeOpdsFeedIcon(iconImage, iconUrl);
+    } catch (e) {
+        debug("OPDS feed icon download error", iconUrl, e);
+        return undefined;
+    }
 };
 
 export function saga() {
@@ -289,6 +394,7 @@ export function saga() {
                         let theUrl = url;
                         let title = url;
                         let feedColor: TOpdsFeedColor = OPDS_FEED_DEFAULT_COLOR;
+                        let feedIcon: string | undefined;
 
                         // https://www.thoriumreader.com/en/badge/catalog/
                         //
@@ -305,7 +411,9 @@ export function saga() {
                             // const bookshelf = u.searchParams.get("bookshelf");
                             // const passphrase = u.searchParams.get("passphrase");
                             // const hashed_passphrase = u.searchParams.get("hashed_passphrase");
-                            // const icon = u.searchParams.get("icon");
+                            feedIcon = yield* callTyped(() => downloadOpdsFeedIcon(
+                                getOpdsFeedIconUrl(u.searchParams.get("icon")),
+                            ));
                             // const banner = u.searchParams.get("banner");
                             // const open_in = u.searchParams.get("open_in");
 
@@ -319,7 +427,7 @@ export function saga() {
                             }
                         }
 
-                        const feed = yield* callTyped(addFeed, { title, url: theUrl, color: feedColor }, "deeplink" as TCatalogAddAnalyticsOrigin);
+                        const feed = yield* callTyped(addFeed, { title, url: theUrl, color: feedColor, icon: feedIcon }, "deeplink" as TCatalogAddAnalyticsOrigin);
                         if (feed) {
 
                             yield* callTyped(appActivate);

--- a/src/renderer/assets/styles/components/catalogs.scss
+++ b/src/renderer/assets/styles/components/catalogs.scss
@@ -192,17 +192,26 @@ $catalog-card-colors-dark: (
             left: 30px;
             display: block;
 
-            svg {
+            svg,
+            .catalog_icon_image {
                 width: 30px;
                 height: 30px;
                 margin-bottom: 30px;
-                color: var(--catalog-card-foreground);
                 background-color: var(--color-neutral-base);
                 padding: 11px;
                 border-radius: 50%;
                 position: absolute;
                 top: 0;
                 left: -10px;
+            }
+
+            svg {
+                color: var(--catalog-card-foreground);
+            }
+
+            .catalog_icon_image {
+                box-sizing: content-box;
+                object-fit: contain;
             }
 
             p {

--- a/src/renderer/assets/styles/components/catalogs.scss.d.ts
+++ b/src/renderer/assets/styles/components/catalogs.scss.d.ts
@@ -12,6 +12,7 @@ export declare const catalog_container: string;
 export declare const catalog_content: string;
 export declare const catalog_favorite_icon_false: string;
 export declare const catalog_favorite_icon_true: string;
+export declare const catalog_icon_image: string;
 export declare const catalog_infos_text: string;
 export declare const catalog_title: string;
 export declare const catalog_wrapper: string;

--- a/src/renderer/library/components/dialog/OpdsFeedUpdateForm.tsx
+++ b/src/renderer/library/components/dialog/OpdsFeedUpdateForm.tsx
@@ -47,6 +47,7 @@ interface IState {
     url: string | undefined;
     favorite: boolean | undefined;
     color: TOpdsFeedColor;
+    icon: string | undefined;
 }
 
 class OpdsFeedUpdateForm extends React.Component<IProps, IState> {
@@ -57,6 +58,7 @@ class OpdsFeedUpdateForm extends React.Component<IProps, IState> {
             url: props.feed?.url,
             favorite: props.feed?.favorite,
             color: props.feed?.color || OPDS_FEED_DEFAULT_COLOR,
+            icon: props.feed?.icon,
         };
     }
     public render(): React.ReactElement<{}> {
@@ -143,6 +145,7 @@ class OpdsFeedUpdateForm extends React.Component<IProps, IState> {
         const url = this.state.url;
         const favorite = this.state.favorite;
         const color = this.state.color;
+        const icon = this.state.icon;
         if (!title || !url) {
             return;
         }
@@ -152,6 +155,7 @@ class OpdsFeedUpdateForm extends React.Component<IProps, IState> {
             authenticationUrl: this.props.feed.authenticationUrl,
             favorite,
             color,
+            icon,
         }).catch((err) => {
             console.error("Error to fetch api opds/updateFeed", err);
         });

--- a/src/renderer/library/components/opds/FeedCard.tsx
+++ b/src/renderer/library/components/opds/FeedCard.tsx
@@ -40,6 +40,12 @@ export const FeedCard: React.FC<IFeedCardProps> = (props) => {
     const { feed, setFeedsResult, location } = props;
     const dispatch = useDispatch();
     const [__] = useTranslator();
+    const [iconHasError, setIconHasError] = React.useState(false);
+    const catalogIcon = feed.icon && !iconHasError ? feed.icon : undefined;
+
+    React.useEffect(() => {
+        setIconHasError(false);
+    }, [feed.icon]);
 
     const logout: (feedUrl: string) => void = (feedUrl) => {
         dispatch(authActions.logout.build(feedUrl));
@@ -109,7 +115,18 @@ export const FeedCard: React.FC<IFeedCardProps> = (props) => {
             >
                 <div className={stylesCatalogs.catalog_color_band} />
                 <div className={stylesCatalogs.catalog_title}>
-                    <SVG ariaHidden svg={GlobeIcon} />
+                    {catalogIcon ?
+                        <img
+                            aria-hidden={true}
+                            alt=""
+                            className={stylesCatalogs.catalog_icon_image}
+                            loading="lazy"
+                            referrerPolicy="no-referrer"
+                            src={catalogIcon}
+                            onError={() => setIconHasError(true)}
+                        />
+                        : <SVG ariaHidden svg={GlobeIcon} />
+                    }
                     <p title={`${feed.title} --- ${feed.url}`}>{feed.title}</p>
                 </div>
             </Link>


### PR DESCRIPTION
Fixes #3851 

Changes

- Parse the catalog badge `icon` query parameter from Thorium deep links.
- Download HTTP(S) PNG/SVG catalog icons in the main process.
- Decode PNG icons with Electron `nativeImage`, normalize them to a 128x128 PNG via `resize()`, and persist them as `data:image/png;base64` URLs.
- Check SVG icons size, square ratio and persist them as `data:image/svg+xml;base64,`
- Add `icon` to OPDS feed models, documents, and views.
- Render persisted catalog icons in `FeedCard`, with the existing globe icon as fallback.
- Preserve catalog icons when editing an OPDS feed.


Tested with PNG and SVG icons:
- https://www.thoriumreader.com/en/add/catalog/?title=Biblioth%C3%A8que+num%C3%A9rique+de+Paris&main=https%3A%2F%2Fbibliotheques.paris.fr%2Fnumerique&icon=https://www.svgrepo.com/show/535660/square-plus.svg&color=green
- https://www.thoriumreader.com/en/add/catalog/?title=Biblioth%C3%A8que+num%C3%A9rique+de+Paris&main=https%3A%2F%2Fbibliotheques.paris.fr%2Fnumerique&icon=https://www.edrlab.org/wp-content/uploads/2016/12/edrlab_logo@2x.jpg&color=green
- https://www.thoriumreader.com/add/catalog/?title=Biblioth%C3%A8que+num%C3%A9rique+de+Paris&main=https%3A%2F%2Fbibliotheques.paris.fr%2Fnumerique&icon=https%3A%2F%2Fwww.paris.fr%2Fapple-touch-icon.png&color=blue