### PR TITLE
Persist catalog deeplink LCP passphrases as generic secrets

### DIFF
--- a/src/main/redux/sagas/event.ts
+++ b/src/main/redux/sagas/event.ts
@@ -39,7 +39,7 @@ import { getAndStartCustomizationWellKnownFileWatchingEventChannel } from "./get
 // import { ICustomizationProfileError, ICustomizationProfileProvisioned, ICustomizationProfileProvisionedWithError } from "readium-desktop/common/redux/states/customization";
 import { URL_HOST_CUSTOMPROFILE, URL_HOST_OPDS_AUTH, URL_DOMAIN_APP_HANDLER_THORIUM_READER, URL_PROTOCOL_APP_HANDLER_THORIUM, URL_PROTOCOL_APP_HANDLER_THORIUM_READER, URL_PROTOCOL_APP_HANDLER_THORIUM_READER_DESKTOP, URL_PROTOCOL_OPDS } from "readium-desktop/common/streamerProtocol";
 import { EXT_THORIUM } from "readium-desktop/common/extension";
-import { getLibraryWindowFromDi } from "readium-desktop/main/di";
+import { diMainGet, getLibraryWindowFromDi } from "readium-desktop/main/di";
 import { getTranslator } from "readium-desktop/common/services/translator";
 
 import * as path from "node:path";
@@ -426,10 +426,6 @@ export function saga() {
                                 u.searchParams.get("passphrase"),
                                 u.searchParams.get("hashed_passphrase"),
                             );
-                            if (lcpHashedPassphrase) {
-                                // TODO: persist the hashed passphrase
-                                debug("LCP HASHED PASSPHRASE", lcpHashedPassphrase);
-                            }
                             feedIcon = yield* callTyped(() => downloadOpdsFeedIcon(
                                 getOpdsFeedIconUrl(u.searchParams.get("icon")),
                             ));
@@ -443,6 +439,11 @@ export function saga() {
 
                             if (!/^https?:\/\//.test(theUrl)) {
                                 throw new Error("HTTP!! " + theUrl + " ------- " + url);
+                            }
+
+                            if (lcpHashedPassphrase) {
+                                const lcpManager = diMainGet("lcp-manager");
+                                yield* callTyped(() => lcpManager.saveGenericSecret(lcpHashedPassphrase));
                             }
                         }
 

--- a/src/main/services/lcp.ts
+++ b/src/main/services/lcp.ts
@@ -68,13 +68,20 @@ import { RequesetToCloseAllReadersWithTheSamePubId } from "../redux/sagas/reader
 const debug = debug_("readium-desktop:main#services/lcp");
 
 const CONFIGREPOSITORY_LCP_SECRETS = "CONFIGREPOSITORY_LCP_SECRETS";
+const LCP_GENERIC_SECRET_ID_PREFIX = "__THORIUM_LCP_GENERIC_SECRET__:";
 
-// object map with keys = PublicationDocument.identifier,
+// object map with keys = PublicationDocument.identifier, or a generated generic key,
 // and values = object tuple of single passphrase + provider (cached here to avoid costly lookup in Publication DB)
 // this way, we can query all passphrases associated with a particular publication,
 // or alternatively query all passphrases known for a given LCP provider
 // (as in practice passphrases are sometimes shared between different publications from the same provider)
 type TLCPSecrets = Record<string, { passphrase?: string, provider?: string }>;
+
+const getGenericSecretId = (lcpHashedPassphrase: string): string =>
+    `${LCP_GENERIC_SECRET_ID_PREFIX}${lcpHashedPassphrase}`;
+
+const isGenericSecretId = (id: string): boolean =>
+    id.startsWith(LCP_GENERIC_SECRET_ID_PREFIX);
 
 interface ICheckPublicationLicenseUpdateResult {
     publicationDocument: PublicationDocument;
@@ -153,15 +160,28 @@ export class LcpManager {
 
         const allSecrets = await this.getAllSecrets();
         const ids = Object.keys(allSecrets);
-        for (const id of ids) {
+        const addSecret = (id: string) => {
             const val = allSecrets[id];
             if (val.passphrase && !secrets.includes(val.passphrase)) {
-                const provider = doc.lcp?.provider;
+                secrets.push(val.passphrase);
+            }
+        };
 
-                if (doc.identifier === id ||
-                    provider && val.provider && provider === val.provider) {
-                    secrets.push(val.passphrase);
+        addSecret(doc.identifier);
+
+        const provider = doc.lcp?.provider;
+        if (provider) {
+            for (const id of ids) {
+                const val = allSecrets[id];
+                if (val.provider && provider === val.provider) {
+                    addSecret(id);
                 }
+            }
+        }
+
+        for (const id of ids) {
+            if (isGenericSecretId(id)) {
+                addSecret(id);
             }
         }
 
@@ -173,6 +193,28 @@ export class LcpManager {
         // );
         // const secrets = lcpSecretDocs.map((doc) => doc.secret).filter((secret) => secret);
         // return secrets;
+    }
+
+    private async persistSecrets(allSecrets: TLCPSecrets): Promise<void> {
+        const str = JSON.stringify(allSecrets);
+        const encrypted = encryptPersist(str, CONFIGREPOSITORY_LCP_SECRETS, lcpHashesFilePath);
+        if (!encrypted) {
+            throw new Error("encryptPersist???! CONFIGREPOSITORY_LCP_SECRETS");
+        }
+        await fs.promises.writeFile(lcpHashesFilePath, encrypted);
+    }
+
+    public async saveGenericSecret(lcpHashedPassphrase: string) {
+        debug("LCP saveGenericSecret ...");
+
+        const allSecrets = await this.getAllSecrets();
+        allSecrets[getGenericSecretId(lcpHashedPassphrase)] = {
+            passphrase: lcpHashedPassphrase,
+        };
+
+        debug("LCP saveGenericSecret: ", allSecrets);
+
+        await this.persistSecrets(allSecrets);
     }
 
     public async saveSecret(doc: PublicationDocument, lcpHashedPassphrase: string) {
@@ -194,12 +236,7 @@ export class LcpManager {
 
         debug("LCP saveSecret: ", allSecrets);
 
-        const str = JSON.stringify(allSecrets);
-        const encrypted = encryptPersist(str, CONFIGREPOSITORY_LCP_SECRETS, lcpHashesFilePath);
-        if (!encrypted) {
-            throw new Error("encryptPersist???! CONFIGREPOSITORY_LCP_SECRETS");
-        }
-        await fs.promises.writeFile(lcpHashesFilePath, encrypted);
+        await this.persistSecrets(allSecrets);
     }
 
     private async injectLcplIntoZip_(epubPath: string, lcpStr: string) {

--- a/test/main/services/lcp.test.ts
+++ b/test/main/services/lcp.test.ts
@@ -80,6 +80,15 @@ type TLcpManagerForPublicationArchiveReplacement = {
     };
 };
 
+type TLcpSecrets = Record<string, { passphrase?: string; provider?: string }>;
+
+type TLcpManagerForSecrets = {
+    getAllSecrets: () => Promise<TLcpSecrets>;
+    getSecrets: (doc: { identifier: string; lcp?: { provider?: string } }) => Promise<string[]>;
+    persistSecrets: (allSecrets: TLcpSecrets) => Promise<void>;
+    saveGenericSecret: (lcpHashedPassphrase: string) => Promise<void>;
+};
+
 const link = (partial: TPublicationLink): TPublicationLink => ({
     Href: "https://example.org/book.epub",
     ...partial,
@@ -108,6 +117,58 @@ const httpGetMock = httpGet as jest.MockedFunction<typeof httpGet>;
 
 beforeEach(() => {
     jest.clearAllMocks();
+});
+
+describe("LcpManager secrets", () => {
+    it("returns publication, provider, then generic fallback secrets without duplicates", async () => {
+        const manager = Object.create(LcpManager.prototype) as TLcpManagerForSecrets;
+        manager.getAllSecrets = jest.fn(async () => ({
+            "publication-1": { passphrase: "publication-passphrase" },
+            "publication-2": { passphrase: "provider-passphrase", provider: "provider-a" },
+            "publication-3": { passphrase: "not-generic-no-provider" },
+            "publication-4": { passphrase: "other-provider-passphrase", provider: "provider-b" },
+            "__THORIUM_LCP_GENERIC_SECRET__:generic-passphrase": { passphrase: "generic-passphrase" },
+            "__THORIUM_LCP_GENERIC_SECRET__:provider-passphrase": { passphrase: "provider-passphrase" },
+        }));
+
+        await expect(manager.getSecrets({
+            identifier: "publication-1",
+            lcp: {
+                provider: "provider-a",
+            },
+        })).resolves.toEqual([
+            "publication-passphrase",
+            "provider-passphrase",
+            "generic-passphrase",
+        ]);
+    });
+
+    it("stores catalog passphrases once under a generic vault key", async () => {
+        let persistedSecrets: TLcpSecrets = {
+            "publication-1": { passphrase: "publication-passphrase", provider: "provider-a" },
+        };
+
+        const manager = Object.create(LcpManager.prototype) as TLcpManagerForSecrets;
+        manager.getAllSecrets = jest.fn(async () => persistedSecrets);
+        manager.persistSecrets = jest.fn(async (allSecrets: TLcpSecrets) => {
+            persistedSecrets = allSecrets;
+        });
+
+        await manager.saveGenericSecret("catalog-passphrase-hash");
+        await manager.saveGenericSecret("catalog-passphrase-hash");
+
+        expect(persistedSecrets["publication-1"]).toEqual({
+            passphrase: "publication-passphrase",
+            provider: "provider-a",
+        });
+
+        const genericEntries = Object.entries(persistedSecrets).filter(([id, val]) =>
+            id.startsWith("__THORIUM_LCP_GENERIC_SECRET__:") &&
+            val.passphrase === "catalog-passphrase-hash",
+        );
+        expect(genericEntries).toHaveLength(1);
+        expect(genericEntries[0][1]).toEqual({ passphrase: "catalog-passphrase-hash" });
+    });
 });
 
 describe("LcpManager.lcpPublicationLinkResourceChanged", () => {


### PR DESCRIPTION
Fixes #3854 

Adds support for storing LCP passphrases received from catalog deeplinks without changing or migrating the existing secrets vault structure.

Catalog deeplink passphrases are now saved as generic vault entries using a deterministic synthetic key, which makes repeated imports idempotent. LCP secret lookup now follows the desktop equivalent of the mobile fallback cascade:

1. publication/license-specific secret
2. provider-matching secret
3. generic/unscoped secret

This keeps existing publication-keyed secrets compatible while allowing catalog-provided passphrases to unlock future publications.
