### PR TITLE
feat: parse passphrase from deeplink publication and catalog

### DIFF
--- a/src/common/api/interface/publicationApi.interface.ts
+++ b/src/common/api/interface/publicationApi.interface.ts
@@ -39,6 +39,7 @@ export interface IPublicationApi {
         link: IOpdsLinkView,
         willBeImmediatelyFollowedByOpen: boolean,
         pub?: IOpdsPublicationView,
+        rootFeedIdentifier?: string,
     ) => SagaGenerator<PublicationView>;
     importFromString: (
         manifest: string,

--- a/src/common/redux/actions/import/verify.ts
+++ b/src/common/redux/actions/import/verify.ts
@@ -13,11 +13,13 @@ export const ID = "IMPORT_VERIFICATION_REQUEST";
 export interface Payload {
     link: IOpdsLinkView;
     pub: IOpdsPublicationView;
+    rootFeedIdentifier?: string;
 }
 
 export function build(
     link: IOpdsLinkView,
     pub: IOpdsPublicationView,
+    rootFeedIdentifier?: string,
 ): Action<typeof ID, Payload> {
 
     return {
@@ -25,6 +27,7 @@ export function build(
         payload: {
             link,
             pub,
+            rootFeedIdentifier,
         },
     };
 }

--- a/src/main/converter/opds.ts
+++ b/src/main/converter/opds.ts
@@ -17,6 +17,7 @@ import { convertMultiLangStringToString } from "readium-desktop/common/language-
 import { getOpdsFeedColor, getOpdsFeedIcon } from "readium-desktop/common/models/opds";
 import { OpdsFeedDocument } from "readium-desktop/main/db/document/opds";
 import { ContentType } from "readium-desktop/utils/contentType";
+import { normalizeLcpHashedPassphrase } from "readium-desktop/utils/lcp";
 
 import { IWithAdditionalJSON, TaJsonSerialize } from "@r2-lcp-js/serializable";
 import { OPDSFeed } from "@r2-opds-js/opds/opds2/opds2";
@@ -200,48 +201,7 @@ export class OpdsFeedViewConverter {
 
         if (properties) {
 
-            const key = "lcp_hashed_passphrase";
-            const lcpHashedPassphraseObj = properties.AdditionalJSON ? properties.AdditionalJSON[key] : undefined;
-            let lcpHashedPassphrase: string;
-            if (typeof lcpHashedPassphraseObj === "string") {
-                const lcpHashedPassphraseHexOrB64 = lcpHashedPassphraseObj as string;
-                let isHex = false;
-                try {
-                    const low1 = lcpHashedPassphraseHexOrB64.toLowerCase();
-                    const buff = Buffer.from(low1, "hex");
-                    const str = buff.toString("hex");
-                    const low2 = str.toLowerCase();
-                    isHex = low1 === low2;
-                    if (!isHex) {
-                        debug(`OPDS lcp_hashed_passphrase should be HEX! (${lcpHashedPassphraseHexOrB64}) ${low1} !== ${low2}`);
-                    } else {
-                        debug(`OPDS lcp_hashed_passphrase is HEX: ${lcpHashedPassphraseHexOrB64}`);
-                    }
-                } catch (err) {
-                    debug(err); // ignore
-                }
-                if (isHex) {
-                    lcpHashedPassphrase = lcpHashedPassphraseHexOrB64;
-                } else {
-                    let isBase64 = false;
-                    try {
-                        const buff = Buffer.from(lcpHashedPassphraseHexOrB64, "base64");
-                        const str = buff.toString("hex");
-                        const b64 = Buffer.from(str, "hex").toString("base64");
-                        isBase64 = lcpHashedPassphraseHexOrB64 === b64;
-                        if (!isBase64) {
-                            debug(`OPDS lcp_hashed_passphrase is not BASE64?! (${lcpHashedPassphraseHexOrB64}) ${lcpHashedPassphraseHexOrB64} !== ${b64}`);
-                        } else {
-                            debug(`OPDS lcp_hashed_passphrase is BASE64! (${lcpHashedPassphraseHexOrB64})`);
-                        }
-                    } catch (err) {
-                        debug(err); // ignore
-                    }
-                    if (isBase64) {
-                        lcpHashedPassphrase = Buffer.from(lcpHashedPassphraseHexOrB64, "base64").toString("hex");
-                    }
-                }
-            }
+            const lcpHashedPassphrase = normalizeLcpHashedPassphrase(properties.AdditionalJSON?.lcp_hashed_passphrase);
 
             const indirectAcquisitions = properties.IndirectAcquisitions ?
                 (Array.isArray(properties.IndirectAcquisitions) ?

--- a/src/main/redux/sagas/api/publication/import/index.ts
+++ b/src/main/redux/sagas/api/publication/import/index.ts
@@ -150,6 +150,7 @@ export function* importFromLink(
     link: IOpdsLinkView,
     willBeImmediatelyFollowedByOpen: boolean,
     pub?: IOpdsPublicationView,
+    rootFeedIdentifier?: string,
     deep: number = 0,
 ): SagaGenerator<PublicationView | undefined> {
 
@@ -157,7 +158,12 @@ export function* importFromLink(
 
     try {
 
-        const [publicationDocument, alreadyImported] = yield* callTyped(importFromLinkService, link, willBeImmediatelyFollowedByOpen, pub);
+        const [publicationDocument, alreadyImported] = yield* callTyped(
+            importFromLinkService,
+            link,
+            willBeImmediatelyFollowedByOpen,
+            pub,
+        );
 
         if (!publicationDocument) {
             throw new Error("publicationDocument not imported on db");
@@ -184,7 +190,14 @@ export function* importFromLink(
                 );
                 if (!cleanedPublicationDocument) {
                     debug("restart import process after LCP cleanup");
-                    const replacementPublicationView = yield* callTyped(importFromLink, link, willBeImmediatelyFollowedByOpen, pub, retryDeep);
+                    const replacementPublicationView = yield* callTyped(
+                        importFromLink,
+                        link,
+                        willBeImmediatelyFollowedByOpen,
+                        pub,
+                        rootFeedIdentifier,
+                        retryDeep,
+                    );
                     yield* callTyped(
                         () => restorePersonalModeReplacementUserData(replacementPublicationView?.identifier, replacementUserData),
                     );
@@ -203,7 +216,14 @@ export function* importFromLink(
                     }
                     try {
                         debug("restart import process after publication was already imported, missing, but not deleted");
-                        return yield* callTyped(importFromLink, link, willBeImmediatelyFollowedByOpen, pub, retryDeep);
+                        return yield* callTyped(
+                            importFromLink,
+                            link,
+                            willBeImmediatelyFollowedByOpen,
+                            pub,
+                            rootFeedIdentifier,
+                            retryDeep,
+                        );
                     } catch (e) {
                         debug("Error during the second import of the publication", e);
                         return undefined;

--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -51,6 +51,7 @@ import { appendFileSyncWithRotation } from "readium-desktop/utils/log";
 import { TCatalogAddAnalyticsOrigin } from "src/common/analytics/catalog";
 import { nativeImage } from "electron";
 import { httpGetWithAuth } from "readium-desktop/main/network/http";
+import { getLcpHashedPassphrase } from "readium-desktop/utils/lcp";
 
 // Logger
 const debug = debug_("readium-desktop:main:saga:event");
@@ -306,6 +307,7 @@ export function saga() {
                     }
 
                     let theUrl = url;
+                    let lcpHashedPassphrase: string | undefined;
 
                     // https://www.thoriumreader.com/en/badge/publication/
                     //
@@ -321,8 +323,10 @@ export function saga() {
                         // const title = u.searchParams.get("title") || theUrl;
                         // const author = u.searchParams.get("author");
                         // const cover = u.searchParams.get("cover");
-                        // const passphrase = u.searchParams.get("passphrase");
-                        // const hashed_passphrase = u.searchParams.get("hashed_passphrase");
+                        lcpHashedPassphrase = getLcpHashedPassphrase(
+                            u.searchParams.get("passphrase"),
+                            u.searchParams.get("hashed_passphrase"),
+                        );
 
                         if (!/^https?:\/\//.test(theUrl)) {
                             throw new Error("HTTP!! " + theUrl + " ------- " + url);
@@ -333,6 +337,9 @@ export function saga() {
 
                     const link: IOpdsLinkView = {
                         url: openUrl,
+                        properties: lcpHashedPassphrase ? {
+                            lcpHashedPassphrase,
+                        } : undefined,
                     };
 
                     const pubViewArray = (yield* callTyped(importFromLink, link, true /* willBeImmediatelyFollowedByOpen */)) as PublicationView | PublicationView[];
@@ -400,6 +407,7 @@ export function saga() {
                         let title = url;
                         let feedColor: TOpdsFeedColor = OPDS_FEED_DEFAULT_COLOR;
                         let feedIcon: string | undefined;
+                        let lcpHashedPassphrase: string | undefined;
 
                         // https://www.thoriumreader.com/en/badge/catalog/
                         //
@@ -414,8 +422,14 @@ export function saga() {
                             theUrl = u.searchParams.get("main");
                             title = u.searchParams.get("title") || theUrl;
                             // const bookshelf = u.searchParams.get("bookshelf");
-                            // const passphrase = u.searchParams.get("passphrase");
-                            // const hashed_passphrase = u.searchParams.get("hashed_passphrase");
+                            lcpHashedPassphrase = getLcpHashedPassphrase(
+                                u.searchParams.get("passphrase"),
+                                u.searchParams.get("hashed_passphrase"),
+                            );
+                            if (lcpHashedPassphrase) {
+                                // TODO: persist the hashed passphrase
+                                debug("LCP HASHED PASSPHRASE", lcpHashedPassphrase);
+                            }
                             feedIcon = yield* callTyped(() => downloadOpdsFeedIcon(
                                 getOpdsFeedIconUrl(u.searchParams.get("icon")),
                             ));

--- a/src/renderer/library/components/dialog/publicationInfos/opdsControls/OpdsControls.tsx
+++ b/src/renderer/library/components/dialog/publicationInfos/opdsControls/OpdsControls.tsx
@@ -21,6 +21,7 @@ import {
 } from "readium-desktop/renderer/common/components/hoc/translator";
 import SVG from "readium-desktop/renderer/common/components/SVG";
 import { dispatchOpdsLink } from "readium-desktop/renderer/library/opds/handleLink";
+import { parseOpdsBrowserRoute } from "readium-desktop/renderer/library/opds/route";
 import { ILibraryRootState } from "readium-desktop/common/redux/states/renderer/libraryRootState";
 import { TDispatch } from "readium-desktop/typings/redux";
 import { findExtWithMimeType, findMimeTypeWithExtension, ADOBE_ADEPT_XML } from "readium-desktop/utils/mimeTypes";
@@ -59,6 +60,7 @@ export class OpdsControls extends React.Component<IProps, undefined> {
             sampleButtonIsDisabled,
             __,
         } = this.props;
+        const rootFeedIdentifier = parseOpdsBrowserRoute(this.props.location.pathname)?.rootFeedIdentifier;
 
         const boxStyle = { minHeight: "50px", height: "fit-content", padding: "0.4em", paddingTop: "0.2em", marginBottom: "0.5em", marginTop: "0.4em", fontSize: "14px" };
 
@@ -106,6 +108,7 @@ export class OpdsControls extends React.Component<IProps, undefined> {
                                         verifyImport(
                                             ln,
                                             opdsPublicationView,
+                                            rootFeedIdentifier,
                                         );
                                     }
                                 }}
@@ -141,6 +144,7 @@ export class OpdsControls extends React.Component<IProps, undefined> {
                                         verifyImport(
                                             ln,
                                             opdsPublicationView,
+                                            rootFeedIdentifier,
                                         );
                                     }
                                 }}

--- a/src/renderer/library/redux/sagas/sameFileImport.ts
+++ b/src/renderer/library/redux/sagas/sameFileImport.ts
@@ -24,7 +24,7 @@ const debug = debug_(filename_);
 
 function* sameFileImport(action: importActions.verify.TAction) {
 
-    const { link, pub } = action.payload;
+    const { link, pub, rootFeedIdentifier } = action.payload;
 
     const downloads = yield* selectTyped(
         (state: ILibraryRootState) => state.download);
@@ -54,6 +54,7 @@ function* sameFileImport(action: importActions.verify.TAction) {
             link,
             false, // willBeImmediatelyFollowedByOpen
             pub,
+            rootFeedIdentifier,
         );
     }
 }

--- a/src/utils/lcp.ts
+++ b/src/utils/lcp.ts
@@ -7,8 +7,102 @@
 
 import * as crypto from "node:crypto";
 
+// SHA256 - 32 bytes - 64 chars
+const LCP_HASHED_PASSPHRASE_BYTES = 32;
+const LCP_HASHED_PASSPHRASE_HEX_LENGTH = LCP_HASHED_PASSPHRASE_BYTES * 2;
+
 export function toSha256Hex(data: string) {
     const checkSum = crypto.createHash("sha256");
     checkSum.update(data);
     return checkSum.digest("hex");
+}
+
+/* previous implementation
+let lcpHashedPassphrase: string;
+if (typeof lcpHashedPassphraseObj === "string") {
+    const lcpHashedPassphraseHexOrB64 = lcpHashedPassphraseObj as string;
+    let isHex = false;
+    try {
+        const low1 = lcpHashedPassphraseHexOrB64.toLowerCase();
+        const buff = Buffer.from(low1, "hex");
+        const str = buff.toString("hex");
+        const low2 = str.toLowerCase();
+        isHex = low1 === low2;
+        if (!isHex) {
+            debug(`OPDS lcp_hashed_passphrase should be HEX! (${lcpHashedPassphraseHexOrB64}) ${low1} !== ${low2}`);
+        } else {
+            debug(`OPDS lcp_hashed_passphrase is HEX: ${lcpHashedPassphraseHexOrB64}`);
+        }
+    } catch (err) {
+        debug(err); // ignore
+    }
+    if (isHex) {
+        lcpHashedPassphrase = lcpHashedPassphraseHexOrB64;
+    } else {
+        let isBase64 = false;
+        try {
+            const buff = Buffer.from(lcpHashedPassphraseHexOrB64, "base64");
+            const str = buff.toString("hex");
+            const b64 = Buffer.from(str, "hex").toString("base64");
+            isBase64 = lcpHashedPassphraseHexOrB64 === b64;
+            if (!isBase64) {
+                debug(`OPDS lcp_hashed_passphrase is not BASE64?! (${lcpHashedPassphraseHexOrB64}) ${lcpHashedPassphraseHexOrB64} !== ${b64}`);
+            } else {
+                debug(`OPDS lcp_hashed_passphrase is BASE64! (${lcpHashedPassphraseHexOrB64})`);
+            }
+        } catch (err) {
+            debug(err); // ignore
+        }
+        if (isBase64) {
+            lcpHashedPassphrase = Buffer.from(lcpHashedPassphraseHexOrB64, "base64").toString("hex");
+        }
+    }
+}
+*/
+
+export function normalizeLcpHashedPassphrase(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+        return undefined;
+    }
+
+    const lcpHashedPassphraseHexOrB64 = value.trim();
+    if (!lcpHashedPassphraseHexOrB64) {
+        return undefined;
+    }
+
+    const lowerCaseHex = lcpHashedPassphraseHexOrB64.toLowerCase();
+    if (
+        lowerCaseHex.length === LCP_HASHED_PASSPHRASE_HEX_LENGTH &&
+        /^[0-9a-f]+$/.test(lowerCaseHex)
+    ) {
+        return lowerCaseHex;
+    }
+
+    try {
+        const buffer = Buffer.from(lcpHashedPassphraseHexOrB64, "base64");
+        if (
+            buffer.length === LCP_HASHED_PASSPHRASE_BYTES &&
+            buffer.toString("base64") === lcpHashedPassphraseHexOrB64
+        ) {
+            return buffer.toString("hex");
+        }
+    } catch {
+        // ignore
+    }
+
+    return undefined;
+}
+
+export function getLcpHashedPassphrase(
+    passphrase: string | null | undefined,
+    hashedPassphrase: string | null | undefined,
+): string | undefined {
+    const normalizedHashedPassphrase = normalizeLcpHashedPassphrase(hashedPassphrase);
+    if (normalizedHashedPassphrase) {
+        return normalizedHashedPassphrase;
+    }
+
+    return typeof passphrase === "string" && passphrase.length ?
+        toSha256Hex(passphrase) :
+        undefined;
 }


### PR DESCRIPTION
fixes #3848 

- Adds shared LCP helpers to:
  - hash `passphrase` as a plain-text value
  - normalize `hashed_passphrase` when provided as a valid SHA-256 hex or base64 digest
  - prefer `hashed_passphrase` when both parameters are present
- Parses LCP passphrase parameters from publication and catalog deeplinks.
- Refactors OPDS `lcp_hashed_passphrase` property parsing to reuse the shared normalization helper.
- Propagates the OPDS root feed identifier through import verification/import APIs, preparing imports from catalog feeds to carry feed context.

The LCP passphrase attached to a catalog is not persisted or stored as a secret. A dedicated issue #3854, target this issue.
