### PR TITLE
Fixes LCP CRL handling with HTTP cache control

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,12 +98,13 @@ const getCacheControlMaxAgeMs = (cacheControl: string | undefined): number | und
     let maxAgeMs: number | undefined;
     for (const directive of cacheControl.split(",")) {
         const [rawName, rawValue] = directive.trim().split("=", 2);
-        const name = rawName.toLowerCase();
+        const name = rawName.trim().toLowerCase();
+        const value = rawValue?.trim();
         if (name === "no-cache" || name === "no-store") {
             return 0;
         }
-        if (name === "max-age" && rawValue) {
-            const seconds = Number(rawValue.replace(/^"|"$/g, ""));
+        if (name === "max-age" && value) {
+            const seconds = Number(value.replace(/^"|"$/g, ""));
             if (Number.isFinite(seconds) && seconds >= 0) {
                 maxAgeMs = seconds * 1000;
             }
@@ -122,7 +123,7 @@ const isLcpCrlCacheExpired = () =>
 
 const refreshLcpCrlCache = (): Promise<void> => {
     debug("REFRESH LCP CRL REQUEST", lcpCrlCache);
-    if (lcpCrlCache.refreshPromise) {
+    if (typeof lcpCrlCache.refreshPromise !== "undefined") {
         return lcpCrlCache.refreshPromise;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ setLcpNativePluginPath(lcpNativePluginPath);
 interface ILcpCrlCache {
     crlPem: string;
     etag: string | undefined;
+    lastModified: string | undefined;
     validatedAt: number;
     refreshPromise: Promise<void> | undefined;
 }
@@ -81,12 +82,13 @@ interface ILcpCrlCache {
 const lcpCrlCache: ILcpCrlCache = {
     crlPem: DUMMY_CRL,
     etag: undefined,
+    lastModified: undefined,
     validatedAt: 0,
     refreshPromise: undefined,
 };
 
 // 1h
-const LCP_CRL_CACHE_FRESHNESS_MS = 60 * 60 * 1000;
+const LCP_CRL_CACHE_FRESHNESS_MS = 0;// 60 * 60 * 1000;
 
 // TODO: HTTP cache-control Header !?
 const isLcpCrlCacheExpired = () =>
@@ -106,6 +108,9 @@ const refreshLcpCrlCache = (): Promise<void> => {
             if (lcpCrlCache.etag) {
                 headers["If-None-Match"] = lcpCrlCache.etag;
             }
+            if (lcpCrlCache.lastModified) {
+                headers["If-Modified-Since"] = lcpCrlCache.lastModified;
+            }
             // RFC 2585 Security Considerations: CRL retrieval does not need
             // authentication, so this uses Thorium's no-auth HTTP helper.
             const res = await httpGetWithAuth(false)(CRL_URL, {
@@ -115,6 +120,7 @@ const refreshLcpCrlCache = (): Promise<void> => {
                 redirect: "error",
             });
             if (res.statusCode === 304) {
+                lcpCrlCache.lastModified = res.response.headers?.get("last-modified") || lcpCrlCache.lastModified;
                 lcpCrlCache.validatedAt = Date.now();
                 debug("LCP CRL HTTP cache refreshed: not modified");
                 return;
@@ -133,7 +139,8 @@ const refreshLcpCrlCache = (): Promise<void> => {
                 const buf = await res.response.buffer();
                 const lcplStr = "-----BEGIN X509 CRL-----\n" + buf.toString("base64") + "\n-----END X509 CRL-----";
                 lcpCrlCache.crlPem = lcplStr;
-                lcpCrlCache.etag = res.response.headers?.get("etag") || undefined;
+                lcpCrlCache.etag = res.response.headers?.get("etag") || undefined; // '"295-65b0d9de8addd"' double quote is included
+                lcpCrlCache.lastModified = res.response.headers?.get("last-modified") || undefined;
                 lcpCrlCache.validatedAt = Date.now();
                 debug("LCP CRL HTTP fetch success");
                 debug(lcplStr);

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ interface ILcpCrlCache {
     etag: string | undefined;
     lastModified: string | undefined;
     validatedAt: number;
+    expiresAt: number;
     refreshPromise: Promise<void> | undefined;
 }
 
@@ -84,15 +85,40 @@ const lcpCrlCache: ILcpCrlCache = {
     etag: undefined,
     lastModified: undefined,
     validatedAt: 0,
+    expiresAt: 0,
     refreshPromise: undefined,
 };
 
-// 1h
-const LCP_CRL_CACHE_FRESHNESS_MS = 0;// 60 * 60 * 1000;
+const LCP_CRL_CACHE_FALLBACK_FRESHNESS_MS = 60 * 60 * 1000;
 
-// TODO: HTTP cache-control Header !?
+const getCacheControlMaxAgeMs = (cacheControl: string | undefined): number | undefined => {
+    if (!cacheControl) {
+        return undefined;
+    }
+    let maxAgeMs: number | undefined;
+    for (const directive of cacheControl.split(",")) {
+        const [rawName, rawValue] = directive.trim().split("=", 2);
+        const name = rawName.toLowerCase();
+        if (name === "no-cache" || name === "no-store") {
+            return 0;
+        }
+        if (name === "max-age" && rawValue) {
+            const seconds = Number(rawValue.replace(/^"|"$/g, ""));
+            if (Number.isFinite(seconds) && seconds >= 0) {
+                maxAgeMs = seconds * 1000;
+            }
+        }
+    }
+    return maxAgeMs;
+};
+
+const getLcpCrlExpiresAt = (headers: { get(name: string): string | null } | undefined, validatedAt: number): number => {
+    const cacheControlMaxAgeMs = getCacheControlMaxAgeMs(headers?.get("cache-control") || undefined);
+    return validatedAt + (cacheControlMaxAgeMs ?? LCP_CRL_CACHE_FALLBACK_FRESHNESS_MS);
+};
+
 const isLcpCrlCacheExpired = () =>
-    Date.now() - lcpCrlCache.validatedAt >= LCP_CRL_CACHE_FRESHNESS_MS;
+    Date.now() >= lcpCrlCache.expiresAt;
 
 const refreshLcpCrlCache = (): Promise<void> => {
     debug("REFRESH LCP CRL REQUEST", lcpCrlCache);
@@ -121,7 +147,9 @@ const refreshLcpCrlCache = (): Promise<void> => {
             });
             if (res.statusCode === 304) {
                 lcpCrlCache.lastModified = res.response.headers?.get("last-modified") || lcpCrlCache.lastModified;
-                lcpCrlCache.validatedAt = Date.now();
+                const validatedAt = Date.now();
+                lcpCrlCache.validatedAt = validatedAt;
+                lcpCrlCache.expiresAt = getLcpCrlExpiresAt(res.response.headers, validatedAt);
                 debug("LCP CRL HTTP cache refreshed: not modified");
                 return;
             }
@@ -141,7 +169,9 @@ const refreshLcpCrlCache = (): Promise<void> => {
                 lcpCrlCache.crlPem = lcplStr;
                 lcpCrlCache.etag = res.response.headers?.get("etag") || undefined; // '"295-65b0d9de8addd"' double quote is included
                 lcpCrlCache.lastModified = res.response.headers?.get("last-modified") || undefined;
-                lcpCrlCache.validatedAt = Date.now();
+                const validatedAt = Date.now();
+                lcpCrlCache.validatedAt = validatedAt;
+                lcpCrlCache.expiresAt = getLcpCrlExpiresAt(res.response.headers, validatedAt);
                 debug("LCP CRL HTTP fetch success");
                 debug(lcplStr);
                 return;
@@ -160,6 +190,7 @@ const refreshLcpCrlCache = (): Promise<void> => {
 const initLcpCrlCacheValidatedAt = lcpCrlCache.validatedAt;
 refreshLcpCrlCache().then(() => {
     debug(lcpCrlCache.validatedAt > initLcpCrlCacheValidatedAt ? "INIT LCP CRL LOADED" : "INIT LCP CRL FAILED");
+    debug(lcpCrlCache);
 }).catch((err) => {
     debug("INIT LCP CRL FAILED");
     debug(err);

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,41 +71,99 @@ initGlobalConverters_GENERIC();
 const lcpNativePluginPath = path.normalize(path.join(__dirname, "external-assets", "lcp.node"));
 setLcpNativePluginPath(lcpNativePluginPath);
 
-setCRLGetter(async (): Promise<string> => {
-    try {
-        // RFC 2585 Security Considerations: CRL retrieval does not need
-        // authentication, so this uses Thorium's no-auth HTTP helper.
-        const res = await httpGetWithAuth(false)(CRL_URL, {
-            headers: {
-                Accept: ContentType.PkixCrl,
-            },
-            // Reject redirects so the native LCP plugin receives bytes from the
-            // configured CRL endpoint only.
-            redirect: "error",
-        });
-        const mediaType = res.contentType?.split(";")[0].trim().toLowerCase();
-        // RFC 5280 section 4.2.1.13 says HTTP CRL distribution point URIs point
-        // to a single DER encoded CRL, and HTTP servers SHOULD respond with
-        // Content-Type application/pkix-crl.
-        // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
-        // RFC 2585 section 4.2 registers application/pkix-crl.
-        // https://datatracker.ietf.org/doc/html/rfc2585#section-4.2
-        // RFC 2585 Security Considerations: authentication is not necessary
-        // to retrieve certificates and CRLs.
-        // https://datatracker.ietf.org/doc/html/rfc2585#page-6
-        if (res.statusCode === 200 && mediaType === ContentType.PkixCrl) {
-            const buf = await res.response.buffer();
-            const lcplStr = "-----BEGIN X509 CRL-----\n" + buf.toString("base64") + "\n-----END X509 CRL-----";
-            debug("LCP CRL HTTP fetch success");
-            debug(lcplStr);
-            return lcplStr;
-        }
-        debug(`LCP CRL HTTP fetch fail => DUMMY_CRL (${res.statusCode} ${res.contentType})`);
-    } catch (err) {
-        debug("LCP CRL HTTP fetch error => DUMMY_CRL");
-        debug(err);
+interface ILcpCrlCache {
+    crlPem: string;
+    etag: string | undefined;
+    validatedAt: number;
+    refreshPromise: Promise<void> | undefined;
+}
+
+const lcpCrlCache: ILcpCrlCache = {
+    crlPem: DUMMY_CRL,
+    etag: undefined,
+    validatedAt: 0,
+    refreshPromise: undefined,
+};
+
+// 1h
+const LCP_CRL_CACHE_FRESHNESS_MS = 60 * 60 * 1000;
+
+// TODO: HTTP cache-control Header !?
+const isLcpCrlCacheExpired = () =>
+    Date.now() - lcpCrlCache.validatedAt >= LCP_CRL_CACHE_FRESHNESS_MS;
+
+const refreshLcpCrlCache = (): Promise<void> => {
+    debug("REFRESH LCP CRL REQUEST", lcpCrlCache);
+    if (lcpCrlCache.refreshPromise) {
+        return lcpCrlCache.refreshPromise;
     }
-    return DUMMY_CRL;
+
+    lcpCrlCache.refreshPromise = (async () => {
+        try {
+            const headers: Record<string, string> = {
+                Accept: ContentType.PkixCrl,
+            };
+            if (lcpCrlCache.etag) {
+                headers["If-None-Match"] = lcpCrlCache.etag;
+            }
+            // RFC 2585 Security Considerations: CRL retrieval does not need
+            // authentication, so this uses Thorium's no-auth HTTP helper.
+            const res = await httpGetWithAuth(false)(CRL_URL, {
+                headers,
+                // Reject redirects so the native LCP plugin receives bytes from the
+                // configured CRL endpoint only.
+                redirect: "error",
+            });
+            if (res.statusCode === 304) {
+                lcpCrlCache.validatedAt = Date.now();
+                debug("LCP CRL HTTP cache refreshed: not modified");
+                return;
+            }
+            const mediaType = res.contentType?.split(";")[0].trim().toLowerCase();
+            // RFC 5280 section 4.2.1.13 says HTTP CRL distribution point URIs point
+            // to a single DER encoded CRL, and HTTP servers SHOULD respond with
+            // Content-Type application/pkix-crl.
+            // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
+            // RFC 2585 section 4.2 registers application/pkix-crl.
+            // https://datatracker.ietf.org/doc/html/rfc2585#section-4.2
+            // RFC 2585 Security Considerations: authentication is not necessary
+            // to retrieve certificates and CRLs.
+            // https://datatracker.ietf.org/doc/html/rfc2585#page-6
+            if (res.statusCode === 200 && mediaType === ContentType.PkixCrl) {
+                const buf = await res.response.buffer();
+                const lcplStr = "-----BEGIN X509 CRL-----\n" + buf.toString("base64") + "\n-----END X509 CRL-----";
+                lcpCrlCache.crlPem = lcplStr;
+                lcpCrlCache.etag = res.response.headers?.get("etag") || undefined;
+                lcpCrlCache.validatedAt = Date.now();
+                debug("LCP CRL HTTP fetch success");
+                debug(lcplStr);
+                return;
+            }
+            debug(`LCP CRL HTTP fetch fail; keeping cached CRL (${res.statusCode} ${res.contentType})`);
+        } catch (err) {
+            debug("LCP CRL HTTP fetch error; keeping cached CRL");
+            debug(err);
+        }
+    })().finally(() => {
+        lcpCrlCache.refreshPromise = undefined;
+    });
+
+    return lcpCrlCache.refreshPromise;
+};
+const initLcpCrlCacheValidatedAt = lcpCrlCache.validatedAt;
+refreshLcpCrlCache().then(() => {
+    debug(lcpCrlCache.validatedAt > initLcpCrlCacheValidatedAt ? "INIT LCP CRL LOADED" : "INIT LCP CRL FAILED");
+}).catch((err) => {
+    debug("INIT LCP CRL FAILED");
+    debug(err);
+});
+
+setCRLGetter(async (): Promise<string> => {
+    const crlPem = lcpCrlCache.crlPem;
+    if (isLcpCrlCacheExpired()) {
+        void refreshLcpCrlCache();
+    }
+    return crlPem;
 });
 
 app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");

--- a/src/main/network/http.ts
+++ b/src/main/network/http.ts
@@ -231,7 +231,7 @@ async function httpFetchRawResponse(
     url: string | URL,
     options: THttpOptions = {},
     // redirectCounter = 0,
-    locale = tryCatchSync(() => diMainGet("store").getState().i18n.locale, filename_),
+    locale = tryCatchSync(() => diMainGet("store").getState().i18n.locale, filename_) || "en", // en fallback if the request is done before the start of the redux store
 ): Promise<THttpResponse> {
 
     url = new URL(url);


### PR DESCRIPTION
Fixes #3863 

The algorithm keeps the last successfully downloaded CRL in memory and uses it immediately when opening an LCP license, even if it is stale.

A stale CRL is still usable. Expiration only means that Thorium should refresh the CRL in the background for the next license opening.

`Cache-Control` is used only to decide when the CRL cache is considered **stale**, not whether it is usable.

Current freshness logic:

- If response has `Cache-Control: max-age=N`, the cache expires after `N` seconds.
- If response has `Cache-Control: no-cache` or `no-store`, the cache is immediately expired.
- If no usable `Cache-Control` directive exists, Thorium uses the fallback freshness duration, currently 1 hour.

When the cache is expired:

- Thorium still returns the cached CRL immediately for the current license opening.
- Thorium starts an asynchronous refresh in the background.
- The refreshed CRL, if successfully fetched, is used by the next license opening.

So “expired” means “needs refresh”, not “cannot be used”.

On refresh, Thorium sends conditional HTTP headers when available: `If-None-Match` with the cached `ETag`, and `If-Modified-Since` with the cached `Last-Modified`.

If the server returns `304 Not Modified`, Thorium keeps the existing CRL and updates its freshness metadata. If the server returns `200 OK` with `application/pkix-crl`, Thorium replaces the cached CRL and stores the new `ETag`, `Last-Modified`, validation timestamp, and freshness expiry.

If the refresh fails because of a network error, HTTP error, or unexpected content type, Thorium keeps the existing CRL untouched.

Breaking change: 

Thorium returns `DUMMY_CRL` before any CRL has been successfully downloaded. Opening a license immediately if the initial refresh fails or not yet downloaded causes the dummy CRL to be used.

